### PR TITLE
Update vcpkg baseline to b216ddf for dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,18 +152,18 @@ jobs:
             - name: Cache the build
               uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
-            - name: Cache vcpkg downloads
-              if: runner.os == 'Windows'
-              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-              with:
-                  path: C:/vcpkg/downloads
-                  key: vcpkg-downloads-windows-${{steps.vcpkg-commit-id.outputs.id}}
-                  restore-keys: vcpkg-downloads-windows-
-
             - name: Setup vcpkg
               uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11
               with:
                   vcpkgGitURL: 'https://github.com/microsoft/vcpkg.git'
+
+            - name: Cache vcpkg downloads
+              if: runner.os == 'Windows'
+              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+              with:
+                  path: ${{env.VCPKG_ROOT}}/downloads
+                  key: vcpkg-downloads-windows-${{steps.vcpkg-commit-id.outputs.id}}
+                  restore-keys: vcpkg-downloads-windows-
 
             - name: Setup vcpkg NuGet credentials
               shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,11 @@ env:
     BUILD_DIR: build
     BUILD_TYPE: Release
     SCCACHE_GHA_ENABLED: true
+    VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
 
 permissions:
     contents: read
+    packages: write
 
 jobs:
     changed:
@@ -156,6 +158,19 @@ jobs:
               uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11
               with:
                   vcpkgGitURL: 'https://github.com/microsoft/vcpkg.git'
+
+            - name: Setup vcpkg NuGet credentials
+              shell: bash
+              run: |
+                  NUGET=$(vcpkg fetch nuget | tail -n 1)
+                  $NUGET sources add \
+                    -Name "GitHub" \
+                    -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" \
+                    -UserName "${{github.actor}}" \
+                    -Password "${{secrets.GITHUB_TOKEN}}" \
+                    -StorePasswordInClearText
+                  $NUGET setapikey "${{secrets.GITHUB_TOKEN}}" \
+                    -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json"
 
             - name: Create build tree
               run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,7 @@ jobs:
                   sudo apt-get update -qq &&
                   sudo apt-get install -qq -y --no-install-recommends libtool libasound2-dev libgl1-mesa-dev libltdl-dev
                   libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxrandr-dev
+                  mono-complete
 
             - name: Install nuget
               if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,14 @@ jobs:
                   echo "id=$id" >> $GITHUB_OUTPUT
                   echo "VCPKG_GIT_COMMIT_ID=$id" >> $GITHUB_ENV
 
+            - name: Cache linux packages
+              if: runner.os == 'Linux'
+              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+              with:
+                  path: /var/cache/apt/archives
+                  key: apt-${{runner.os}}-${{hashFiles('.github/workflows/build.yml')}}
+                  restore-keys: apt-${{runner.os}}-
+
             - name: Install linux packages
               if: runner.os == 'Linux'
               run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
     BUILD_DIR: build
     BUILD_TYPE: Release
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     SCCACHE_GHA_ENABLED: true
     VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
               run: |
                   [[ "$RUNNER_OS" != "Windows" ]] && unset VCPKG_FORCE_SYSTEM_BINARIES
                   NUGET=$(vcpkg fetch nuget | tail -n 1)
-                  [[ "$RUNNER_OS" == "macOS" ]] && NUGET="mono $NUGET"
+                  [[ "$NUGET" == *.exe && "$RUNNER_OS" != "Windows" ]] && NUGET="mono $NUGET"
                   $NUGET sources add \
                     -Name "GitHub" \
                     -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,10 @@ jobs:
                   sudo apt-get install -qq -y --no-install-recommends libtool libasound2-dev libgl1-mesa-dev libltdl-dev
                   libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxrandr-dev
 
+            - name: Install nuget
+              if: runner.os == 'macOS'
+              run: brew install nuget
+
             - name: Setup MSVC toolchain
               if: runner.os == 'Windows'
               uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,18 +109,12 @@ jobs:
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
             - name: Extract git commit id from vcpkg configuration
