### PR TITLE
fix(build): update sccache-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Cache the build
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Cache the build
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.8
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11


### PR DESCRIPTION
Github has migrated customers to a new cache service. See https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts