### PR TITLE
fix(input): prevent menu bouncing on held gamepad confirm button

### DIFF
--- a/game/src/layer/exitlayer.cpp
+++ b/game/src/layer/exitlayer.cpp
@@ -162,6 +162,17 @@ bool ExitLayer::onUpdate(const double elapsedTime) {
         auto& mgr = Application::get().getInputManager();
         mgr.setActiveContext(sponge::input::InputContext::Menu);
 
+        {
+            using sponge::input::GameAction;
+            const auto& input = mgr.getSnapshot();
+            if (!wasActiveLastFrame) {
+                waitForConfirmRelease = input.isHeld(GameAction::MenuConfirm);
+            } else if (waitForConfirmRelease &&
+                       !input.isHeld(GameAction::MenuConfirm)) {
+                waitForConfirmRelease = false;
+            }
+        }
+
         if (wasActiveLastFrame && !Maze::get().getOptionLayer()->isActive()) {
             const auto&    input     = mgr.getSnapshot();
             constexpr auto itemCount = static_cast<int>(ExitMenuItem::Count);
@@ -176,11 +187,14 @@ bool ExitLayer::onUpdate(const double elapsedTime) {
                     itemCount);
             }
             if (input.isActive(GameAction::MenuBack)) {
+                mgr.consumeActive(GameAction::MenuBack);
                 clearHoveredItems();
                 selectedItem = ExitMenuItem::Continue;
                 resumeGame();
             }
-            if (input.isActive(GameAction::MenuConfirm)) {
+            if (!waitForConfirmRelease &&
+                input.isActive(GameAction::MenuConfirm)) {
+                mgr.consumeActive(GameAction::MenuConfirm);
                 if (selectedItem == ExitMenuItem::Continue) {
                     resumeGame();
                 } else if (selectedItem == ExitMenuItem::Options) {
@@ -267,8 +281,9 @@ bool ExitLayer::onUpdate(const double elapsedTime) {
     UNUSED(exitButton->onUpdate(elapsedTime));
 
     if (!isActive()) {
-        wasActiveLastFrame = false;
-        selectedItem       = ExitMenuItem::Continue;
+        wasActiveLastFrame    = false;
+        waitForConfirmRelease = false;
+        selectedItem          = ExitMenuItem::Continue;
     }
 
     return isRunning;

--- a/game/src/layer/exitlayer.hpp
+++ b/game/src/layer/exitlayer.hpp
@@ -25,8 +25,9 @@ public:
     bool onUpdate(double elapsedTime) override;
 
 private:
-    ExitMenuItem selectedItem       = ExitMenuItem::Continue;
-    bool         wasActiveLastFrame = false;
+    ExitMenuItem selectedItem          = ExitMenuItem::Continue;
+    bool         wasActiveLastFrame    = false;
+    bool         waitForConfirmRelease = false;
 
     static void recalculateLayout(float width, float height);
 

--- a/game/src/layer/introlayer.cpp
+++ b/game/src/layer/introlayer.cpp
@@ -170,6 +170,17 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
             sponge::platform::glfw::core::Application::get().getInputManager();
         mgr.setActiveContext(sponge::input::InputContext::Menu);
 
+        {
+            using sponge::input::GameAction;
+            const auto& input = mgr.getSnapshot();
+            if (!wasActiveLastFrame) {
+                waitForConfirmRelease = input.isHeld(GameAction::MenuConfirm);
+            } else if (waitForConfirmRelease &&
+                       !input.isHeld(GameAction::MenuConfirm)) {
+                waitForConfirmRelease = false;
+            }
+        }
+
         if (wasActiveLastFrame && !isFadingIn &&
             !Maze::get().getOptionLayer()->isActive()) {
             using sponge::input::GameAction;
@@ -185,7 +196,9 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
                     (static_cast<int>(selectedItem) - 1 + itemCount) %
                     itemCount);
             }
-            if (input.isActive(GameAction::MenuConfirm)) {
+            if (!waitForConfirmRelease &&
+                input.isActive(GameAction::MenuConfirm)) {
+                mgr.consumeActive(GameAction::MenuConfirm);
                 if (selectedItem == IntroMenuItem::NewGame) {
                     clearHoveredItems();
                     setActive(false);
@@ -271,8 +284,9 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
     UNUSED(quitButton->onUpdate(elapsedTime));
 
     if (!isActive()) {
-        wasActiveLastFrame = false;
-        selectedItem       = IntroMenuItem::NewGame;
+        wasActiveLastFrame    = false;
+        waitForConfirmRelease = false;
+        selectedItem          = IntroMenuItem::NewGame;
     }
 
     // Render gamepad connection status

--- a/game/src/layer/introlayer.hpp
+++ b/game/src/layer/introlayer.hpp
@@ -21,11 +21,12 @@ public:
     void beginFadeIn(double duration);
 
 private:
-    IntroMenuItem selectedItem       = IntroMenuItem::NewGame;
-    bool          wasActiveLastFrame = false;
-    bool          isFadingIn         = false;
-    double        fadeInDuration     = 0.0;
-    double        fadeInAccumulator  = 0.0;
+    IntroMenuItem selectedItem          = IntroMenuItem::NewGame;
+    bool          wasActiveLastFrame    = false;
+    bool          isFadingIn            = false;
+    bool          waitForConfirmRelease = false;
+    double        fadeInDuration        = 0.0;
+    double        fadeInAccumulator     = 0.0;
 
     static void recalculateLayout(float width, float height);
 

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -292,6 +292,17 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
             sponge::platform::glfw::core::Application::get().getInputManager();
         mgr.setActiveContext(sponge::input::InputContext::Menu);
 
+        {
+            using sponge::input::GameAction;
+            const auto& input = mgr.getSnapshot();
+            if (!wasActiveLastFrame) {
+                waitForConfirmRelease = input.isHeld(GameAction::MenuConfirm);
+            } else if (waitForConfirmRelease &&
+                       !input.isHeld(GameAction::MenuConfirm)) {
+                waitForConfirmRelease = false;
+            }
+        }
+
         if (wasActiveLastFrame) {
             const auto&    input     = mgr.getSnapshot();
             constexpr auto itemCount = static_cast<int>(OptionMenuItem::Count);
@@ -326,12 +337,15 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                 }
             }
             if (input.isActive(GameAction::MenuBack)) {
+                mgr.consumeActive(GameAction::MenuBack);
                 clearHoveredItems();
                 selectedItem = OptionMenuItem::AspectRatio;
                 resetSelectionToCurrentState();
                 setActive(false);
             }
-            if (input.isActive(GameAction::MenuConfirm)) {
+            if (!waitForConfirmRelease &&
+                input.isActive(GameAction::MenuConfirm)) {
+                mgr.consumeActive(GameAction::MenuConfirm);
                 if (selectedItem == OptionMenuItem::Return) {
                     if (hasUnappliedChanges && !filteredResolutions.empty()) {
                         const auto& res =
@@ -440,7 +454,8 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
     UNUSED(returnButton->onUpdate(elapsedTime));
 
     if (!isActive()) {
-        wasActiveLastFrame = false;
+        wasActiveLastFrame    = false;
+        waitForConfirmRelease = false;
     }
 
     return true;

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -35,8 +35,9 @@ private:
     OptionMenuItem                selectedItem = OptionMenuItem::AspectRatio;
     std::optional<OptionMenuItem> hoveredItem;
 
-    bool hasUnappliedChanges = false;
-    bool wasActiveLastFrame  = false;
+    bool hasUnappliedChanges   = false;
+    bool wasActiveLastFrame    = false;
+    bool waitForConfirmRelease = false;
 
     std::unique_ptr<ui::SelectList> aspectRatioList;
     std::unique_ptr<ui::SelectList> resolutionList;

--- a/game/src/layer/splashscreenlayer.cpp
+++ b/game/src/layer/splashscreenlayer.cpp
@@ -94,6 +94,8 @@ bool SplashScreenLayer::onUpdate(const double elapsedTime) {
     const auto& snap = mgr.getSnapshot();
     if (snap.isActive(GameAction::MenuConfirm) ||
         snap.isActive(GameAction::MenuBack)) {
+        mgr.consumeActive(GameAction::MenuConfirm);
+        mgr.consumeActive(GameAction::MenuBack);
         setActive(false);
         Maze::get().getIntroLayer()->setActive(true);
         return true;

--- a/sponge/src/platform/glfw/core/inputmanager.hpp
+++ b/sponge/src/platform/glfw/core/inputmanager.hpp
@@ -24,6 +24,10 @@ public:
         return snapshot;
     }
 
+    void consumeActive(input::GameAction a) {
+        snapshot.active[+a] = false;
+    }
+
     void                pushContext(input::InputContext ctx);
     void                popContext();
     void                setActiveContext(input::InputContext ctx);


### PR DESCRIPTION
## Summary

- Add `consumeActive(GameAction)` to `InputManager` — clears an action's active flag mid-frame so downstream layers in the same render pass cannot process the same edge event
- Add `waitForConfirmRelease` to `IntroLayer`, `OptionLayer`, and `ExitLayer` — on the first active frame, if MenuConfirm is already held the layer ignores it until the button is fully released
- Consume MenuConfirm/MenuBack in `SplashScreenLayer` on dismiss

## Test plan

- [ ] Hold A through splash dismiss — intro menu should not immediately trigger New Game
- [ ] Hold A through intro → Options open — options menu should not immediately close
- [ ] Hold A through Options close → intro — intro should not immediately re-open options
- [ ] Hold A through exit overlay open — exit menu should not immediately fire Continue
- [ ] Quick-tap A in each menu — navigation should require a deliberate re-press after each transition