-              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               id: vcpkg-commit-id
-              with:
-                  script: |
-                      const fs = require('fs');
-                      const path = require('path');
-                      const fullPath = path.join(process.env.GITHUB_WORKSPACE, 'vcpkg.json');
-                      const config = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-                      const id = config['builtin-baseline'];
-                      core.setOutput('id', id);
-                      core.exportVariable('VCPKG_GIT_COMMIT_ID', id);
-                      console.log(`Extracted vcpkg git commit id: ${id}`);
+              shell: bash
+              run: |
+                  id=$(jq -r '."builtin-baseline"' vcpkg.json)
+                  echo "id=$id" >> $GITHUB_OUTPUT
+                  echo "VCPKG_GIT_COMMIT_ID=$id" >> $GITHUB_ENV
 
             - name: Install linux packages
               if: runner.os == 'Linux'
@@ -130,6 +124,10 @@ jobs:
                   libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxrandr-dev
                   mono-complete
 
+            - name: Install mono
+              if: runner.os == 'macOS'
+              run: brew install mono
+
             - name: Setup MSVC toolchain
               if: runner.os == 'Windows'
               uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -138,11 +136,10 @@ jobs:
               uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
             - name: Configure sccache
-              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-              with:
-                  script: |
-                      core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-                      core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+              shell: bash
+              run: |
+                  echo "ACTIONS_RESULTS_URL=${ACTIONS_RESULTS_URL}" >> $GITHUB_ENV
+                  echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> $GITHUB_ENV
 
             - name: Cache the build
               uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -159,10 +156,6 @@ jobs:
               uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11
               with:
                   vcpkgGitURL: 'https://github.com/microsoft/vcpkg.git'
-
-            - name: Install mono
-              if: runner.os == 'macOS'
-              run: brew install mono
 
             - name: Setup vcpkg NuGet credentials
               shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
               if: runner.os == 'Linux'
               uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
               with:
