### PR TITLE
fix(options): defer fullscreen, vsync, and AA changes until apply

### DIFF
--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -76,19 +76,16 @@ std::tuple<float, float, float, float> getNodeLayout(const YGNodeRef node,
 inline std::string quadShaderName;
 inline std::string fontShaderName;
 
-void saveVideoSettings(const uint32_t width, const uint32_t height) {
+void saveVideoSettings(const uint32_t width, const uint32_t height,
+                       const bool fullscreen, const bool vsync,
+                       const bool fxaa) {
     using sponge::core::Settings;
     Settings::set("video.width", width);
     Settings::set("video.height", height);
-    Settings::set("video.fullscreen", game::Maze::get().isFullscreen());
-    Settings::set("video.vsync", game::Maze::get().hasVerticalSync());
-    Settings::set("video.fxaa", game::Maze::get().isFxaaEnabled());
+    Settings::set("video.fullscreen", fullscreen);
+    Settings::set("video.vsync", vsync);
+    Settings::set("video.fxaa", fxaa);
     Settings::save();
-}
-
-void saveVideoSettings() {
-    const auto window = game::Maze::get().getWindow();
-    saveVideoSettings(window->getWidth(), window->getHeight());
 }
 
 std::unique_ptr<game::ui::Button> returnButton;
@@ -300,6 +297,9 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
             using sponge::input::GameAction;
             const auto& input = mgr.getSnapshot();
             if (!wasActiveLastFrame) {
+                pendingFullscreen     = Maze::get().isFullscreen();
+                pendingVsync          = Maze::get().hasVerticalSync();
+                pendingFxaa           = Maze::get().isFxaaEnabled();
                 waitForConfirmRelease = input.isHeld(GameAction::MenuConfirm);
             } else if (waitForConfirmRelease &&
                        !input.isHeld(GameAction::MenuConfirm)) {
@@ -352,10 +352,15 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                 mgr.consumeActive(GameAction::MenuConfirm);
                 if (selectedItem == OptionMenuItem::Return) {
                     if (hasUnappliedChanges) {
+                        const auto currentWindow = Maze::get().getWindow();
+                        auto       saveWidth     = currentWindow->getWidth();
+                        auto       saveHeight    = currentWindow->getHeight();
                         if (!filteredResolutions.empty()) {
                             const auto& res =
                                 filteredResolutions[resolutionList
                                                         ->getSelectedIndex()];
+                            saveWidth  = res.width;
+                            saveHeight = res.height;
                             Maze::get().setResolution(res.width, res.height);
                         }
                         if (pendingFullscreen != Maze::get().isFullscreen()) {
@@ -363,7 +368,9 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                         }
                         Maze::get().setVerticalSync(pendingVsync);
                         Maze::get().setFxaaEnabled(pendingFxaa);
-                        saveVideoSettings();
+                        saveVideoSettings(saveWidth, saveHeight,
+                                          pendingFullscreen, pendingVsync,
+                                          pendingFxaa);
                         hasUnappliedChanges = false;
                         returnButton->setMessage(returnMessage);
                     } else {
@@ -498,9 +505,14 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
 
     if (returnButton->isInside({ mouseX, mouseY })) {
         if (hasUnappliedChanges) {
+            const auto currentWindow = Maze::get().getWindow();
+            auto       saveWidth     = currentWindow->getWidth();
+            auto       saveHeight    = currentWindow->getHeight();
             if (!filteredResolutions.empty()) {
                 const auto& res =
                     filteredResolutions[resolutionList->getSelectedIndex()];
+                saveWidth  = res.width;
+                saveHeight = res.height;
                 Maze::get().setResolution(res.width, res.height);
             }
             if (pendingFullscreen != Maze::get().isFullscreen()) {
@@ -508,7 +520,8 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
             }
             Maze::get().setVerticalSync(pendingVsync);
             Maze::get().setFxaaEnabled(pendingFxaa);
-            saveVideoSettings();
+            saveVideoSettings(saveWidth, saveHeight, pendingFullscreen,
+                              pendingVsync, pendingFxaa);
             hasUnappliedChanges = false;
             returnButton->setMessage(returnMessage);
         } else {

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -238,6 +238,10 @@ void OptionLayer::onAttach() {
     const auto currentWidth  = window->getWidth();
     const auto currentHeight = window->getHeight();
 
+    pendingFullscreen = Maze::get().isFullscreen();
+    pendingVsync      = Maze::get().hasVerticalSync();
+    pendingFxaa       = Maze::get().isFxaaEnabled();
+
     const auto g  = std::gcd(currentWidth, currentHeight);
     const auto rw = currentWidth / g;
     const auto rh = currentHeight / g;
@@ -347,12 +351,19 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                 input.isActive(GameAction::MenuConfirm)) {
                 mgr.consumeActive(GameAction::MenuConfirm);
                 if (selectedItem == OptionMenuItem::Return) {
-                    if (hasUnappliedChanges && !filteredResolutions.empty()) {
-                        const auto& res =
-                            filteredResolutions[resolutionList
-                                                    ->getSelectedIndex()];
-                        Maze::get().setResolution(res.width, res.height);
-                        saveVideoSettings(res.width, res.height);
+                    if (hasUnappliedChanges) {
+                        if (!filteredResolutions.empty()) {
+                            const auto& res =
+                                filteredResolutions[resolutionList
+                                                        ->getSelectedIndex()];
+                            Maze::get().setResolution(res.width, res.height);
+                        }
+                        if (pendingFullscreen != Maze::get().isFullscreen()) {
+                            Maze::get().toggleFullscreen();
+                        }
+                        Maze::get().setVerticalSync(pendingVsync);
+                        Maze::get().setFxaaEnabled(pendingFxaa);
+                        saveVideoSettings();
                         hasUnappliedChanges = false;
                         returnButton->setMessage(returnMessage);
                     } else {
@@ -362,14 +373,14 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                         setActive(false);
                     }
                 } else if (selectedItem == OptionMenuItem::FullScreen) {
-                    Maze::get().toggleFullscreen();
-                    saveVideoSettings();
+                    pendingFullscreen = !pendingFullscreen;
+                    updateChangeStatus();
                 } else if (selectedItem == OptionMenuItem::VerticalSync) {
-                    Maze::get().setVerticalSync(!Maze::get().hasVerticalSync());
-                    saveVideoSettings();
+                    pendingVsync = !pendingVsync;
+                    updateChangeStatus();
                 } else if (selectedItem == OptionMenuItem::AntiAliasing) {
-                    Maze::get().setFxaaEnabled(!Maze::get().isFxaaEnabled());
-                    saveVideoSettings();
+                    pendingFxaa = !pendingFxaa;
+                    updateChangeStatus();
                 }
             }
         }
@@ -425,18 +436,15 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
 
     renderRowBackground(fsX, fsY, fsW, fsH, OptionMenuItem::FullScreen);
     renderRowLabel(fsX, fsY, fsH, "Full Screen");
-    fullScreenCheckbox->onUpdate(fsX, fsY, fsW, fsH,
-                                 Maze::get().isFullscreen());
+    fullScreenCheckbox->onUpdate(fsX, fsY, fsW, fsH, pendingFullscreen);
 
     renderRowBackground(vsX, vsY, vsW, vsH, OptionMenuItem::VerticalSync);
     renderRowLabel(vsX, vsY, vsH, "Vertical Sync");
-    verticalSyncCheckbox->onUpdate(vsX, vsY, vsW, vsH,
-                                   Maze::get().hasVerticalSync());
+    verticalSyncCheckbox->onUpdate(vsX, vsY, vsW, vsH, pendingVsync);
 
     renderRowBackground(aaX, aaY, aaW, aaH, OptionMenuItem::AntiAliasing);
     renderRowLabel(aaX, aaY, aaH, "Anti-Aliasing");
-    antiAliasingCheckbox->onUpdate(aaX, aaY, aaW, aaH,
-                                   Maze::get().isFxaaEnabled());
+    antiAliasingCheckbox->onUpdate(aaX, aaY, aaW, aaH, pendingFxaa);
 
     returnButton->setPosition({ retX, retY }, { retX + retW, retY + retH });
     if (selectedItem == OptionMenuItem::Return) {
@@ -489,11 +497,18 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         sponge::platform::glfw::core::Application::get().getMousePosition();
 
     if (returnButton->isInside({ mouseX, mouseY })) {
-        if (hasUnappliedChanges && !filteredResolutions.empty()) {
-            const auto& res =
-                filteredResolutions[resolutionList->getSelectedIndex()];
-            Maze::get().setResolution(res.width, res.height);
-            saveVideoSettings(res.width, res.height);
+        if (hasUnappliedChanges) {
+            if (!filteredResolutions.empty()) {
+                const auto& res =
+                    filteredResolutions[resolutionList->getSelectedIndex()];
+                Maze::get().setResolution(res.width, res.height);
+            }
+            if (pendingFullscreen != Maze::get().isFullscreen()) {
+                Maze::get().toggleFullscreen();
+            }
+            Maze::get().setVerticalSync(pendingVsync);
+            Maze::get().setFxaaEnabled(pendingFxaa);
+            saveVideoSettings();
             hasUnappliedChanges = false;
             returnButton->setMessage(returnMessage);
         } else {
@@ -558,8 +573,8 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         selectedItem = OptionMenuItem::FullScreen;
         if (fullScreenCheckbox->isInside(mouseX, mouseY, fullX, fullY, fullW,
                                          fullH)) {
-            Maze::get().toggleFullscreen();
-            saveVideoSettings();
+            pendingFullscreen = !pendingFullscreen;
+            updateChangeStatus();
         }
         return true;
     }
@@ -572,8 +587,8 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         selectedItem = OptionMenuItem::VerticalSync;
         if (verticalSyncCheckbox->isInside(mouseX, mouseY, vsyncX, vsyncY,
                                            vsyncW, vsyncH)) {
-            Maze::get().setVerticalSync(!Maze::get().hasVerticalSync());
-            saveVideoSettings();
+            pendingVsync = !pendingVsync;
+            updateChangeStatus();
         }
         return true;
     }
@@ -586,8 +601,8 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         selectedItem = OptionMenuItem::AntiAliasing;
         if (antiAliasingCheckbox->isInside(mouseX, mouseY, aaX, aaY, aaW,
                                            aaH)) {
-            Maze::get().setFxaaEnabled(!Maze::get().isFxaaEnabled());
-            saveVideoSettings();
+            pendingFxaa = !pendingFxaa;
+            updateChangeStatus();
         }
         return true;
     }
@@ -718,16 +733,22 @@ void OptionLayer::filterResolutions() {
 }
 
 void OptionLayer::updateChangeStatus() {
+    const bool checkboxChanged =
+        pendingFullscreen != Maze::get().isFullscreen() ||
+        pendingVsync != Maze::get().hasVerticalSync() ||
+        pendingFxaa != Maze::get().isFxaaEnabled();
+
     if (filteredResolutions.empty()) {
-        hasUnappliedChanges = false;
-        returnButton->setMessage(returnMessage);
+        hasUnappliedChanges = checkboxChanged;
+        returnButton->setMessage(hasUnappliedChanges ? applyMessage :
+                                                       returnMessage);
         return;
     }
 
     const auto  window = Maze::get().getWindow();
     const auto& res = filteredResolutions[resolutionList->getSelectedIndex()];
-    hasUnappliedChanges =
-        res.width != window->getWidth() || res.height != window->getHeight();
+    hasUnappliedChanges = res.width != window->getWidth() ||
+                          res.height != window->getHeight() || checkboxChanged;
 
     returnButton->setMessage(hasUnappliedChanges ? applyMessage :
                                                    returnMessage);
@@ -739,6 +760,10 @@ void OptionLayer::clearHoveredItems() {
 }
 
 void OptionLayer::resetSelectionToCurrentState() {
+    pendingFullscreen = Maze::get().isFullscreen();
+    pendingVsync      = Maze::get().hasVerticalSync();
+    pendingFxaa       = Maze::get().isFxaaEnabled();
+
     const auto window        = Maze::get().getWindow();
     const auto currentWidth  = window->getWidth();
     const auto currentHeight = window->getHeight();

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -235,9 +235,7 @@ void OptionLayer::onAttach() {
     const auto currentWidth  = window->getWidth();
     const auto currentHeight = window->getHeight();
 
-    pendingFullscreen = Maze::get().isFullscreen();
-    pendingVsync      = Maze::get().hasVerticalSync();
-    pendingFxaa       = Maze::get().isFxaaEnabled();
+    syncPendingCheckboxState();
 
     const auto g  = std::gcd(currentWidth, currentHeight);
     const auto rw = currentWidth / g;
@@ -297,9 +295,7 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
             using sponge::input::GameAction;
             const auto& input = mgr.getSnapshot();
             if (!wasActiveLastFrame) {
-                pendingFullscreen     = Maze::get().isFullscreen();
-                pendingVsync          = Maze::get().hasVerticalSync();
-                pendingFxaa           = Maze::get().isFxaaEnabled();
+                syncPendingCheckboxState();
                 waitForConfirmRelease = input.isHeld(GameAction::MenuConfirm);
             } else if (waitForConfirmRelease &&
                        !input.isHeld(GameAction::MenuConfirm)) {
@@ -352,27 +348,7 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                 mgr.consumeActive(GameAction::MenuConfirm);
                 if (selectedItem == OptionMenuItem::Return) {
                     if (hasUnappliedChanges) {
-                        const auto currentWindow = Maze::get().getWindow();
-                        auto       saveWidth     = currentWindow->getWidth();
-                        auto       saveHeight    = currentWindow->getHeight();
-                        if (!filteredResolutions.empty()) {
-                            const auto& res =
-                                filteredResolutions[resolutionList
-                                                        ->getSelectedIndex()];
-                            saveWidth  = res.width;
-                            saveHeight = res.height;
-                            Maze::get().setResolution(res.width, res.height);
-                        }
-                        if (pendingFullscreen != Maze::get().isFullscreen()) {
-                            Maze::get().toggleFullscreen();
-                        }
-                        Maze::get().setVerticalSync(pendingVsync);
-                        Maze::get().setFxaaEnabled(pendingFxaa);
-                        saveVideoSettings(saveWidth, saveHeight,
-                                          pendingFullscreen, pendingVsync,
-                                          pendingFxaa);
-                        hasUnappliedChanges = false;
-                        returnButton->setMessage(returnMessage);
+                        applyChanges();
                     } else {
                         clearHoveredItems();
                         selectedItem = OptionMenuItem::AspectRatio;
@@ -505,25 +481,7 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
 
     if (returnButton->isInside({ mouseX, mouseY })) {
         if (hasUnappliedChanges) {
-            const auto currentWindow = Maze::get().getWindow();
-            auto       saveWidth     = currentWindow->getWidth();
-            auto       saveHeight    = currentWindow->getHeight();
-            if (!filteredResolutions.empty()) {
-                const auto& res =
-                    filteredResolutions[resolutionList->getSelectedIndex()];
-                saveWidth  = res.width;
-                saveHeight = res.height;
-                Maze::get().setResolution(res.width, res.height);
-            }
-            if (pendingFullscreen != Maze::get().isFullscreen()) {
-                Maze::get().toggleFullscreen();
-            }
-            Maze::get().setVerticalSync(pendingVsync);
-            Maze::get().setFxaaEnabled(pendingFxaa);
-            saveVideoSettings(saveWidth, saveHeight, pendingFullscreen,
-                              pendingVsync, pendingFxaa);
-            hasUnappliedChanges = false;
-            returnButton->setMessage(returnMessage);
+            applyChanges();
         } else {
             clearHoveredItems();
             resetSelectionToCurrentState();
@@ -745,24 +703,52 @@ void OptionLayer::filterResolutions() {
     updateChangeStatus();
 }
 
+void OptionLayer::applyChanges() {
+    const auto currentWindow = Maze::get().getWindow();
+    auto       saveWidth     = currentWindow->getWidth();
+    auto       saveHeight    = currentWindow->getHeight();
+
+    if (!filteredResolutions.empty()) {
+        const auto& res =
+            filteredResolutions[resolutionList->getSelectedIndex()];
+        saveWidth  = res.width;
+        saveHeight = res.height;
+        Maze::get().setResolution(res.width, res.height);
+    }
+    if (pendingFullscreen != Maze::get().isFullscreen()) {
+        Maze::get().toggleFullscreen();
+    }
+    Maze::get().setVerticalSync(pendingVsync);
+    Maze::get().setFxaaEnabled(pendingFxaa);
+    saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
+                      pendingFxaa);
+
+    hasUnappliedChanges = false;
+    returnButton->setMessage(returnMessage);
+}
+
+void OptionLayer::syncPendingCheckboxState() {
+    pendingFullscreen = Maze::get().isFullscreen();
+    pendingVsync      = Maze::get().hasVerticalSync();
+    pendingFxaa       = Maze::get().isFxaaEnabled();
+}
+
 void OptionLayer::updateChangeStatus() {
     const bool checkboxChanged =
         pendingFullscreen != Maze::get().isFullscreen() ||
         pendingVsync != Maze::get().hasVerticalSync() ||
         pendingFxaa != Maze::get().isFxaaEnabled();
 
-    if (filteredResolutions.empty()) {
-        hasUnappliedChanges = checkboxChanged;
-        returnButton->setMessage(hasUnappliedChanges ? applyMessage :
-                                                       returnMessage);
-        return;
+    bool resolutionChanged = false;
+    if (!filteredResolutions.empty()) {
+        const auto  window = Maze::get().getWindow();
+        const auto& res =
+            filteredResolutions[resolutionList->getSelectedIndex()];
+        resolutionChanged = res.width != window->getWidth() ||
+                            res.height != window->getHeight();
     }
 
-    const auto  window = Maze::get().getWindow();
-    const auto& res = filteredResolutions[resolutionList->getSelectedIndex()];
-    hasUnappliedChanges = res.width != window->getWidth() ||
-                          res.height != window->getHeight() || checkboxChanged;
-
+    hasUnappliedChanges = checkboxChanged || resolutionChanged;
     returnButton->setMessage(hasUnappliedChanges ? applyMessage :
                                                    returnMessage);
 }
@@ -773,9 +759,7 @@ void OptionLayer::clearHoveredItems() {
 }
 
 void OptionLayer::resetSelectionToCurrentState() {
-    pendingFullscreen = Maze::get().isFullscreen();
-    pendingVsync      = Maze::get().hasVerticalSync();
-    pendingFxaa       = Maze::get().isFxaaEnabled();
+    syncPendingCheckboxState();
 
     const auto window        = Maze::get().getWindow();
     const auto currentWidth  = window->getWidth();

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -723,6 +723,7 @@ void OptionLayer::applyChanges() {
     saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
                       pendingFxaa);
 
+    syncPendingCheckboxState();
     hasUnappliedChanges = false;
     returnButton->setMessage(returnMessage);
 }

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -39,6 +39,10 @@ private:
     bool wasActiveLastFrame    = false;
     bool waitForConfirmRelease = false;
 
+    bool pendingFullscreen = false;
+    bool pendingVsync      = false;
+    bool pendingFxaa       = false;
+
     std::unique_ptr<ui::SelectList> aspectRatioList;
     std::unique_ptr<ui::SelectList> resolutionList;
     std::unique_ptr<ui::Checkbox>   antiAliasingCheckbox;

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -56,6 +56,10 @@ private:
 
     static void recalculateLayout(float width, float height);
 
+    void applyChanges();
+
+    void syncPendingCheckboxState();
+
     void updateChangeStatus();
 
     bool onMouseButtonPressed(


### PR DESCRIPTION
## Summary

- Fullscreen, vertical sync, and anti-aliasing checkboxes now stage changes rather than applying immediately
- Toggling any checkbox marks the options dirty and switches the Return button to Apply
- All pending changes (resolution + checkboxes) are committed together when Apply is activated
- Cancelling or pressing Back discards pending checkbox state, consistent with resolution behaviour