### PR TITLE
fix(mac): register mimalloc as malloc zone to fix release crash

### DIFF
--- a/game/src/mimallocoverride.cpp
+++ b/game/src/mimallocoverride.cpp
@@ -4,6 +4,113 @@
 
 #include <new>
 
+#if defined(__APPLE__)
+// Apple's libc++ std::basic_string::__grow_by_and_replace calls system realloc
+// directly rather than going through operator new/delete. With operator new
+// overridden to use mimalloc, string buffers are mimalloc memory, but system
+// realloc does not recognise mimalloc pointers and aborts.
+//
+// DYLD interposition does not work here: libc++'s call to realloc is resolved
+// directly within the dyld shared cache, bypassing the stub mechanism that
+// interposition relies on.
+//
+// The fix is to register mimalloc as a malloc zone. System realloc uses
+// malloc_zone_from_ptr to find the owning zone for a pointer (querying each
+// zone's size callback), then dispatches to that zone's realloc. Registering
+// mimalloc as a zone makes system realloc correctly dispatch to mi_realloc for
+// mimalloc-owned pointers, even when called from deep inside libc++.
+//
+// constructor(101) is the earliest user priority, running before any C++
+// static initializers, ensuring the zone is in place before the first
+// operator new allocates anything.
+#include <malloc/malloc.h>
+
+static size_t mi_zone_size(malloc_zone_t*, const void* p) noexcept {
+    if (!mi_is_in_heap_region(p))
+        return 0;
+    return mi_usable_size(p);
+}
+static void* mi_zone_malloc(malloc_zone_t*, size_t n) noexcept {
+    return mi_malloc(n);
+}
+static void* mi_zone_calloc(malloc_zone_t*, size_t c, size_t n) noexcept {
+    return mi_calloc(c, n);
+}
+static void* mi_zone_valloc(malloc_zone_t*, size_t n) noexcept {
+    return mi_malloc_aligned(n, 4096);
+}
+static void mi_zone_free(malloc_zone_t*, void* p) noexcept {
+    mi_free(p);
+}
+static void* mi_zone_realloc(malloc_zone_t*, void* p, size_t n) noexcept {
+    return mi_realloc(p, n);
+}
+static void mi_zone_destroy(malloc_zone_t* zone) noexcept {
+    (void)zone;
+}
+static void* mi_zone_memalign(malloc_zone_t*, size_t al, size_t n) noexcept {
+    return mi_malloc_aligned(n, al);
+}
+static void mi_zone_free_definite_size(malloc_zone_t*, void* p,
+                                       size_t n) noexcept {
+    mi_free_size(p, n);
+}
+
+static kern_return_t mi_enumerator(task_t, void*, unsigned, vm_address_t,
+                                   memory_reader_t, vm_range_recorder_t) {
+    return KERN_SUCCESS;
+}
+static size_t mi_good_size_fn(malloc_zone_t*, size_t n) {
+    return mi_good_size(n);
+}
+static boolean_t mi_check_fn(malloc_zone_t* /*zone*/) {
+    return true;
+}
+static void mi_print_fn(malloc_zone_t* /*zone*/, boolean_t) {}
+static void mi_log_fn(malloc_zone_t* /*zone*/, void*) {}
+static void mi_force_lock_fn(malloc_zone_t* /*zone*/) {}
+static void mi_force_unlock_fn(malloc_zone_t* /*zone*/) {}
+static void mi_statistics_fn(malloc_zone_t* /*zone*/, malloc_statistics_t* s) {
+    s->blocks_in_use   = 0;
+    s->size_in_use     = 0;
+    s->max_size_in_use = 0;
+    s->size_allocated  = 0;
+}
+static boolean_t mi_zone_locked_fn(malloc_zone_t* /*zone*/) {
+    return false;
+}
+
+static malloc_introspection_t mi_introspect;
+static malloc_zone_t          mi_zone;
+
+__attribute__((constructor(101))) static void mi_register_zone() noexcept {
+    mi_introspect.enumerator   = mi_enumerator;
+    mi_introspect.good_size    = mi_good_size_fn;
+    mi_introspect.check        = mi_check_fn;
+    mi_introspect.print        = mi_print_fn;
+    mi_introspect.log          = mi_log_fn;
+    mi_introspect.force_lock   = mi_force_lock_fn;
+    mi_introspect.force_unlock = mi_force_unlock_fn;
+    mi_introspect.statistics   = mi_statistics_fn;
+    mi_introspect.zone_locked  = mi_zone_locked_fn;
+
+    mi_zone.size               = mi_zone_size;
+    mi_zone.malloc             = mi_zone_malloc;
+    mi_zone.calloc             = mi_zone_calloc;
+    mi_zone.valloc             = mi_zone_valloc;
+    mi_zone.free               = mi_zone_free;
+    mi_zone.realloc            = mi_zone_realloc;
+    mi_zone.destroy            = mi_zone_destroy;
+    mi_zone.zone_name          = "mimalloc";
+    mi_zone.introspect         = &mi_introspect;
+    mi_zone.version            = 6;
+    mi_zone.memalign           = mi_zone_memalign;
+    mi_zone.free_definite_size = mi_zone_free_definite_size;
+
+    malloc_zone_register(&mi_zone);
+}
+#endif
+
 void* operator new(std::size_t n) {
     auto* p = mi_malloc(n);
     if (!p) {

--- a/sponge/src/platform/opengl/renderer/shader.cpp
+++ b/sponge/src/platform/opengl/renderer/shader.cpp
@@ -192,6 +192,10 @@ std::string Shader::loadSourceFromFile(const std::string& path) {
         file.good()) {
         file.seekg(0, std::ios::end);
         const auto size = file.tellg();
+        if (size <= 0) {
+            SPONGE_GL_ERROR("Unable to determine size of file: {}", path);
+            return code;
+        }
         file.seekg(0, std::ios::beg);
         code.resize(size);
         file.read(code.data(), size);


### PR DESCRIPTION
## Problem

The macOS release build crashes inside `std::string` operations with a stack trace like:

```
std::__1::basic_string::__grow_by_and_replace(...)
  → ::realloc(...)
    → malloc_vreport(...)
      → abort()
```

### Root cause

Apple's libc++ contains an optimisation in `std::basic_string::__grow_by_and_replace` that calls `::realloc` directly rather than going through `operator new`/`operator delete`. With `operator new` overridden to use mimalloc, string buffers are allocated from the mimalloc heap. When the string later needs to grow, it calls system `realloc` with a mimalloc pointer — system malloc does not recognise that pointer and aborts.

### Why DYLD interposition doesn't work

The obvious fix would be to interpose `realloc` via `__DATA,__interpose` so calls to `realloc` are redirected to `mi_realloc`. This fails on macOS 11+ because `libc++` and `libsystem_malloc` are both compiled into the dyld shared cache. Calls between dylibs within the shared cache are resolved as direct addresses at cache build time — there are no PLT stubs for interposition to hook.

## Fix

### `game/src/mimallocoverride.cpp` — register mimalloc as a malloc zone

macOS's `realloc` implementation uses `malloc_zone_from_ptr` to look up the owning zone for a pointer before dispatching. It queries each registered zone's `size` callback; if `size` returns non-zero the zone owns the pointer and its `realloc` is called.

Registering mimalloc as a malloc zone makes system `realloc` correctly dispatch to `mi_realloc` for mimalloc-owned pointers, regardless of where `realloc` was called from — including from deep inside libc++.

Key implementation details:
- `mi_zone_size` uses `mi_is_in_heap_region` as a fast path guard, then `mi_usable_size` to return the allocation's usable size (or 0 for non-mimalloc pointers).
- `mi_zone_realloc` delegates to `mi_realloc`, which handles the growth correctly.
- `__attribute__((constructor(101)))` — priority 101 is the earliest user-space constructor priority, ensuring the zone is registered before any C++ static initializers run (and therefore before the first `operator new` allocates anything).
- The global `operator new`/`operator delete` overrides are **unchanged** — all C++ allocations still go through mimalloc with full Tracy profiling hooks.

### `sponge/src/platform/opengl/renderer/shader.cpp` — guard indeterminate file size

Added a `size <= 0` check after `seekg` to end of file. `tellg` can return a negative value (cast to a large `size_t`) if the seek fails; without the guard `code.resize(size)` would attempt a multi-gigabyte allocation.

## Testing

- macOS release build: no longer crashes on string operations that trigger `__grow_by_and_replace`.
- The mimalloc zone registration is Apple-only (`#if defined(__APPLE__)`); Linux/Windows builds are unaffected.