-                  path: /var/cache/apt/archives
+                  path: /var/cache/apt/archives/*.deb
                   key: apt-${{runner.os}}-${{hashFiles('.github/workflows/build.yml')}}
                   restore-keys: apt-${{runner.os}}-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
                   sudo apt-get update -qq &&
                   sudo apt-get install -qq -y --no-install-recommends libtool libasound2-dev libgl1-mesa-dev libltdl-dev
                   libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxrandr-dev
-                  mono-runtime ca-certificates-mono
+                  mono-complete
 
             - name: Install mono
               if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,14 +117,6 @@ jobs:
                   echo "id=$id" >> $GITHUB_OUTPUT
                   echo "VCPKG_GIT_COMMIT_ID=$id" >> $GITHUB_ENV
 
-            - name: Cache linux packages
-              if: runner.os == 'Linux'
-              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-              with:
-                  path: /var/cache/apt/archives/*.deb
-                  key: apt-${{runner.os}}-${{hashFiles('.github/workflows/build.yml')}}
-                  restore-keys: apt-${{runner.os}}-
-
             - name: Install linux packages
               if: runner.os == 'Linux'
               run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,9 +160,9 @@ jobs:
               with:
                   vcpkgGitURL: 'https://github.com/microsoft/vcpkg.git'
 
-            - name: Allow vcpkg to fetch nuget
+            - name: Install mono
               if: runner.os == 'macOS'
-              run: echo "VCPKG_FORCE_SYSTEM_BINARIES=" >> $GITHUB_ENV
+              run: brew install mono
 
             - name: Setup vcpkg NuGet credentials
               shell: bash
@@ -175,7 +175,9 @@ jobs:
                     --store-password-in-clear-text
 
             - name: Create build tree
-              run: >
+              shell: bash
+              run: |
+                  [[ "$RUNNER_OS" == "macOS" ]] && unset VCPKG_FORCE_SYSTEM_BINARIES
                   cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} --preset ${{matrix.preset}}
 
             - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,10 +130,6 @@ jobs:
                   libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxrandr-dev
                   mono-complete
 
-            - name: Install nuget
-              if: runner.os == 'macOS'
-              run: brew install nuget
-
             - name: Setup MSVC toolchain
               if: runner.os == 'Windows'
               uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -163,6 +159,10 @@ jobs:
               uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11
               with:
                   vcpkgGitURL: 'https://github.com/microsoft/vcpkg.git'
+
+            - name: Allow vcpkg to fetch nuget
+              if: runner.os == 'macOS'
+              run: echo "VCPKG_FORCE_SYSTEM_BINARIES=" >> $GITHUB_ENV
 
             - name: Setup vcpkg NuGet credentials
               shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,15 +162,12 @@ jobs:
             - name: Setup vcpkg NuGet credentials
               shell: bash
               run: |
-                  NUGET=$(vcpkg fetch nuget | tail -n 1)
-                  $NUGET sources add \
-                    -Name "GitHub" \
-                    -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" \
-                    -UserName "${{github.actor}}" \
-                    -Password "${{secrets.GITHUB_TOKEN}}" \
-                    -StorePasswordInClearText
-                  $NUGET setapikey "${{secrets.GITHUB_TOKEN}}" \
-                    -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json"
+                  dotnet nuget add source \
+                    "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" \
+                    --name "GitHub" \
+                    --username "${{github.actor}}" \
+                    --password "${{secrets.GITHUB_TOKEN}}" \
+                    --store-password-in-clear-text
 
             - name: Create build tree
               run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,6 +169,7 @@ jobs:
               run: |
                   [[ "$RUNNER_OS" != "Windows" ]] && unset VCPKG_FORCE_SYSTEM_BINARIES
                   NUGET=$(vcpkg fetch nuget | tail -n 1)
+                  [[ "$RUNNER_OS" == "macOS" ]] && NUGET="mono $NUGET"
                   $NUGET sources add \
                     -Name "GitHub" \
                     -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,17 +167,21 @@ jobs:
             - name: Setup vcpkg NuGet credentials
               shell: bash
               run: |
-                  dotnet nuget add source \
-                    "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" \
-                    --name "GitHub" \
-                    --username "${{github.actor}}" \
-                    --password "${{secrets.GITHUB_TOKEN}}" \
-                    --store-password-in-clear-text
+                  [[ "$RUNNER_OS" != "Windows" ]] && unset VCPKG_FORCE_SYSTEM_BINARIES
+                  NUGET=$(vcpkg fetch nuget | tail -n 1)
+                  $NUGET sources add \
+                    -Name "GitHub" \
+                    -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" \
+                    -UserName "${{github.actor}}" \
+                    -Password "${{secrets.GITHUB_TOKEN}}" \
+                    -StorePasswordInClearText
+                  $NUGET setapikey "${{secrets.GITHUB_TOKEN}}" \
+                    -Source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json"
 
             - name: Create build tree
               shell: bash
               run: |
-                  [[ "$RUNNER_OS" == "macOS" ]] && unset VCPKG_FORCE_SYSTEM_BINARIES
+                  [[ "$RUNNER_OS" != "Windows" ]] && unset VCPKG_FORCE_SYSTEM_BINARIES
                   cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} --preset ${{matrix.preset}}
 
             - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
                   sudo apt-get update -qq &&
                   sudo apt-get install -qq -y --no-install-recommends libtool libasound2-dev libgl1-mesa-dev libltdl-dev
                   libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxrandr-dev
-                  mono-complete
+                  mono-runtime ca-certificates-mono
 
             - name: Install mono
               if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,14 @@ jobs:
             - name: Cache the build
               uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
+            - name: Cache vcpkg downloads
+              if: runner.os == 'Windows'
+              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+              with:
+                  path: C:/vcpkg/downloads
+                  key: vcpkg-downloads-windows-${{steps.vcpkg-commit-id.outputs.id}}
+                  restore-keys: vcpkg-downloads-windows-
+
             - name: Setup vcpkg
               uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11
               with:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "maze",
   "version-string": "latest",
-  "builtin-baseline": "c16c1bd46c7f6de21efc6dcf19c1069d6825df23",
+  "builtin-baseline": "b216ddff25a1f432870e6c340ce79357049ef86e",
   "dependencies": [
     {
       "name": "fmt",


### PR DESCRIPTION
## Description

Updated the vcpkg baseline to commit `b216ddf` to include the latest dependency updates.

Switches vcpkg binary caching from the removed `x-gha` backend to NuGet via GitHub Packages. Adds `packages: write` permission, sets `VCPKG_BINARY_SOURCES`, and registers vcpkg's bundled nuget with the GitHub Packages feed before cmake triggers vcpkg install.

Also simplifies the workflow: replaces two `actions/github-script` invocations with shell equivalents, fixes the vcpkg downloads cache path on Windows, and opts into Node.js 24 for actions.