### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+This project runs on merit. The standard for participation is the quality of your work and how you treat other contributors.
+
+## Expected conduct
+
+**Technical rigor.** Write code that works. File issues with precision: what failed, what you expected, how to reproduce it. Review code on its technical merits.
+
+**Direct communication.** Disagree on the merits. Say what you mean. Ask when you don't understand. Criticism of code is not an attack on the person who wrote it, and contributors should not treat it as one.
+
+**Good faith.** Engage arguments, not identities. Assume other contributors are trying to build something good until they prove otherwise.
+
+## Unacceptable conduct
+
+* Harassment, threats, or personal attacks
+* Sustained disruption of discussions or reviews
+* Deliberately wasting contributors' time through bad-faith reports or frivolous objections
+
+## Enforcement
+
+Maintainers act on behavior, not group membership. Everyone is held to the same standard. Consequences range from comment removal to a permanent ban, proportional to the offense.
+
+Enforcement decisions belong to the project owner. They are not subject to community vote.
+
+## Scope
+
+These rules apply in issues, pull requests, discussions, and any venue where you represent this project.


### PR DESCRIPTION
## Description

Adds `CODE_OF_CONDUCT.md` to the repo root, where GitHub surfaces it automatically on the community health page.

The approach: behavior-based enforcement only. Standards apply equally to everyone — no categorical exemptions, no protected-class framing. Violations are judged on what someone did, not who they are.

## Type of change

* [x] Documentation

## Testing

No code changes.

## Checklist

* [x] Pre-commit hooks pass