### PR TITLE
fix: defer fullscreen toggle to main thread and fix windowed centering

### DIFF
--- a/sponge/src/platform/glfw/core/application.cpp
+++ b/sponge/src/platform/glfw/core/application.cpp
@@ -182,45 +182,8 @@ void Application::popOverlay(const std::shared_ptr<layer::Layer>& layer) const {
 }
 
 void Application::toggleFullscreen() {
-    auto* glfwWindow = static_cast<GLFWwindow*>(window->getNativeWindow());
-    if (!glfwWindow) {
-        SPONGE_CORE_WARN("Window handle is null");
-        return;
-    }
-
     fullscreen = !fullscreen;
-
-    if (fullscreen) {
-        glfwGetWindowPos(glfwWindow, &prevX, &prevY);
-        glfwGetWindowSize(glfwWindow, &prevW, &prevH);
-
-        GLFWmonitor*       monitor = glfwGetPrimaryMonitor();
-        const GLFWvidmode* mode    = glfwGetVideoMode(monitor);
-        glfwSetWindowMonitor(glfwWindow, monitor, 0, 0, prevW, prevH,
-                             mode->refreshRate);
-    } else {
-        if (prevW <= 0) {
-            prevW = static_cast<int>(window->getWidth());
-        }
-        if (prevH <= 0) {
-            prevH = static_cast<int>(window->getHeight());
-        }
-
-        GLFWmonitor*       monitor = glfwGetPrimaryMonitor();
-        const GLFWvidmode* mode    = glfwGetVideoMode(monitor);
-
-        if (prevX <= 0) {
-            prevX = prevW - mode->width / 2;
-        }
-        if (prevY <= 0) {
-            prevY = prevH - mode->height / 2;
-        }
-
-        glfwSetWindowAttrib(glfwWindow, GLFW_DECORATED, GLFW_TRUE);
-        glfwSetWindowMonitor(glfwWindow, nullptr, prevX, prevY, prevW, prevH,
-                             GLFW_DONT_CARE);
-        glfwFocusWindow(glfwWindow);
-    }
+    pendingFullscreenToggle.store(true, std::memory_order_release);
 }
 
 void Application::setMouseVisible(const bool value) const {
@@ -356,14 +319,52 @@ void Application::run() {
         inputManager.recenterCursor();
         glfwPollEvents();
 
-        // Apply any deferred resolution change requested by a render-thread
-        // layer. Must be done on the main thread.
+        // glfwSetWindowMonitor from render/update threads deadlocks on Windows
+        // (Win32 message pump runs only here). Runs before pendingResolution
+        // so fullscreen matches the actual OS state when the resize branch
+        // fires.
+        if (pendingFullscreenToggle.load(std::memory_order_acquire)) {
+            auto* glfwWindow =
+                static_cast<GLFWwindow*>(window->getNativeWindow());
+            if (glfwWindow != nullptr) {
+                GLFWmonitor* monitor = glfwGetPrimaryMonitor();
+                if (monitor != nullptr) {
+                    const GLFWvidmode* mode = glfwGetVideoMode(monitor);
+                    if (mode != nullptr) {
+                        if (fullscreen) {
+                            glfwGetWindowPos(glfwWindow, &prevX, &prevY);
+                            glfwGetWindowSize(glfwWindow, &prevW, &prevH);
+                            glfwSetWindowMonitor(glfwWindow, monitor, 0, 0,
+                                                 prevW, prevH,
+                                                 mode->refreshRate);
+                        } else {
+                            if (prevW <= 0) {
+                                prevW = static_cast<int>(appSpec.width);
+                            }
+                            if (prevH <= 0) {
+                                prevH = static_cast<int>(appSpec.height);
+                            }
+                            const int posX = (mode->width - prevW) / 2;
+                            const int posY = (mode->height - prevH) / 2;
+                            glfwSetWindowAttrib(glfwWindow, GLFW_DECORATED,
+                                                GLFW_TRUE);
+                            glfwSetWindowMonitor(glfwWindow, nullptr, posX,
+                                                 posY, prevW, prevH,
+                                                 GLFW_DONT_CARE);
+                            glfwFocusWindow(glfwWindow);
+                        }
+                    }
+                }
+            }
+            pendingFullscreenToggle.store(false, std::memory_order_relaxed);
+        }
+
+        // Runs after pendingFullscreenToggle so fullscreen matches OS state.
         if (pendingResolution.load(std::memory_order_acquire)) {
             const uint32_t w =
                 pendingResolutionW.load(std::memory_order_relaxed);
             const uint32_t h =
                 pendingResolutionH.load(std::memory_order_relaxed);
-            // Re-implement original logic here on main thread
             auto* glfwWindow =
                 static_cast<GLFWwindow*>(window->getNativeWindow());
             if (glfwWindow != nullptr) {

--- a/sponge/src/platform/glfw/core/application.cpp
+++ b/sponge/src/platform/glfw/core/application.cpp
@@ -141,7 +141,7 @@ bool Application::onUserDestroy() {
 void Application::onEvent(event::Event& event) {
     SPONGE_PROFILE_SECTION("Application::onEvent");
 
-    for (auto it = layerStack->rbegin(); it != layerStack->rend(); ++it) {
+    for (auto it = layerStack->rbegin(); it != layerStack->rend(); it++) {
         const auto& layer = *it;
         layer->onEvent(event);
         if (event.handled) {
@@ -306,7 +306,7 @@ void Application::run() {
     // Warm up render thread (acquires GL context) before pipelined loop.
     renderThread.kick();
     renderThread.blockUntilRenderComplete();
-    ++frame;
+    frame++;
 
     // Pipelined loop: update[N] overlaps with render[N-1].
     while (true) {

--- a/sponge/src/platform/glfw/core/application.hpp
+++ b/sponge/src/platform/glfw/core/application.hpp
@@ -168,6 +168,10 @@ private:
     std::atomic<uint32_t> pendingResolutionW{ 0 };
     std::atomic<uint32_t> pendingResolutionH{ 0 };
 
+    // fullscreen flips immediately in toggleFullscreen(); the GLFW window call
+    // runs here to avoid deadlocking the Win32 message pump.
+    std::atomic<bool> pendingFullscreenToggle{ false };
+
     static Application* instance;
 
     std::shared_ptr<imgui::GLFWManager> glfwManager =

--- a/sponge/src/platform/glfw/core/window.cpp
+++ b/sponge/src/platform/glfw/core/window.cpp
@@ -73,6 +73,10 @@ void Window::init(const sponge::core::WindowProps& props) {
     data.width  = static_cast<uint32_t>(w);
     data.height = static_cast<uint32_t>(h);
 
+    if (!props.fullscreen) {
+        glfwSetWindowPos(window, (mode->width - w) / 2, (mode->height - h) / 2);
+    }
+
     glfwSetWindowAttrib(window, GLFW_DECORATED,
                         props.fullscreen ? GLFW_FALSE : GLFW_TRUE);
 


### PR DESCRIPTION
## Summary

- `toggleFullscreen` called `glfwSetWindowMonitor` from the render or update thread, deadlocking on Windows because `SetWindowPos` sends synchronous Win32 messages that only the main thread can pump while it was blocked in `blockUntilRenderComplete`
- Windowed centering was broken by an inverted formula (`prevW - mode->width/2` instead of `(mode->width - prevW)/2`), hitting on every first windowed switch since the app starts fullscreen
- `pendingResolution` ran before `pendingFullscreenToggle`, so a simultaneous resolution + fullscreen change from Options read a stale `fullscreen` flag

## Changes

- `toggleFullscreen` now flips the bool immediately and sets `pendingFullscreenToggle`; the GLFW call moves to the main loop, matching the existing `pendingResolution` pattern
- Windowed restore centers unconditionally using the correct formula, consistent with the resolution-change path
- `pendingFullscreenToggle` runs before `pendingResolution` in the main loop