### PR TITLE
fix(vcpkg): update builtin-baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "maze",
   "version-string": "latest",
-  "builtin-baseline": "00d899c410b31467733472fc3a83a25729046b13",
+  "builtin-baseline": "c16c1bd46c7f6de21efc6dcf19c1069d6825df23",
   "dependencies": [
     {
       "name": "fmt",


### PR DESCRIPTION
Bumps the vcpkg `builtin-baseline` to `c16c1bd46c7f6de21efc6dcf19c1069d6825df23`, picking up current upstream port versions for the existing dependency set. No dependency additions or version constraints changed.