### PR TITLE
feat: add bloom post-processing

### DIFF
--- a/assets/shaders/glsl/bloom_composite.frag.glsl
+++ b/assets/shaders/glsl/bloom_composite.frag.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D scene;
+uniform sampler2D bloomTex;
+uniform float     intensity;
+
+void main() {
+    vec3 color = texture(scene,    texCoords).rgb;
+    vec3 bloom = texture(bloomTex, texCoords).rgb;
+    FragColor  = vec4(color + bloom * intensity, 1.0);
+}

--- a/assets/shaders/glsl/bloom_down.frag.glsl
+++ b/assets/shaders/glsl/bloom_down.frag.glsl
@@ -1,0 +1,20 @@
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D image;
+uniform float     offset;
+
+void main() {
+    vec2 halfpixel = 0.5 / vec2(textureSize(image, 0));
+    vec2 o         = halfpixel * offset;
+
+    vec3 color = texture(image, texCoords).rgb * 4.0;
+    color += texture(image, texCoords + vec2(-o.x, -o.y)).rgb;
+    color += texture(image, texCoords + vec2( o.x, -o.y)).rgb;
+    color += texture(image, texCoords + vec2(-o.x,  o.y)).rgb;
+    color += texture(image, texCoords + vec2( o.x,  o.y)).rgb;
+
+    FragColor = vec4(color / 8.0, 1.0);
+}

--- a/assets/shaders/glsl/bloom_extract.frag.glsl
+++ b/assets/shaders/glsl/bloom_extract.frag.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D scene;
+uniform float     threshold;
+
+void main() {
+    vec3  color      = texture(scene, texCoords).rgb;
+    float brightness = dot(color, vec3(0.2126, 0.7152, 0.0722));
+    FragColor = brightness > threshold ? vec4(color, 1.0)
+                                       : vec4(0.0, 0.0, 0.0, 1.0);
+}

--- a/assets/shaders/glsl/bloom_up.frag.glsl
+++ b/assets/shaders/glsl/bloom_up.frag.glsl
@@ -1,0 +1,24 @@
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D image;
+uniform float     offset;
+
+void main() {
+    vec2 halfpixel = 0.5 / vec2(textureSize(image, 0));
+    vec2 o         = halfpixel * offset;
+
+    vec3 color = vec3(0.0);
+    color += texture(image, texCoords + vec2(-o.x * 2.0, 0.0)).rgb;
+    color += texture(image, texCoords + vec2( o.x * 2.0, 0.0)).rgb;
+    color += texture(image, texCoords + vec2(0.0, -o.y * 2.0)).rgb;
+    color += texture(image, texCoords + vec2(0.0,  o.y * 2.0)).rgb;
+    color += texture(image, texCoords + vec2(-o.x,  o.y)).rgb * 2.0;
+    color += texture(image, texCoords + vec2( o.x,  o.y)).rgb * 2.0;
+    color += texture(image, texCoords + vec2(-o.x, -o.y)).rgb * 2.0;
+    color += texture(image, texCoords + vec2( o.x, -o.y)).rgb * 2.0;
+
+    FragColor = vec4(color / 12.0, 1.0);
+}

--- a/assets/shaders/glsl/fxaa.frag.glsl
+++ b/assets/shaders/glsl/fxaa.frag.glsl
@@ -134,6 +134,12 @@ vec4 fxaaPass(vec2 uv) {
     return texture(screenTexture, finalUV);
 }
 
+uniform sampler2D bloomTex;
+uniform float     bloomIntensity;
+
 void main() {
     fragColor = fxaaPass(fragTexCoords);
+    if (bloomIntensity > 0.0) {
+        fragColor.rgb += texture(bloomTex, fragTexCoords).rgb * bloomIntensity;
+    }
 }

--- a/assets/shaders/glsl/pbr.frag.glsl
+++ b/assets/shaders/glsl/pbr.frag.glsl
@@ -39,6 +39,7 @@ uniform float evsmBleedThreshold;
 uniform vec3      viewPos;
 uniform float     ambientStrength;
 uniform bool      hasNoTexture;
+uniform vec3      emissive;
 
 const float M_PI = 3.14159265359;
 
@@ -105,7 +106,7 @@ void main() {
     float gamma = 2.2;
     color       = pow(color, vec3(1.0 / gamma));
 
-    FragColor = vec4(color, 1.0);
+    FragColor = vec4(color + emissive, 1.0);
 }
 
 float attenuationFromLight(PointLight light) {

--- a/docs/superpowers/plans/2026-06-18-bloom.md
+++ b/docs/superpowers/plans/2026-06-18-bloom.md
@@ -1,0 +1,1266 @@
+# Bloom Post-Processing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a toggleable Dual Kawase bloom post-processing effect with tunable threshold and intensity, exposed in the options UI.
+
+**Architecture:** `Bloom` owns a scene-capture FBO and a 5-level downsample/upsample mip chain. When bloom is enabled it captures the scene (replacing FXAA's scene capture); FXAA gains `applyWithBloom()` that reads bloom's scene + bloom textures and additively composites them. When only FXAA is on the existing path is unchanged.
+
+**Tech Stack:** OpenGL 3.3, GLSL 3.30, existing `renderer::Shader` / `VertexArray` / `VertexBuffer`, Yoga layout (OptionLayer UI), sponge settings system.
+
+## Global Constraints
+
+* No AI attribution in commits or PR descriptions.
+* Do not edit files under `out/` or `sponge/deps/`.
+* Build with preset `windows-msvc-release` (`cmake -B build --preset windows-msvc-release && cmake --build build --target game --config Release`).
+* GLSL `#version 330 core` in all shaders.
+* All new OpenGL objects must be deleted in their owner's destructor.
+* Follow existing patterns exactly: `SPONGE_GL_CRITICAL` for incomplete FBOs, `glCheckFramebufferStatus` after every FBO construction, `GL_CLAMP_TO_EDGE` + `GL_LINEAR` on all bloom textures.
+
+***
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `assets/shaders/glsl/bloom_extract.frag.glsl` |
+| Create | `assets/shaders/glsl/bloom_down.frag.glsl` |
+| Create | `assets/shaders/glsl/bloom_up.frag.glsl` |
+| Create | `assets/shaders/glsl/bloom_composite.frag.glsl` |
+| Modify | `assets/shaders/glsl/fxaa.frag.glsl` |
+| Create | `sponge/src/platform/opengl/scene/bloom.hpp` |
+| Create | `sponge/src/platform/opengl/scene/bloom.cpp` |
+| Modify | `sponge/src/sponge.hpp` |
+| Modify | `sponge/src/platform/opengl/scene/fxaa.hpp` |
+| Modify | `sponge/src/platform/opengl/scene/fxaa.cpp` |
+| Modify | `game/src/thread/mazeframe.hpp` |
+| Modify | `game/src/layer/mazelayer.hpp` |
+| Modify | `game/src/layer/mazelayer.cpp` |
+| Modify | `game/src/maze.hpp` |
+| Modify | `game/src/maze.cpp` |
+| Modify | `game/src/layer/optionlayer.hpp` |
+| Modify | `game/src/layer/optionlayer.cpp` |
+
+***
+
+## Task 1: Bloom shaders
+
+**Files:**
+
+* Create: `assets/shaders/glsl/bloom_extract.frag.glsl`
+* Create: `assets/shaders/glsl/bloom_down.frag.glsl`
+* Create: `assets/shaders/glsl/bloom_up.frag.glsl`
+* Create: `assets/shaders/glsl/bloom_composite.frag.glsl`
+
+**Interfaces:**
+
+* Produces: four fragment shaders consumed by the `Bloom` class in Task 2.
+
+* All use `blur.vert.glsl` as vertex shader (outputs `texCoords`).
+
+* \[ ] **Step 1: Write `bloom_extract.frag.glsl`**
+
+```glsl
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D scene;
+uniform float     threshold;
+
+void main() {
+    vec3  color      = texture(scene, texCoords).rgb;
+    float brightness = dot(color, vec3(0.2126, 0.7152, 0.0722));
+    FragColor = brightness > threshold ? vec4(color, 1.0)
+                                       : vec4(0.0, 0.0, 0.0, 1.0);
+}
+```
+
+* \[ ] **Step 2: Write `bloom_down.frag.glsl`** (RGB Dual Kawase downsample)
+
+```glsl
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D image;
+uniform float     offset;
+
+void main() {
+    vec2 halfpixel = 0.5 / vec2(textureSize(image, 0));
+    vec2 o         = halfpixel * offset;
+
+    vec3 color = texture(image, texCoords).rgb * 4.0;
+    color += texture(image, texCoords + vec2(-o.x, -o.y)).rgb;
+    color += texture(image, texCoords + vec2( o.x, -o.y)).rgb;
+    color += texture(image, texCoords + vec2(-o.x,  o.y)).rgb;
+    color += texture(image, texCoords + vec2( o.x,  o.y)).rgb;
+
+    FragColor = vec4(color / 8.0, 1.0);
+}
+```
+
+* \[ ] **Step 3: Write `bloom_up.frag.glsl`** (RGB Dual Kawase upsample)
+
+```glsl
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D image;
+uniform float     offset;
+
+void main() {
+    vec2 halfpixel = 0.5 / vec2(textureSize(image, 0));
+    vec2 o         = halfpixel * offset;
+
+    vec3 color = vec3(0.0);
+    color += texture(image, texCoords + vec2(-o.x * 2.0, 0.0)).rgb;
+    color += texture(image, texCoords + vec2( o.x * 2.0, 0.0)).rgb;
+    color += texture(image, texCoords + vec2(0.0, -o.y * 2.0)).rgb;
+    color += texture(image, texCoords + vec2(0.0,  o.y * 2.0)).rgb;
+    color += texture(image, texCoords + vec2(-o.x,  o.y)).rgb * 2.0;
+    color += texture(image, texCoords + vec2( o.x,  o.y)).rgb * 2.0;
+    color += texture(image, texCoords + vec2(-o.x, -o.y)).rgb * 2.0;
+    color += texture(image, texCoords + vec2( o.x, -o.y)).rgb * 2.0;
+
+    FragColor = vec4(color / 12.0, 1.0);
+}
+```
+
+* \[ ] **Step 4: Write `bloom_composite.frag.glsl`** (bloom-only composite path)
+
+```glsl
+#version 330 core
+
+in  vec2 texCoords;
+out vec4 FragColor;
+
+uniform sampler2D scene;
+uniform sampler2D bloomTex;
+uniform float     intensity;
+
+void main() {
+    vec3 color = texture(scene,    texCoords).rgb;
+    vec3 bloom = texture(bloomTex, texCoords).rgb;
+    FragColor  = vec4(color + bloom * intensity, 1.0);
+}
+```
+
+* \[ ] **Step 5: Commit**
+
+```
+git add assets/shaders/glsl/bloom_extract.frag.glsl \
+        assets/shaders/glsl/bloom_down.frag.glsl \
+        assets/shaders/glsl/bloom_up.frag.glsl \
+        assets/shaders/glsl/bloom_composite.frag.glsl
+git commit -m "feat: add bloom GLSL shaders (extract, down, up, composite)"
+```
+
+***
+
+## Task 2: Extend FXAA for bloom composite
+
+**Files:**
+
+* Modify: `assets/shaders/glsl/fxaa.frag.glsl`
+* Modify: `sponge/src/platform/opengl/scene/fxaa.hpp`
+* Modify: `sponge/src/platform/opengl/scene/fxaa.cpp`
+
+**Interfaces:**
+
+* Produces: `FXAA::applyWithBloom(uint32_t sceneTexId, uint32_t bloomTexId, float intensity) const`
+
+* Consumed by: `MazeLayer::onRender()` in Task 4.
+
+* \[ ] **Step 1: Add bloom uniforms to `fxaa.frag.glsl`**
+
+Replace the existing `void main()` block (keep everything above it unchanged):
+
+```glsl
+uniform sampler2D bloomTex;
+uniform float     bloomIntensity;
+
+void main() {
+    fragColor = fxaaPass(fragTexCoords);
+    if (bloomIntensity > 0.0) {
+        fragColor.rgb += texture(bloomTex, fragTexCoords).rgb * bloomIntensity;
+    }
+}
+```
+
+* \[ ] **Step 2: Add `applyWithBloom` declaration to `fxaa.hpp`**
+
+Inside the `class FXAA` public section, after the existing `apply() const;` line:
+
+```cpp
+void applyWithBloom(uint32_t sceneTexId, uint32_t bloomTexId,
+                    float intensity) const;
+```
+
+* \[ ] **Step 3: Implement `applyWithBloom` in `fxaa.cpp`**
+
+Add after the existing `FXAA::apply()` definition:
+
+```cpp
+void FXAA::applyWithBloom(const uint32_t sceneTexId,
+                          const uint32_t bloomTexId,
+                          const float    intensity) const {
+    glDisable(GL_DEPTH_TEST);
+
+    shader->bind();
+    shader->setFloat2("rcpFrame", glm::vec2(1.0f / static_cast<float>(width),
+                                            1.0f / static_cast<float>(height)));
+    shader->setInteger("screenTexture", 0);
+    shader->setInteger("bloomTex",      1);
+    shader->setFloat("bloomIntensity",  intensity);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, sceneTexId);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, bloomTexId);
+
+    vao->bind();
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
+    vao->unbind();
+
+    glActiveTexture(GL_TEXTURE0);
+    shader->unbind();
+
+    glEnable(GL_DEPTH_TEST);
+}
+```
+
+Also add `shader->setFloat("bloomIntensity", 0.0f);` in the existing `FXAA::initialize()` after `shader->setInteger("screenTexture", 0);` so the uniform is initialized to zero (no bloom) on first use.
+
+* \[ ] **Step 4: Build and verify no compile errors**
+
+```
+cmake --build build --target game --config Release 2>&1 | tail -20
+```
+
+Expected: no errors mentioning fxaa.
+
+* \[ ] **Step 5: Commit**
+
+```
+git add assets/shaders/glsl/fxaa.frag.glsl \
+        sponge/src/platform/opengl/scene/fxaa.hpp \
+        sponge/src/platform/opengl/scene/fxaa.cpp
+git commit -m "feat: extend FXAA with applyWithBloom() for bloom composite pass"
+```
+
+***
+
+## Task 3: Bloom class
+
+**Files:**
+
+* Create: `sponge/src/platform/opengl/scene/bloom.hpp`
+* Create: `sponge/src/platform/opengl/scene/bloom.cpp`
+* Modify: `sponge/src/sponge.hpp`
+
+**Interfaces:**
+
+* Produces:
+  * `Bloom(uint32_t width, uint32_t height)`
+  * `void begin() const` — bind scene FBO
+  * `void end() const` — unbind
+  * `void process() const` — extract → 5× down → 5× up
+  * `void apply() const` — composite to default FB (bloom-only path)
+  * `uint32_t getSceneTexture() const`
+  * `uint32_t getBloomTexture() const` — returns `upTextures[0]`
+  * `void resize(uint32_t w, uint32_t h)`
+  * `bool isEnabled() const` / `void setEnabled(bool)`
+  * `float getThreshold() const` / `void setThreshold(float)`
+  * `float getIntensity() const` / `void setIntensity(float)`
+
+* Consumed by: `MazeLayer` in Task 4.
+
+* \[ ] **Step 1: Write `bloom.hpp`**
+
+```cpp
+#pragma once
+
+#include "platform/opengl/renderer/shader.hpp"
+#include "platform/opengl/renderer/vertexarray.hpp"
+#include "platform/opengl/renderer/vertexbuffer.hpp"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace sponge::platform::opengl::scene {
+
+class Bloom {
+public:
+    Bloom() = delete;
+    Bloom(uint32_t width, uint32_t height);
+    ~Bloom();
+
+    Bloom(const Bloom&)            = delete;
+    Bloom& operator=(const Bloom&) = delete;
+
+    void begin() const;
+    void end() const;
+    void process() const;
+    void apply() const;
+
+    uint32_t getSceneTexture() const {
+        return sceneColorTexture;
+    }
+
+    uint32_t getBloomTexture() const {
+        return upTextures[0];
+    }
+
+    void resize(uint32_t newWidth, uint32_t newHeight);
+
+    bool isEnabled() const {
+        return enabled;
+    }
+
+    void setEnabled(bool val) {
+        enabled = val;
+    }
+
+    float getThreshold() const {
+        return threshold;
+    }
+
+    void setThreshold(float val) {
+        threshold = val;
+    }
+
+    float getIntensity() const {
+        return intensity;
+    }
+
+    void setIntensity(float val) {
+        intensity = val;
+    }
+
+private:
+    static constexpr std::string_view extractShaderName   = "bloom_extract";
+    static constexpr std::string_view downShaderName      = "bloom_down";
+    static constexpr std::string_view upShaderName        = "bloom_up";
+    static constexpr std::string_view compositeShaderName = "bloom_composite";
+    static constexpr int              numLevels           = 5;
+
+    std::shared_ptr<renderer::Shader>       extractShader;
+    std::shared_ptr<renderer::Shader>       downShader;
+    std::shared_ptr<renderer::Shader>       upShader;
+    std::shared_ptr<renderer::Shader>       compositeShader;
+    std::unique_ptr<renderer::VertexArray>  vao;
+    std::unique_ptr<renderer::VertexBuffer> vbo;
+
+    uint32_t sceneFbo          = 0;
+    uint32_t sceneColorTexture = 0;
+    uint32_t sceneDepthRbo     = 0;
+
+    std::array<uint32_t, numLevels> downFbos{};
+    std::array<uint32_t, numLevels> downTextures{};
+    std::array<uint32_t, numLevels> upFbos{};
+    std::array<uint32_t, numLevels> upTextures{};
+
+    uint32_t width     = 0;
+    uint32_t height    = 0;
+    bool     enabled   = true;
+    float    threshold = 0.8F;
+    float    intensity = 1.0F;
+
+    void initialize();
+    void createFramebuffers();
+    void destroyFramebuffers();
+    void renderQuad() const;
+};
+
+}  // namespace sponge::platform::opengl::scene
+```
+
+* \[ ] **Step 2: Write `bloom.cpp`**
+
+```cpp
+#include "platform/opengl/scene/bloom.hpp"
+
+#include "logging/log.hpp"
+#include "platform/opengl/renderer/assetmanager.hpp"
+#include "platform/opengl/renderer/gl.hpp"
+
+#include <array>
+
+namespace {
+constexpr std::array quadVertices = {
+    -1.F, -1.F, 0.F, 0.F,
+     1.F, -1.F, 1.F, 0.F,
+    -1.F,  1.F, 0.F, 1.F,
+     1.F,  1.F, 1.F, 1.F,
+};
+constexpr uint32_t quadVertexCount = 4;
+constexpr uint32_t quadStride      = 4 * sizeof(float);
+}  // namespace
+
+namespace sponge::platform::opengl::scene {
+using renderer::AssetManager;
+
+Bloom::Bloom(const uint32_t width, const uint32_t height) :
+    width(width), height(height) {
+    initialize();
+}
+
+Bloom::~Bloom() {
+    destroyFramebuffers();
+}
+
+void Bloom::initialize() {
+    auto makeShader = [](std::string_view name, const char* frag) {
+        return AssetManager::createShader(renderer::ShaderCreateInfo{
+            .name               = std::string(name),
+            .vertexShaderPath   = "/shaders/glsl/blur.vert.glsl",
+            .fragmentShaderPath = frag,
+        });
+    };
+
+    extractShader   = makeShader(extractShaderName,
+                                 "/shaders/glsl/bloom_extract.frag.glsl");
+    downShader      = makeShader(downShaderName,
+                                 "/shaders/glsl/bloom_down.frag.glsl");
+    upShader        = makeShader(upShaderName,
+                                 "/shaders/glsl/bloom_up.frag.glsl");
+    compositeShader = makeShader(compositeShaderName,
+                                 "/shaders/glsl/bloom_composite.frag.glsl");
+
+    vao = renderer::VertexArray::create();
+    vao->bind();
+    vbo = std::make_unique<renderer::VertexBuffer>(quadVertices.data(),
+                                                   sizeof(quadVertices));
+    vbo->bind();
+
+    // blur.vert.glsl uses layout(location=0) aPos, layout(location=1) aTexCoord
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, quadStride,
+                          reinterpret_cast<const void*>(0));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, quadStride,
+                          reinterpret_cast<const void*>(2 * sizeof(float)));
+
+    vao->unbind();
+
+    createFramebuffers();
+}
+
+void Bloom::createFramebuffers() {
+    // Scene capture FBO at full resolution
+    glGenTextures(1, &sceneColorTexture);
+    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, static_cast<GLsizei>(width),
+                 static_cast<GLsizei>(height), 0, GL_RGB, GL_UNSIGNED_BYTE,
+                 nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    glGenRenderbuffers(1, &sceneDepthRbo);
+    glBindRenderbuffer(GL_RENDERBUFFER, sceneDepthRbo);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24,
+                          static_cast<GLsizei>(width),
+                          static_cast<GLsizei>(height));
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+    glGenFramebuffers(1, &sceneFbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                           GL_TEXTURE_2D, sceneColorTexture, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                              GL_RENDERBUFFER, sceneDepthRbo);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        SPONGE_GL_CRITICAL("Bloom scene framebuffer is not complete!");
+    }
+
+    // Mip-chain FBOs: level i at (width >> (i+1)) x (height >> (i+1))
+    glGenFramebuffers(numLevels, downFbos.data());
+    glGenTextures(numLevels, downTextures.data());
+    glGenFramebuffers(numLevels, upFbos.data());
+    glGenTextures(numLevels, upTextures.data());
+
+    auto makeMipTex = [](uint32_t tex, GLsizei w, GLsizei h) {
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB,
+                     GL_UNSIGNED_BYTE, nullptr);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glBindTexture(GL_TEXTURE_2D, 0);
+    };
+
+    for (int i = 0; i < numLevels; i++) {
+        const auto w = static_cast<GLsizei>(width  >> (i + 1));
+        const auto h = static_cast<GLsizei>(height >> (i + 1));
+
+        makeMipTex(downTextures[i], w, h);
+        glBindFramebuffer(GL_FRAMEBUFFER, downFbos[i]);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                               GL_TEXTURE_2D, downTextures[i], 0);
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+            SPONGE_GL_CRITICAL("Bloom down framebuffer {} is not complete!", i);
+        }
+
+        makeMipTex(upTextures[i], w, h);
+        glBindFramebuffer(GL_FRAMEBUFFER, upFbos[i]);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                               GL_TEXTURE_2D, upTextures[i], 0);
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+            SPONGE_GL_CRITICAL("Bloom up framebuffer {} is not complete!", i);
+        }
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void Bloom::destroyFramebuffers() {
+    if (sceneFbo != 0) {
+        glDeleteFramebuffers(1, &sceneFbo);
+        sceneFbo = 0;
+    }
+    if (sceneColorTexture != 0) {
+        glDeleteTextures(1, &sceneColorTexture);
+        sceneColorTexture = 0;
+    }
+    if (sceneDepthRbo != 0) {
+        glDeleteRenderbuffers(1, &sceneDepthRbo);
+        sceneDepthRbo = 0;
+    }
+    glDeleteFramebuffers(numLevels, downFbos.data());
+    glDeleteTextures(numLevels, downTextures.data());
+    glDeleteFramebuffers(numLevels, upFbos.data());
+    glDeleteTextures(numLevels, upTextures.data());
+    downFbos.fill(0);
+    downTextures.fill(0);
+    upFbos.fill(0);
+    upTextures.fill(0);
+}
+
+void Bloom::begin() const {
+    glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
+}
+
+void Bloom::end() const {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void Bloom::renderQuad() const {
+    vao->bind();
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
+    vao->unbind();
+}
+
+void Bloom::process() const {
+    glDisable(GL_DEPTH_TEST);
+    glActiveTexture(GL_TEXTURE0);
+
+    // Extract bright pixels → down[0] at (w/2, h/2)
+    glBindFramebuffer(GL_FRAMEBUFFER, downFbos[0]);
+    glViewport(0, 0, static_cast<GLsizei>(width  >> 1),
+                     static_cast<GLsizei>(height >> 1));
+    extractShader->bind();
+    extractShader->setInteger("scene", 0);
+    extractShader->setFloat("threshold", threshold);
+    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
+    renderQuad();
+    extractShader->unbind();
+
+    // Downsample: down[i-1] → down[i]
+    downShader->bind();
+    downShader->setInteger("image", 0);
+    downShader->setFloat("offset", 1.0F);
+    for (int i = 1; i < numLevels; i++) {
+        glBindFramebuffer(GL_FRAMEBUFFER, downFbos[i]);
+        glViewport(0, 0, static_cast<GLsizei>(width  >> (i + 1)),
+                         static_cast<GLsizei>(height >> (i + 1)));
+        glBindTexture(GL_TEXTURE_2D, downTextures[i - 1]);
+        renderQuad();
+    }
+    downShader->unbind();
+
+    // Upsample: from deepest down level back up to up[0]
+    upShader->bind();
+    upShader->setInteger("image", 0);
+    upShader->setFloat("offset", 1.0F);
+    for (int i = numLevels - 1; i >= 0; i--) {
+        glBindFramebuffer(GL_FRAMEBUFFER, upFbos[i]);
+        glViewport(0, 0, static_cast<GLsizei>(width  >> (i + 1)),
+                         static_cast<GLsizei>(height >> (i + 1)));
+        const uint32_t src =
+            (i == numLevels - 1) ? downTextures[i] : upTextures[i + 1];
+        glBindTexture(GL_TEXTURE_2D, src);
+        renderQuad();
+    }
+    upShader->unbind();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glEnable(GL_DEPTH_TEST);
+}
+
+void Bloom::apply() const {
+    glDisable(GL_DEPTH_TEST);
+
+    compositeShader->bind();
+    compositeShader->setInteger("scene",    0);
+    compositeShader->setInteger("bloomTex", 1);
+    compositeShader->setFloat("intensity",  intensity);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, upTextures[0]);
+
+    renderQuad();
+    compositeShader->unbind();
+
+    glActiveTexture(GL_TEXTURE0);
+    glEnable(GL_DEPTH_TEST);
+}
+
+void Bloom::resize(const uint32_t newWidth, const uint32_t newHeight) {
+    if (width == newWidth && height == newHeight) {
+        return;
+    }
+    width  = newWidth;
+    height = newHeight;
+    destroyFramebuffers();
+    createFramebuffers();
+}
+
+}  // namespace sponge::platform::opengl::scene
+```
+
+* \[ ] **Step 3: Register `bloom.hpp` in `sponge.hpp`**
+
+Add after the `fxaa.hpp` include line:
+
+```cpp
+#include "platform/opengl/scene/bloom.hpp"
+```
+
+* \[ ] **Step 4: Build**
+
+```
+cmake --build build --target game --config Release 2>&1 | tail -20
+```
+
+Expected: no errors mentioning bloom.
+
+* \[ ] **Step 5: Commit**
+
+```
+git add sponge/src/platform/opengl/scene/bloom.hpp \
+        sponge/src/platform/opengl/scene/bloom.cpp \
+        sponge/src/sponge.hpp
+git commit -m "feat: add Bloom post-processing class (Dual Kawase, 5-level mip chain)"
+```
+
+***
+
+## Task 4: Wire Bloom into MazeRenderFrame and MazeLayer
+
+**Files:**
+
+* Modify: `game/src/thread/mazeframe.hpp`
+* Modify: `game/src/layer/mazelayer.hpp`
+* Modify: `game/src/layer/mazelayer.cpp`
+
+**Interfaces:**
+
+* Consumes: `Bloom` (Task 3), `FXAA::applyWithBloom` (Task 2).
+
+* Produces: `MazeLayer::isBloomEnabled()`, `setBloomEnabled(bool)`, `getBloomThreshold()`, `setBloomThreshold(float)`, `getBloomIntensity()`, `setBloomIntensity(float)` — consumed by Task 5.
+
+* \[ ] **Step 1: Extend `MazeRenderFrame` with bloom fields**
+
+In `game/src/thread/mazeframe.hpp`, inside `struct MazeRenderFrame`, after `bool fxaaEnabled{ false };`:
+
+```cpp
+bool  bloomEnabled{ false };
+float bloomThreshold{ 0.8F };
+float bloomIntensity{ 1.0F };
+```
+
+* \[ ] **Step 2: Add `bloom` member and fields to `mazelayer.hpp`**
+
+In the private section, after `std::unique_ptr<sponge::platform::opengl::scene::FXAA> fxaa;`:
+
+```cpp
+std::unique_ptr<sponge::platform::opengl::scene::Bloom> bloom;
+```
+
+After `bool fxaaEnabled = true;`:
+
+```cpp
+bool  bloomEnabled    = true;
+float bloomThreshold  = 0.8F;
+float bloomIntensity  = 1.0F;
+```
+
+In the public section, after the `isFxaaEnabled` / `setFxaaEnabled` declarations:
+
+```cpp
+bool  isBloomEnabled() const;
+void  setBloomEnabled(bool val);
+float getBloomThreshold() const;
+void  setBloomThreshold(float val);
+float getBloomIntensity() const;
+void  setBloomIntensity(float val);
+```
+
+* \[ ] **Step 3: Implement bloom accessors in `mazelayer.cpp`**
+
+Add at the end of the file, after the `setFxaaEnabled` definition:
+
+```cpp
+bool MazeLayer::isBloomEnabled() const {
+    return bloomEnabled;
+}
+
+void MazeLayer::setBloomEnabled(const bool val) {
+    bloomEnabled = val;
+    if (bloom) {
+        bloom->setEnabled(val);
+    }
+}
+
+float MazeLayer::getBloomThreshold() const {
+    return bloomThreshold;
+}
+
+void MazeLayer::setBloomThreshold(const float val) {
+    bloomThreshold = val;
+    if (bloom) {
+        bloom->setThreshold(val);
+    }
+}
+
+float MazeLayer::getBloomIntensity() const {
+    return bloomIntensity;
+}
+
+void MazeLayer::setBloomIntensity(const float val) {
+    bloomIntensity = val;
+    if (bloom) {
+        bloom->setIntensity(val);
+    }
+}
+```
+
+* \[ ] **Step 4: Add `using` alias and construct `bloom` in `onAttach`**
+
+In `mazelayer.cpp`, in the `using` block near the top of the namespace (after `using sponge::platform::opengl::scene::FXAA;`):
+
+```cpp
+using sponge::platform::opengl::scene::Bloom;
+```
+
+In `onAttach()`, after the line that constructs `fxaa`:
+
+```cpp
+bloom = std::make_unique<Bloom>(Maze::get().getWindow()->getWidth(),
+                                Maze::get().getWindow()->getHeight());
+bloom->setEnabled(bloomEnabled);
+bloom->setThreshold(bloomThreshold);
+bloom->setIntensity(bloomIntensity);
+```
+
+* \[ ] **Step 5: Capture bloom state in `captureRenderFrame`**
+
+In `captureRenderFrame()`, after `frame.fxaaEnabled = fxaaEnabled;`:
+
+```cpp
+frame.bloomEnabled   = bloomEnabled;
+frame.bloomThreshold = bloomThreshold;
+frame.bloomIntensity = bloomIntensity;
+```
+
+* \[ ] **Step 6: Resize bloom in the pending resize block in `onRender`**
+
+In the `if (pendingResize...)` block, after `if (fxaa) { fxaa->resize(w, h); }`:
+
+```cpp
+if (bloom) {
+    bloom->resize(w, h);
+}
+```
+
+* \[ ] **Step 7: Wire bloom into the render loop**
+
+Replace the existing bloom/fxaa section in `onRender()`:
+
+```cpp
+if (frame.shadowEnabled && frame.shadowCastShadow) {
+    renderSceneToDepthMap(frame);
+}
+
+if (frame.bloomEnabled && bloom) {
+    bloom->begin();
+} else if (frame.fxaaEnabled && fxaa) {
+    fxaa->begin();
+}
+
+renderGameObjects(frame);
+renderLightCubes(frame);
+
+if (frame.bloomEnabled && bloom) {
+    bloom->end();
+    bloom->process();
+    if (frame.fxaaEnabled && fxaa) {
+        fxaa->applyWithBloom(bloom->getSceneTexture(),
+                             bloom->getBloomTexture(),
+                             frame.bloomIntensity);
+    } else {
+        bloom->apply();
+    }
+} else if (frame.fxaaEnabled && fxaa) {
+    fxaa->end();
+    fxaa->apply();
+}
+```
+
+* \[ ] **Step 8: Build**
+
+```
+cmake --build build --target game --config Release 2>&1 | tail -20
+```
+
+Expected: clean build.
+
+* \[ ] **Step 9: Commit**
+
+```
+git add game/src/thread/mazeframe.hpp \
+        game/src/layer/mazelayer.hpp \
+        game/src/layer/mazelayer.cpp
+git commit -m "feat: wire Bloom into MazeLayer render loop with bloom+FXAA chaining"
+```
+
+***
+
+## Task 5: Settings, Maze proxy, and OptionLayer UI
+
+**Files:**
+
+* Modify: `game/src/maze.hpp`
+* Modify: `game/src/maze.cpp`
+* Modify: `game/src/layer/optionlayer.hpp`
+* Modify: `game/src/layer/optionlayer.cpp`
+
+**Interfaces:**
+
+* Consumes: `MazeLayer::isBloomEnabled()`, `setBloomEnabled()`, `getBloomThreshold()`, `setBloomThreshold()`, `getBloomIntensity()`, `setBloomIntensity()` (Task 4).
+
+Bloom threshold presets: `Low = 0.6F`, `Medium = 0.8F`, `High = 0.95F`.
+Bloom intensity presets: `Low = 0.5F`, `Normal = 1.0F`, `High = 2.0F`, `Extra = 3.0F`.
+
+* \[ ] **Step 1: Add bloom proxy methods to `maze.hpp`**
+
+After `void setFxaaEnabled(bool val) { ... }`:
+
+```cpp
+bool isBloomEnabled() const {
+    return mazeLayer->isBloomEnabled();
+}
+
+void setBloomEnabled(bool val) {
+    mazeLayer->setBloomEnabled(val);
+}
+
+float getBloomThreshold() const {
+    return mazeLayer->getBloomThreshold();
+}
+
+void setBloomThreshold(float val) {
+    mazeLayer->setBloomThreshold(val);
+}
+
+float getBloomIntensity() const {
+    return mazeLayer->getBloomIntensity();
+}
+
+void setBloomIntensity(float val) {
+    mazeLayer->setBloomIntensity(val);
+}
+```
+
+* \[ ] **Step 2: Load bloom settings in `maze.cpp`**
+
+`Settings` has no `getFloat` — threshold and intensity are stored as strings and parsed at load time. Add `#include <string>` if not already present (it is via transitive includes).
+
+After the line `setFxaaEnabled(sponge::core::Settings::getBool("video.fxaa", true));`:
+
+```cpp
+setBloomEnabled(sponge::core::Settings::getBool("video.bloomEnabled", true));
+setBloomThreshold(std::stof(
+    sponge::core::Settings::getString("video.bloomThreshold", "0.8")));
+setBloomIntensity(std::stof(
+    sponge::core::Settings::getString("video.bloomIntensity", "1.0")));
+```
+
+* \[ ] **Step 3: Add bloom state to `optionlayer.hpp`**
+
+Add to `OptionMenuItem` enum after `ShadowQuality`, before `Return`:
+
+```cpp
+BloomEnabled,
+BloomThreshold,
+BloomIntensity,
+```
+
+Add to private members after `bool pendingFxaa = false;`:
+
+```cpp
+bool  pendingBloomEnabled   = true;
+int   pendingBloomThreshold = 1;   // index into bloomThresholds[]
+int   pendingBloomIntensity = 1;   // index into bloomIntensities[]
+```
+
+Add widget members after `std::unique_ptr<ui::Checkbox> antiAliasingCheckbox;`:
+
+```cpp
+std::unique_ptr<ui::Checkbox>   bloomEnabledCheckbox;
+std::unique_ptr<ui::SelectList> bloomThresholdList;
+std::unique_ptr<ui::SelectList> bloomIntensityList;
+```
+
+* \[ ] **Step 4: Add Yoga nodes as file-scope globals in `optionlayer.cpp`**
+
+In the anonymous namespace near the other `YGNodeRef` declarations:
+
+```cpp
+YGNodeRef bloomEnabledNode   = nullptr;
+YGNodeRef bloomThresholdNode = nullptr;
+YGNodeRef bloomIntensityNode = nullptr;
+```
+
+Add preset arrays in the anonymous namespace:
+
+```cpp
+constexpr std::array<float, 3> bloomThresholds  = { 0.6F, 0.8F, 0.95F };
+constexpr std::array<float, 4> bloomIntensities = { 0.5F, 1.0F, 2.0F, 3.0F };
+```
+
+* \[ ] **Step 5: Add `saveVideoSettings` bloom params**
+
+Change the `saveVideoSettings` signature and body:
+
+```cpp
+void saveVideoSettings(const uint32_t width, const uint32_t height,
+                       const bool fullscreen, const bool vsync, const bool fxaa,
+                       const uint32_t shadowRes,
+                       const bool bloomEnabled, const float bloomThreshold,
+                       const float bloomIntensity) {
+    using sponge::core::Settings;
+    Settings::set("video.width",         width);
+    Settings::set("video.height",        height);
+    Settings::set("video.fullscreen",    fullscreen);
+    Settings::set("video.vsync",         vsync);
+    Settings::set("video.fxaa",          fxaa);
+    Settings::set("video.shadowRes",     shadowRes);
+    Settings::set("video.bloomEnabled",   bloomEnabled);
+    Settings::set("video.bloomThreshold", std::to_string(bloomThreshold));
+    Settings::set("video.bloomIntensity", std::to_string(bloomIntensity));
+    Settings::save();
+}
+```
+
+* \[ ] **Step 6: Create bloom Yoga nodes and widgets in `onAttach()`**
+
+After the line `returnNode = makeMenuNode(menuBackgroundNode, 6);`, change the return node index and add the bloom nodes:
+
+```cpp
+bloomEnabledNode   = makeMenuNode(menuBackgroundNode, 6);
+bloomThresholdNode = makeMenuNode(menuBackgroundNode, 7);
+bloomIntensityNode = makeMenuNode(menuBackgroundNode, 8);
+returnNode         = makeMenuNode(menuBackgroundNode, 9);
+```
+
+After `verticalSyncCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);`, add:
+
+```cpp
+bloomEnabledCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
+bloomThresholdList   = std::make_unique<ui::SelectList>(selectCreateInfo);
+bloomIntensityList   = std::make_unique<ui::SelectList>(selectCreateInfo);
+
+bloomThresholdList->setItems({ "Low", "Medium", "High" });
+bloomIntensityList->setItems({ "Low", "Normal", "High", "Extra" });
+```
+
+* \[ ] **Step 7: Sync bloom state in `syncPendingCheckboxState()`**
+
+After `pendingFxaa = Maze::get().isFxaaEnabled();`:
+
+```cpp
+pendingBloomEnabled = Maze::get().isBloomEnabled();
+
+const float curThreshold = Maze::get().getBloomThreshold();
+const auto  tIt = std::ranges::find(bloomThresholds, curThreshold);
+pendingBloomThreshold =
+    tIt != bloomThresholds.end() ?
+        static_cast<int>(tIt - bloomThresholds.begin()) : 1;
+if (bloomThresholdList) {
+    bloomThresholdList->setSelectedIndex(
+        static_cast<size_t>(pendingBloomThreshold));
+}
+
+const float curIntensity = Maze::get().getBloomIntensity();
+const auto  iIt = std::ranges::find(bloomIntensities, curIntensity);
+pendingBloomIntensity =
+    iIt != bloomIntensities.end() ?
+        static_cast<int>(iIt - bloomIntensities.begin()) : 1;
+if (bloomIntensityList) {
+    bloomIntensityList->setSelectedIndex(
+        static_cast<size_t>(pendingBloomIntensity));
+}
+```
+
+* \[ ] **Step 8: Add bloom to `updateChangeStatus()`**
+
+Extend `checkboxChanged` to include bloom:
+
+```cpp
+const bool checkboxChanged =
+    pendingFullscreen != Maze::get().isFullscreen() ||
+    pendingVsync      != Maze::get().hasVerticalSync() ||
+    pendingFxaa       != Maze::get().isFxaaEnabled()   ||
+    pendingBloomEnabled != Maze::get().isBloomEnabled();
+```
+
+Add a bloom-specific list change check alongside the shadow resolution check. Find where `hasUnappliedChanges` is set and add:
+
+```cpp
+const bool bloomThresholdChanged =
+    bloomThresholds[static_cast<size_t>(pendingBloomThreshold)] !=
+    Maze::get().getBloomThreshold();
+const bool bloomIntensityChanged =
+    bloomIntensities[static_cast<size_t>(pendingBloomIntensity)] !=
+    Maze::get().getBloomIntensity();
+hasUnappliedChanges = checkboxChanged || shadowResChanged ||
+                      bloomThresholdChanged || bloomIntensityChanged;
+```
+
+(Match the exact pattern used for `shadowResChanged` in the existing code.)
+
+* \[ ] **Step 9: Apply bloom in `applyChanges()`**
+
+After `Maze::get().setFxaaEnabled(pendingFxaa);`:
+
+```cpp
+Maze::get().setBloomEnabled(pendingBloomEnabled);
+Maze::get().setBloomThreshold(
+    bloomThresholds[static_cast<size_t>(pendingBloomThreshold)]);
+Maze::get().setBloomIntensity(
+    bloomIntensities[static_cast<size_t>(pendingBloomIntensity)]);
+```
+
+Update the `saveVideoSettings` call to pass the new arguments:
+
+```cpp
+saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
+                  pendingFxaa, shadowRes,
+                  pendingBloomEnabled,
+                  bloomThresholds[static_cast<size_t>(pendingBloomThreshold)],
+                  bloomIntensities[static_cast<size_t>(pendingBloomIntensity)]);
+```
+
+* \[ ] **Step 10: Render bloom rows in `onUpdate()`**
+
+After the layout unpacking block (where `sqX, sqY, sqW, sqH` and `retX, retY, retW, retH` are declared), add:
+
+```cpp
+const auto [beX, beY, beW, beH] =
+    getNodeLayout(bloomEnabledNode, menuBgX, menuBgY);
+const auto [btX, btY, btW, btH] =
+    getNodeLayout(bloomThresholdNode, menuBgX, menuBgY);
+const auto [biX, biY, biW, biH] =
+    getNodeLayout(bloomIntensityNode, menuBgX, menuBgY);
+```
+
+After the `shadowQualityList->onUpdate(...)` block:
+
+```cpp
+renderRowBackground(beX, beY, beW, beH, OptionMenuItem::BloomEnabled);
+renderRowLabel(beX, beY, beH, "Bloom");
+bloomEnabledCheckbox->onUpdate(beX, beY, beW, beH, pendingBloomEnabled);
+
+renderRowBackground(btX, btY, btW, btH, OptionMenuItem::BloomThreshold);
+bloomThresholdList->onUpdate(btX, btY, btW, btH, "Bloom Threshold");
+renderDots(bloomThresholds.size(),
+           bloomThresholdList->getValueCenterX(btX, btW), btY, btH,
+           static_cast<size_t>(pendingBloomThreshold), std::nullopt);
+
+renderRowBackground(biX, biY, biW, biH, OptionMenuItem::BloomIntensity);
+bloomIntensityList->onUpdate(biX, biY, biW, biH, "Bloom Intensity");
+renderDots(bloomIntensities.size(),
+           bloomIntensityList->getValueCenterX(biX, biW), biY, biH,
+           static_cast<size_t>(pendingBloomIntensity), std::nullopt);
+```
+
+* \[ ] **Step 11: Handle keyboard input for bloom in `onUpdate()`**
+
+In the `MenuLeft` handler, after the `ShadowQuality` branch:
+
+```cpp
+} else if (selectedItem == OptionMenuItem::BloomThreshold) {
+    bloomThresholdList->selectPrev();
+    pendingBloomThreshold =
+        static_cast<int>(bloomThresholdList->getSelectedIndex());
+    updateChangeStatus();
+} else if (selectedItem == OptionMenuItem::BloomIntensity) {
+    bloomIntensityList->selectPrev();
+    pendingBloomIntensity =
+        static_cast<int>(bloomIntensityList->getSelectedIndex());
+    updateChangeStatus();
+}
+```
+
+In the `MenuRight` handler, after the `ShadowQuality` branch:
+
+```cpp
+} else if (selectedItem == OptionMenuItem::BloomThreshold) {
+    bloomThresholdList->selectNext();
+    pendingBloomThreshold =
+        static_cast<int>(bloomThresholdList->getSelectedIndex());
+    updateChangeStatus();
+} else if (selectedItem == OptionMenuItem::BloomIntensity) {
+    bloomIntensityList->selectNext();
+    pendingBloomIntensity =
+        static_cast<int>(bloomIntensityList->getSelectedIndex());
+    updateChangeStatus();
+}
+```
+
+In the `MenuConfirm` handler, after the `AntiAliasing` branch:
+
+```cpp
+} else if (selectedItem == OptionMenuItem::BloomEnabled) {
+    pendingBloomEnabled = !pendingBloomEnabled;
+    updateChangeStatus();
+}
+```
+
+* \[ ] **Step 12: Handle mouse clicks for bloom in `onMouseButtonPressed()`**
+
+After the shadow quality click block:
+
+```cpp
+const auto [beX2, beY2, beW2, beH2] = getNodeLayout(
+    bloomEnabledNode, menuBackgroundNodeX, menuBackgroundNodeY);
+
+if (mouseX >= beX2 && mouseX <= beX2 + beW2 &&
+    mouseY >= beY2 && mouseY <= beY2 + beH2) {
+    selectedItem = OptionMenuItem::BloomEnabled;
+    if (bloomEnabledCheckbox->isInside(mouseX, mouseY,
+                                        beX2, beY2, beW2, beH2)) {
+        pendingBloomEnabled = !pendingBloomEnabled;
+        updateChangeStatus();
+    }
+    return true;
+}
+
+const auto [btX2, btY2, btW2, btH2] = getNodeLayout(
+    bloomThresholdNode, menuBackgroundNodeX, menuBackgroundNodeY);
+
+if (mouseX >= btX2 && mouseX <= btX2 + btW2 &&
+    mouseY >= btY2 && mouseY <= btY2 + btH2) {
+    selectedItem = OptionMenuItem::BloomThreshold;
+    if (bloomThresholdList->isInsideLeft(mouseX, btX2, btW2)) {
+        bloomThresholdList->selectPrev();
+        pendingBloomThreshold =
+            static_cast<int>(bloomThresholdList->getSelectedIndex());
+        updateChangeStatus();
+    } else if (bloomThresholdList->isInsideRight(mouseX, btX2, btW2)) {
+        bloomThresholdList->selectNext();
+        pendingBloomThreshold =
+            static_cast<int>(bloomThresholdList->getSelectedIndex());
+        updateChangeStatus();
+    }
+    return true;
+}
+
+const auto [biX2, biY2, biW2, biH2] = getNodeLayout(
+    bloomIntensityNode, menuBackgroundNodeX, menuBackgroundNodeY);
+
+if (mouseX >= biX2 && mouseX <= biX2 + biW2 &&
+    mouseY >= biY2 && mouseY <= biY2 + biH2) {
+    selectedItem = OptionMenuItem::BloomIntensity;
+    if (bloomIntensityList->isInsideLeft(mouseX, biX2, biW2)) {
+        bloomIntensityList->selectPrev();
+        pendingBloomIntensity =
+            static_cast<int>(bloomIntensityList->getSelectedIndex());
+        updateChangeStatus();
+    } else if (bloomIntensityList->isInsideRight(mouseX, biX2, biW2)) {
+        bloomIntensityList->selectNext();
+        pendingBloomIntensity =
+            static_cast<int>(bloomIntensityList->getSelectedIndex());
+        updateChangeStatus();
+    }
+    return true;
+}
+```
+
+* \[ ] **Step 13: Handle mouse hover for bloom in `onMouseMoved()`**
+
+After `} else if (isOver(shadowQualityNode)) {`, add:
+
+```cpp
+} else if (isOver(bloomEnabledNode)) {
+    hoveredItem = OptionMenuItem::BloomEnabled;
+} else if (isOver(bloomThresholdNode)) {
+    hoveredItem = OptionMenuItem::BloomThreshold;
+} else if (isOver(bloomIntensityNode)) {
+    hoveredItem = OptionMenuItem::BloomIntensity;
+```
+
+* \[ ] **Step 14: Resize bloom widgets in `onWindowResize()`**
+
+After `shadowQualityList->setFontSize(fontSize);`, add:
+
+```cpp
+bloomThresholdList->setFontSize(fontSize);
+bloomIntensityList->setFontSize(fontSize);
+
+const auto checkboxSize2 = static_cast<float>(fontSize);
+bloomEnabledCheckbox->setSize(checkboxSize2);
+```
+
+After `shadowQualityList->setMaxValueWidth(maxCycleValueWidth);`, add:
+
+```cpp
+bloomThresholdList->setMaxValueWidth(maxCycleValueWidth);
+bloomIntensityList->setMaxValueWidth(maxCycleValueWidth);
+```
+
+* \[ ] **Step 15: Build**
+
+```
+cmake --build build --target game --config Release 2>&1 | tail -20
+```
+
+Expected: clean build.
+
+* \[ ] **Step 16: Smoke test**
+
+Run `build\maze\Release\maze.exe`. Open options. Confirm three new rows appear (Bloom, Bloom Threshold, Bloom Intensity). Toggle bloom on/off, change threshold and intensity, apply, reopen options — settings persist. Bloom glow is visible on bright scene objects when enabled.
+
+* \[ ] **Step 17: Commit**
+
+```
+git add game/src/maze.hpp \
+        game/src/maze.cpp \
+        game/src/layer/optionlayer.hpp \
+        game/src/layer/optionlayer.cpp
+git commit -m "feat: expose bloom controls in OptionLayer with settings persistence"
+```

--- a/docs/superpowers/specs/2026-06-18-bloom-design.md
+++ b/docs/superpowers/specs/2026-06-18-bloom-design.md
@@ -1,0 +1,119 @@
+# Bloom Post-Processing Effect
+
+Date: 2026-06-18
+
+## Overview
+
+Add a Dual Kawase bloom post-processing effect. Bloom is toggleable and exposes
+threshold and intensity as tunable parameters in the options UI.
+
+## Architecture
+
+Render order: scene → bloom extract+blur → FXAA → screen.
+
+`Bloom` owns the scene-capture FBO so FXAA's begin/end API is unchanged. FXAA
+gains an `applyWithBloom(sceneTexId, bloomTexId, intensity)` overload. When
+bloom is off, `bloomTexId = 0` and the shader skips the additive pass —
+FXAA-only behavior is identical to before.
+
+### Render paths
+
+**Bloom + FXAA:**
+
+```
+bloom->begin()
+  renderSceneToDepthMap / renderGameObjects / renderLightCubes
+bloom->end()
+bloom->process()
+fxaa->applyWithBloom(bloom->getSceneTexture(), bloom->getBloomTexture(), intensity)
+```
+
+**Bloom only (FXAA off):**
+
+```
+bloom->begin() → render → bloom->end() → bloom->process() → bloom->apply()
+```
+
+**FXAA only (unchanged):**
+
+```
+fxaa->begin() → render → fxaa->end() → fxaa->apply()
+```
+
+**Neither:** render directly to default framebuffer (unchanged).
+
+## Components
+
+### `Bloom` class
+
+Location: `sponge/src/platform/opengl/scene/bloom.hpp/cpp`
+
+Public interface (mirrors FXAA):
+
+* `Bloom(uint32_t width, uint32_t height)`
+* `begin()` — bind scene-capture FBO
+* `end()` — unbind
+* `process()` — extract → 5× downsample → 5× upsample
+* `apply()` — composite scene + bloom to default FB (bloom-only path)
+* `getSceneTexture()` / `getBloomTexture()` — textures for FXAA composite
+* `resize(uint32_t w, uint32_t h)` — rebuild all FBOs
+* `setEnabled(bool)` / `isEnabled()`
+* `setThreshold(float)` / `getThreshold()`
+* `setIntensity(float)` / `getIntensity()`
+
+Internals:
+
+* 1 scene-capture FBO + texture
+* 10 mip-chain FBOs + textures (5 downsample levels, 5 upsample levels)
+* Each level is half the resolution of the previous
+* All FBOs checked with `glCheckFramebufferStatus`; `SPONGE_GL_CRITICAL` if incomplete
+
+### Shaders
+
+All reuse `blur.vert.glsl` as the vertex shader.
+
+| File | Purpose |
+|------|---------|
+| `bloom_extract.frag.glsl` | Luminance threshold — outputs bright pixels only |
+| `bloom_down.frag.glsl` | Dual Kawase downsample, RGB (adapts `blur.frag.glsl`) |
+| `bloom_up.frag.glsl` | Dual Kawase upsample, RGB (adapts `blur_up.frag.glsl`) |
+| `bloom_composite.frag.glsl` | `scene + bloom * intensity` — bloom-only composite path |
+
+FXAA fragment shader (`fxaa.frag.glsl`) gains a `bloomTex` sampler and
+`bloomIntensity` uniform; additive bloom is skipped when `bloomIntensity == 0`.
+
+### `MazeLayer` changes
+
+* Add `std::unique_ptr<sponge::platform::opengl::scene::Bloom> bloom`
+* Add fields: `bloomEnabled` (bool), `bloomThreshold` (float), `bloomIntensity` (float)
+* Add getters/setters for each
+* `captureRenderFrame()` copies all three into `MazeRenderFrame`
+* `onRender()` branches on `frame.bloomEnabled` and `frame.fxaaEnabled`
+* `onWindowResize` defers bloom resize alongside FXAA resize
+
+### `MazeRenderFrame` changes
+
+Add: `bool bloomEnabled`, `float bloomThreshold`, `float bloomIntensity`.
+
+### `OptionLayer` changes
+
+Bloom section alongside existing FXAA toggle:
+
+* Bloom enable/disable checkbox
+* Threshold slider (e.g. 0.0–1.0)
+* Intensity slider (e.g. 0.0–3.0)
+
+## Error Handling
+
+`glCheckFramebufferStatus` after each of the 11 FBO creations; `SPONGE_GL_CRITICAL`
+if any is incomplete. On resize: destroy all FBOs, then recreate.
+
+## Verification
+
+Manual:
+
+* Toggle bloom on/off in options — effect appears/disappears
+* Threshold slider cuts off dim areas; bright areas always bloom
+* Intensity slider scales the glow strength
+* FXAA-only path (bloom off) is visually identical to pre-change behavior
+* Both on together: bloom composites correctly before AA pass

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -4,11 +4,13 @@ configure_file(bundle/resources/version.hpp.in include/version.hpp)
 
 file(
         GLOB HEADER_FILES
+        CONFIGURE_DEPENDS
         LIST_DIRECTORIES false
         src/*.hpp src/layer/*.hpp src/scene/*.hpp src/thread/*.hpp src/ui/*.hpp)
 
 file(
         GLOB SOURCE_FILES
+        CONFIGURE_DEPENDS
         LIST_DIRECTORIES false
         src/*.cpp src/layer/*.cpp src/scene/*.cpp src/ui/*.cpp)
 

--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -172,7 +172,50 @@ void ImGuiLayer::showLightsSection() {
             showDirectionalLightControls();
             ImGui::EndTabItem();
         }
+        if (ImGui::BeginTabItem("Bloom##Tab")) {
+            showBloomControls();
+            ImGui::EndTabItem();
+        }
         ImGui::EndTabBar();
+    }
+}
+
+void ImGuiLayer::showBloomControls() {
+    if (ImGui::BeginTable("Bloom##Table", 2, tableFlags)) {
+        const auto mazeLayer = Maze::get().getMazeLayer();
+
+        auto bloomEnabled = mazeLayer->isBloomEnabled();
+        showTableRow([&] {
+            ImGui::Text("Enabled");
+            ImGui::TableNextColumn();
+            if (ImGui::Checkbox("##bloomenabled", &bloomEnabled)) {
+                mazeLayer->setBloomEnabled(bloomEnabled);
+            }
+        });
+
+        auto threshold = mazeLayer->getBloomThreshold();
+        showTableRow([&] {
+            ImGui::Text("Threshold");
+            ImGui::TableNextColumn();
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+            if (ImGui::SliderFloat("##bloomthreshold", &threshold, 0.F, 1.F,
+                                   "%.2f", ImGuiSliderFlags_AlwaysClamp)) {
+                mazeLayer->setBloomThreshold(threshold);
+            }
+        });
+
+        auto intensity = mazeLayer->getBloomIntensity();
+        showTableRow([&] {
+            ImGui::Text("Intensity");
+            ImGui::TableNextColumn();
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+            if (ImGui::SliderFloat("##bloomintensity", &intensity, 0.F, 5.F,
+                                   "%.2f", ImGuiSliderFlags_AlwaysClamp)) {
+                mazeLayer->setBloomIntensity(intensity);
+            }
+        });
+
+        ImGui::EndTable();
     }
 }
 

--- a/game/src/layer/imgui/imguilayer.hpp
+++ b/game/src/layer/imgui/imguilayer.hpp
@@ -35,6 +35,7 @@ private:
     static void showLogWindow(float width, float height);
     static void showMenu();  // App info window sections
     static void showLightsSection();
+    static void showBloomControls();
     static void showDirectionalLightControls();
     static void showPointLightControls();
     static void showAttenuationSlider(int32_t& attenuationIndex);

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -48,19 +48,21 @@ std::array gameObjects = {
     // GameObject{ .name = "cube1",
     //             .path = "/models/cube/cube-tex.obj",
     //             .scale = glm::vec3(1.F),
+    //             .rotation    = { .angle = 0.F, .axis{ 0.F, 1.F, 0.F } },
     //             .translation = glm::vec3(-1.5F, .85F, -.5F) },
     //
     // GameObject{ .name = "cube2",
     //             .path = "/models/cube/cube-tex.obj",
     //             .scale = glm::vec3(.5F),
+    //             .rotation    = { .angle = 0.F, .axis{ 0.F, 1.F, 0.F } },
     //             .translation = glm::vec3(0.F, 0.F, .5F) },
-    //
-    // GameObject{ .name = "cube3",
-    //             .path = "/models/cube/cube-tex.obj",
-    //             .scale = glm::vec3(.25F),
-    //             .rotation = { .angle = glm::radians(60.F),
-    //                           .axis = glm::vec3(1.F, 0.F, 1.F) },
-    //             .translation = glm::vec3(-1.F, 0.25F, 1.F) }
+
+    GameObject{ .name        = "cube3",
+                .path        = "/models/cube/cube-tex.obj",
+                .scale       = glm::vec3(.25F),
+                .rotation    = { .angle = glm::radians(60.F),
+                                 .axis  = glm::vec3(1.F, 0.F, 1.F) },
+                .translation = glm::vec3(-1.F, 0.25F, 1.F) },
 
     GameObject{ .name        = "helmet",
                 .path        = "/models/helmet/damaged_helmet.obj",
@@ -82,6 +84,7 @@ using sponge::input::GameAction;
 using sponge::input::InputSnapshot;
 using sponge::platform::glfw::core::Application;
 using sponge::platform::opengl::renderer::AssetManager;
+using sponge::platform::opengl::scene::Bloom;
 using sponge::platform::opengl::scene::Cube;
 using sponge::platform::opengl::scene::FXAA;
 using sponge::platform::opengl::scene::Mesh;
@@ -152,6 +155,12 @@ void MazeLayer::onAttach() {
     fxaa = std::make_unique<FXAA>(Maze::get().getWindow()->getWidth(),
                                   Maze::get().getWindow()->getHeight());
     fxaa->setEnabled(fxaaEnabled);
+
+    bloom = std::make_unique<Bloom>(Maze::get().getWindow()->getWidth(),
+                                    Maze::get().getWindow()->getHeight());
+    bloom->setEnabled(bloomEnabled);
+    bloom->setThreshold(bloomThreshold);
+    bloom->setIntensity(bloomIntensity);
 
     queueResize(Maze::get().getWindow()->getWidth(),
                 Maze::get().getWindow()->getHeight());
@@ -265,7 +274,10 @@ void MazeLayer::captureRenderFrame(const uint32_t slotIndex) {
         frame.lightAttenuationIndices[i] = pointLights.at(i).attenuationIndex;
     }
 
-    frame.fxaaEnabled = fxaaEnabled;
+    frame.fxaaEnabled    = fxaaEnabled;
+    frame.bloomEnabled   = bloomEnabled;
+    frame.bloomThreshold = bloomThreshold;
+    frame.bloomIntensity = bloomIntensity;
 
     // Static after onAttach(); safe to copy.
     frame.objectModelMatrices = objectModelMatrices;
@@ -293,6 +305,9 @@ void MazeLayer::onRender() {
         if (fxaa) {
             fxaa->resize(w, h);
         }
+        if (bloom) {
+            bloom->resize(w, h);
+        }
         pendingResize.store(false, std::memory_order_relaxed);
     }
 
@@ -304,14 +319,26 @@ void MazeLayer::onRender() {
         renderSceneToDepthMap(frame);
     }
 
-    if (fxaa && frame.fxaaEnabled) {
+    if (frame.bloomEnabled && bloom) {
+        bloom->begin();
+    } else if (frame.fxaaEnabled && fxaa) {
         fxaa->begin();
     }
 
     renderGameObjects(frame);
     renderLightCubes(frame);
 
-    if (fxaa && frame.fxaaEnabled) {
+    if (frame.bloomEnabled && bloom) {
+        bloom->end();
+        bloom->process();
+        if (frame.fxaaEnabled && fxaa) {
+            fxaa->applyWithBloom(bloom->getSceneTexture(),
+                                 bloom->getBloomTexture(),
+                                 frame.bloomIntensity);
+        } else {
+            bloom->apply();
+        }
+    } else if (frame.fxaaEnabled && fxaa) {
         fxaa->end();
         fxaa->apply();
     }
@@ -636,6 +663,39 @@ void MazeLayer::setFxaaEnabled(const bool val) {
     fxaaEnabled = val;
     if (fxaa) {
         fxaa->setEnabled(val);
+    }
+}
+
+bool MazeLayer::isBloomEnabled() const {
+    return bloomEnabled;
+}
+
+void MazeLayer::setBloomEnabled(const bool val) {
+    bloomEnabled = val;
+    if (bloom) {
+        bloom->setEnabled(val);
+    }
+}
+
+float MazeLayer::getBloomThreshold() const {
+    return bloomThreshold;
+}
+
+void MazeLayer::setBloomThreshold(const float val) {
+    bloomThreshold = val;
+    if (bloom) {
+        bloom->setThreshold(val);
+    }
+}
+
+float MazeLayer::getBloomIntensity() const {
+    return bloomIntensity;
+}
+
+void MazeLayer::setBloomIntensity(const float val) {
+    bloomIntensity = val;
+    if (bloom) {
+        bloom->setIntensity(val);
     }
 }
 

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -158,9 +158,6 @@ void MazeLayer::onAttach() {
 
     bloom = std::make_unique<Bloom>(Maze::get().getWindow()->getWidth(),
                                     Maze::get().getWindow()->getHeight());
-    bloom->setEnabled(bloomEnabled);
-    bloom->setThreshold(bloomThreshold);
-    bloom->setIntensity(bloomIntensity);
 
     queueResize(Maze::get().getWindow()->getWidth(),
                 Maze::get().getWindow()->getHeight());
@@ -672,9 +669,6 @@ bool MazeLayer::isBloomEnabled() const {
 
 void MazeLayer::setBloomEnabled(const bool val) {
     bloomEnabled = val;
-    if (bloom) {
-        bloom->setEnabled(val);
-    }
 }
 
 float MazeLayer::getBloomThreshold() const {

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -330,13 +330,13 @@ void MazeLayer::onRender() {
 
     if (frame.bloomEnabled && bloom) {
         bloom->end();
-        bloom->process();
+        bloom->process(frame.bloomThreshold);
         if (frame.fxaaEnabled && fxaa) {
             fxaa->applyWithBloom(bloom->getSceneTexture(),
                                  bloom->getBloomTexture(),
                                  frame.bloomIntensity);
         } else {
-            bloom->apply();
+            bloom->apply(frame.bloomIntensity);
         }
     } else if (frame.fxaaEnabled && fxaa) {
         fxaa->end();
@@ -683,9 +683,6 @@ float MazeLayer::getBloomThreshold() const {
 
 void MazeLayer::setBloomThreshold(const float val) {
     bloomThreshold = val;
-    if (bloom) {
-        bloom->setThreshold(val);
-    }
 }
 
 float MazeLayer::getBloomIntensity() const {
@@ -694,9 +691,6 @@ float MazeLayer::getBloomIntensity() const {
 
 void MazeLayer::setBloomIntensity(const float val) {
     bloomIntensity = val;
-    if (bloom) {
-        bloom->setIntensity(val);
-    }
 }
 
 #ifdef ENABLE_IMGUI

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -62,7 +62,8 @@ std::array gameObjects = {
                 .scale       = glm::vec3(.25F),
                 .rotation    = { .angle = glm::radians(60.F),
                                  .axis  = glm::vec3(1.F, 0.F, 1.F) },
-                .translation = glm::vec3(-1.F, 0.25F, 1.F) },
+                .translation = glm::vec3(-1.F, 0.25F, 1.F),
+                .emissive    = glm::vec3(1.5F, 1.2F, 0.5F) },
 
     GameObject{ .name        = "helmet",
                 .path        = "/models/helmet/damaged_helmet.obj",
@@ -107,6 +108,7 @@ void MazeLayer::onAttach() {
             glm::rotate(glm::translate(glm::mat4(1.0f), gameObject.translation),
                         gameObject.rotation.angle, gameObject.rotation.axis),
             gameObject.scale));
+        objectEmissives.push_back(gameObject.emissive);
 
         sponge::platform::opengl::scene::ModelCreateInfo modelCreateInfo{
             .name = std::string(gameObject.name),
@@ -278,6 +280,7 @@ void MazeLayer::captureRenderFrame(const uint32_t slotIndex) {
 
     // Static after onAttach(); safe to copy.
     frame.objectModelMatrices = objectModelMatrices;
+    frame.objectEmissives     = objectEmissives;
     frame.objectModels        = objectModels;
 
     // Publish slot; release/acquire pair with onRender()'s load.
@@ -561,6 +564,7 @@ void MazeLayer::renderGameObjects(const thread::MazeRenderFrame& frame) const {
 
         shader->setMat4("mvp", frame.cameraMVP * modelMatrix);
         shader->setMat4("model", modelMatrix);
+        shader->setFloat3("emissive", frame.objectEmissives[i]);
 
         frame.objectModels[i]->render(shader);
     }

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -21,6 +21,7 @@ struct GameObject {
         glm::vec3 axis{ 0.F, 1.F, 0.F };
     } rotation;
     glm::vec3 translation{ 0.F };
+    glm::vec3 emissive{ 0.F };
 };
 
 class MazeLayer final : public sponge::layer::Layer {
@@ -111,6 +112,7 @@ public:
 private:
     std::shared_ptr<scene::GameCamera> camera;
     std::vector<glm::mat4>             objectModelMatrices;
+    std::vector<glm::vec3>             objectEmissives;
     std::vector<std::shared_ptr<sponge::platform::opengl::scene::Model>>
                                                                 objectModels;
     std::unique_ptr<sponge::platform::opengl::scene::Cube>      cube;

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -97,6 +97,13 @@ public:
 
     void setFxaaEnabled(bool val);
 
+    bool  isBloomEnabled() const;
+    void  setBloomEnabled(bool val);
+    float getBloomThreshold() const;
+    void  setBloomThreshold(float val);
+    float getBloomIntensity() const;
+    void  setBloomIntensity(float val);
+
 #ifdef ENABLE_IMGUI
     bool isImguiActive() const;
 #endif
@@ -108,6 +115,7 @@ private:
                                                                 objectModels;
     std::unique_ptr<sponge::platform::opengl::scene::Cube>      cube;
     std::unique_ptr<sponge::platform::opengl::scene::FXAA>      fxaa;
+    std::unique_ptr<sponge::platform::opengl::scene::Bloom>     bloom;
     std::unique_ptr<sponge::platform::opengl::scene::ShadowMap> shadowMap;
 
     // Double-buffered snapshots: update writes, render reads, no overlap.
@@ -133,6 +141,9 @@ private:
     float   ao                 = .25F;
     int32_t attenuationIndex   = 4;
     bool    fxaaEnabled        = true;
+    bool    bloomEnabled       = true;
+    float   bloomThreshold     = 0.8F;
+    float   bloomIntensity     = 1.0F;
     bool    metallic           = false;
     bool    mouseButtonPressed = false;
     int32_t numLights          = 0;

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -52,6 +52,9 @@ constexpr std::string_view applyMessage  = "Apply";
 
 constexpr std::array<uint32_t, 4> shadowResolutions = { 512, 1024, 2048, 4096 };
 
+constexpr std::array<float, 3> bloomThresholds  = { 0.6F, 0.8F, 0.95F };
+constexpr std::array<float, 4> bloomIntensities = { 0.5F, 1.0F, 2.0F, 3.0F };
+
 constexpr std::string_view cameraName = "intro";
 constexpr std::string_view fontName   = "inter";
 constexpr std::string_view fontPath   = "/fonts/inter.ttf";
@@ -159,7 +162,8 @@ float computeMaxCycleValueWidth() {
 
 void saveVideoSettings(const uint32_t width, const uint32_t height,
                        const bool fullscreen, const bool vsync, const bool fxaa,
-                       const uint32_t shadowRes) {
+                       const uint32_t shadowRes, const bool bloomEnabled,
+                       const float bloomThreshold, const float bloomIntensity) {
     using sponge::core::Settings;
     Settings::set("video.width", width);
     Settings::set("video.height", height);
@@ -167,6 +171,9 @@ void saveVideoSettings(const uint32_t width, const uint32_t height,
     Settings::set("video.vsync", vsync);
     Settings::set("video.fxaa", fxaa);
     Settings::set("video.shadowRes", shadowRes);
+    Settings::set("video.bloomEnabled", bloomEnabled);
+    Settings::set("video.bloomThreshold", std::to_string(bloomThreshold));
+    Settings::set("video.bloomIntensity", std::to_string(bloomIntensity));
     Settings::save();
 }
 
@@ -180,6 +187,9 @@ YGNodeRef resolutionNode     = nullptr;
 YGNodeRef shadowQualityNode  = nullptr;
 YGNodeRef verticalSyncNode   = nullptr;
 YGNodeRef fullScreenNode     = nullptr;
+YGNodeRef bloomEnabledNode   = nullptr;
+YGNodeRef bloomThresholdNode = nullptr;
+YGNodeRef bloomIntensityNode = nullptr;
 YGNodeRef returnNode         = nullptr;
 YGNodeRef rootNode           = nullptr;
 YGNodeRef titleNode          = nullptr;
@@ -259,13 +269,16 @@ void OptionLayer::onAttach() {
         return child;
     };
 
-    aspectRatioNode   = makeMenuNode(menuBackgroundNode, 0);
-    resolutionNode    = makeMenuNode(menuBackgroundNode, 1);
-    fullScreenNode    = makeMenuNode(menuBackgroundNode, 2);
-    verticalSyncNode  = makeMenuNode(menuBackgroundNode, 3);
-    antiAliasingNode  = makeMenuNode(menuBackgroundNode, 4);
-    shadowQualityNode = makeMenuNode(menuBackgroundNode, 5);
-    returnNode        = makeMenuNode(menuBackgroundNode, 6);
+    aspectRatioNode    = makeMenuNode(menuBackgroundNode, 0);
+    resolutionNode     = makeMenuNode(menuBackgroundNode, 1);
+    fullScreenNode     = makeMenuNode(menuBackgroundNode, 2);
+    verticalSyncNode   = makeMenuNode(menuBackgroundNode, 3);
+    antiAliasingNode   = makeMenuNode(menuBackgroundNode, 4);
+    shadowQualityNode  = makeMenuNode(menuBackgroundNode, 5);
+    bloomEnabledNode   = makeMenuNode(menuBackgroundNode, 6);
+    bloomThresholdNode = makeMenuNode(menuBackgroundNode, 7);
+    bloomIntensityNode = makeMenuNode(menuBackgroundNode, 8);
+    returnNode         = makeMenuNode(menuBackgroundNode, 9);
 
     availableResolutions = Maze::get().getAvailableResolutions();
 
@@ -296,6 +309,12 @@ void OptionLayer::onAttach() {
     antiAliasingCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
     fullScreenCheckbox   = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
     verticalSyncCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
+    bloomEnabledCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
+    bloomThresholdList   = std::make_unique<ui::SelectList>(selectCreateInfo);
+    bloomIntensityList   = std::make_unique<ui::SelectList>(selectCreateInfo);
+
+    bloomThresholdList->setItems({ "Low", "Medium", "High" });
+    bloomIntensityList->setItems({ "Low", "Normal", "High", "Extra" });
 
     std::vector<std::string> arItems;
     arItems.reserve(validAspectRatioFilters.size());
@@ -405,6 +424,16 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                     pendingShadowResIndex =
                         static_cast<int>(shadowQualityList->getSelectedIndex());
                     updateChangeStatus();
+                } else if (selectedItem == OptionMenuItem::BloomThreshold) {
+                    bloomThresholdList->selectPrev();
+                    pendingBloomThreshold = static_cast<int>(
+                        bloomThresholdList->getSelectedIndex());
+                    updateChangeStatus();
+                } else if (selectedItem == OptionMenuItem::BloomIntensity) {
+                    bloomIntensityList->selectPrev();
+                    pendingBloomIntensity = static_cast<int>(
+                        bloomIntensityList->getSelectedIndex());
+                    updateChangeStatus();
                 }
             }
             if (input.isActive(GameAction::MenuRight)) {
@@ -419,6 +448,16 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                     shadowQualityList->selectNext();
                     pendingShadowResIndex =
                         static_cast<int>(shadowQualityList->getSelectedIndex());
+                    updateChangeStatus();
+                } else if (selectedItem == OptionMenuItem::BloomThreshold) {
+                    bloomThresholdList->selectNext();
+                    pendingBloomThreshold = static_cast<int>(
+                        bloomThresholdList->getSelectedIndex());
+                    updateChangeStatus();
+                } else if (selectedItem == OptionMenuItem::BloomIntensity) {
+                    bloomIntensityList->selectNext();
+                    pendingBloomIntensity = static_cast<int>(
+                        bloomIntensityList->getSelectedIndex());
                     updateChangeStatus();
                 }
             }
@@ -449,6 +488,9 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                     updateChangeStatus();
                 } else if (selectedItem == OptionMenuItem::AntiAliasing) {
                     pendingFxaa = !pendingFxaa;
+                    updateChangeStatus();
+                } else if (selectedItem == OptionMenuItem::BloomEnabled) {
+                    pendingBloomEnabled = !pendingBloomEnabled;
                     updateChangeStatus();
                 }
             }
@@ -485,6 +527,12 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
         getNodeLayout(antiAliasingNode, menuBgX, menuBgY);
     const auto [sqX, sqY, sqW, sqH] =
         getNodeLayout(shadowQualityNode, menuBgX, menuBgY);
+    const auto [beX, beY, beW, beH] =
+        getNodeLayout(bloomEnabledNode, menuBgX, menuBgY);
+    const auto [btX, btY, btW, btH] =
+        getNodeLayout(bloomThresholdNode, menuBgX, menuBgY);
+    const auto [biX, biY, biW, biH] =
+        getNodeLayout(bloomIntensityNode, menuBgX, menuBgY);
     const auto [retX, retY, retW, retH] =
         getNodeLayout(returnNode, menuBgX, menuBgY);
 
@@ -553,6 +601,22 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
     renderDots(shadowResolutions.size(),
                shadowQualityList->getValueCenterX(sqX, sqW), sqY, sqH,
                shadowQualityList->getSelectedIndex(), currentShadowResIndex);
+
+    renderRowBackground(beX, beY, beW, beH, OptionMenuItem::BloomEnabled);
+    renderRowLabel(beX, beY, beH, "Bloom");
+    bloomEnabledCheckbox->onUpdate(beX, beY, beW, beH, pendingBloomEnabled);
+
+    renderRowBackground(btX, btY, btW, btH, OptionMenuItem::BloomThreshold);
+    bloomThresholdList->onUpdate(btX, btY, btW, btH, "Bloom Threshold");
+    renderDots(bloomThresholds.size(),
+               bloomThresholdList->getValueCenterX(btX, btW), btY, btH,
+               static_cast<size_t>(pendingBloomThreshold), std::nullopt);
+
+    renderRowBackground(biX, biY, biW, biH, OptionMenuItem::BloomIntensity);
+    bloomIntensityList->onUpdate(biX, biY, biW, biH, "Bloom Intensity");
+    renderDots(bloomIntensities.size(),
+               bloomIntensityList->getValueCenterX(biX, biW), biY, biH,
+               static_cast<size_t>(pendingBloomIntensity), std::nullopt);
 
     returnButton->setPosition({ retX, retY }, { retX + retW, retY + retH });
     if (selectedItem == OptionMenuItem::Return) {
@@ -723,6 +787,60 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         return true;
     }
 
+    const auto [beX2, beY2, beW2, beH2] = getNodeLayout(
+        bloomEnabledNode, menuBackgroundNodeX, menuBackgroundNodeY);
+
+    if (mouseX >= beX2 && mouseX <= beX2 + beW2 && mouseY >= beY2 &&
+        mouseY <= beY2 + beH2) {
+        selectedItem = OptionMenuItem::BloomEnabled;
+        if (bloomEnabledCheckbox->isInside(mouseX, mouseY, beX2, beY2, beW2,
+                                           beH2)) {
+            pendingBloomEnabled = !pendingBloomEnabled;
+            updateChangeStatus();
+        }
+        return true;
+    }
+
+    const auto [btX2, btY2, btW2, btH2] = getNodeLayout(
+        bloomThresholdNode, menuBackgroundNodeX, menuBackgroundNodeY);
+
+    if (mouseX >= btX2 && mouseX <= btX2 + btW2 && mouseY >= btY2 &&
+        mouseY <= btY2 + btH2) {
+        selectedItem = OptionMenuItem::BloomThreshold;
+        if (bloomThresholdList->isInsideLeft(mouseX, btX2, btW2)) {
+            bloomThresholdList->selectPrev();
+            pendingBloomThreshold =
+                static_cast<int>(bloomThresholdList->getSelectedIndex());
+            updateChangeStatus();
+        } else if (bloomThresholdList->isInsideRight(mouseX, btX2, btW2)) {
+            bloomThresholdList->selectNext();
+            pendingBloomThreshold =
+                static_cast<int>(bloomThresholdList->getSelectedIndex());
+            updateChangeStatus();
+        }
+        return true;
+    }
+
+    const auto [biX2, biY2, biW2, biH2] = getNodeLayout(
+        bloomIntensityNode, menuBackgroundNodeX, menuBackgroundNodeY);
+
+    if (mouseX >= biX2 && mouseX <= biX2 + biW2 && mouseY >= biY2 &&
+        mouseY <= biY2 + biH2) {
+        selectedItem = OptionMenuItem::BloomIntensity;
+        if (bloomIntensityList->isInsideLeft(mouseX, biX2, biW2)) {
+            bloomIntensityList->selectPrev();
+            pendingBloomIntensity =
+                static_cast<int>(bloomIntensityList->getSelectedIndex());
+            updateChangeStatus();
+        } else if (bloomIntensityList->isInsideRight(mouseX, biX2, biW2)) {
+            bloomIntensityList->selectNext();
+            pendingBloomIntensity =
+                static_cast<int>(bloomIntensityList->getSelectedIndex());
+            updateChangeStatus();
+        }
+        return true;
+    }
+
     return true;
 }
 
@@ -771,6 +889,12 @@ bool OptionLayer::onMouseMoved(const MouseMovedEvent& event) {
         hoveredItem = OptionMenuItem::AntiAliasing;
     } else if (isOver(shadowQualityNode)) {
         hoveredItem = OptionMenuItem::ShadowQuality;
+    } else if (isOver(bloomEnabledNode)) {
+        hoveredItem = OptionMenuItem::BloomEnabled;
+    } else if (isOver(bloomThresholdNode)) {
+        hoveredItem = OptionMenuItem::BloomThreshold;
+    } else if (isOver(bloomIntensityNode)) {
+        hoveredItem = OptionMenuItem::BloomIntensity;
     } else {
         hoveredItem = std::nullopt;
     }
@@ -793,17 +917,24 @@ bool OptionLayer::onWindowResize(const WindowResizeEvent& event) {
         aspectRatioList->setFontSize(fontSize);
         resolutionList->setFontSize(fontSize);
         shadowQualityList->setFontSize(fontSize);
+        bloomThresholdList->setFontSize(fontSize);
+        bloomIntensityList->setFontSize(fontSize);
 
         const auto checkboxSize = static_cast<float>(fontSize);
         antiAliasingCheckbox->setSize(checkboxSize);
         fullScreenCheckbox->setSize(checkboxSize);
         verticalSyncCheckbox->setSize(checkboxSize);
 
+        const auto checkboxSize2 = static_cast<float>(fontSize);
+        bloomEnabledCheckbox->setSize(checkboxSize2);
+
         const float maxCycleValueWidth = computeMaxCycleValueWidth();
 
         aspectRatioList->setMaxValueWidth(maxCycleValueWidth);
         resolutionList->setMaxValueWidth(maxCycleValueWidth);
         shadowQualityList->setMaxValueWidth(maxCycleValueWidth);
+        bloomThresholdList->setMaxValueWidth(maxCycleValueWidth);
+        bloomIntensityList->setMaxValueWidth(maxCycleValueWidth);
     }
 
     if (isActive()) {
@@ -881,11 +1012,19 @@ void OptionLayer::applyChanges() {
     }
     Maze::get().setVerticalSync(pendingVsync);
     Maze::get().setFxaaEnabled(pendingFxaa);
+    Maze::get().setBloomEnabled(pendingBloomEnabled);
+    Maze::get().setBloomThreshold(
+        bloomThresholds[static_cast<size_t>(pendingBloomThreshold)]);
+    Maze::get().setBloomIntensity(
+        bloomIntensities[static_cast<size_t>(pendingBloomIntensity)]);
     const auto shadowRes =
         shadowResolutions[static_cast<size_t>(pendingShadowResIndex)];
     Maze::get().getMazeLayer()->setShadowMapRes(shadowRes);
-    saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
-                      pendingFxaa, shadowRes);
+    saveVideoSettings(
+        saveWidth, saveHeight, pendingFullscreen, pendingVsync, pendingFxaa,
+        shadowRes, pendingBloomEnabled,
+        bloomThresholds[static_cast<size_t>(pendingBloomThreshold)],
+        bloomIntensities[static_cast<size_t>(pendingBloomIntensity)]);
 
     syncPendingCheckboxState();
     hasUnappliedChanges = false;
@@ -893,9 +1032,32 @@ void OptionLayer::applyChanges() {
 }
 
 void OptionLayer::syncPendingCheckboxState() {
-    pendingFullscreen = Maze::get().isFullscreen();
-    pendingVsync      = Maze::get().hasVerticalSync();
-    pendingFxaa       = Maze::get().isFxaaEnabled();
+    pendingFullscreen   = Maze::get().isFullscreen();
+    pendingVsync        = Maze::get().hasVerticalSync();
+    pendingFxaa         = Maze::get().isFxaaEnabled();
+    pendingBloomEnabled = Maze::get().isBloomEnabled();
+
+    const float curThreshold = Maze::get().getBloomThreshold();
+    const auto  tIt          = std::ranges::find(bloomThresholds, curThreshold);
+    pendingBloomThreshold =
+        tIt != bloomThresholds.end() ?
+            static_cast<int>(tIt - bloomThresholds.begin()) :
+            1;
+    if (bloomThresholdList) {
+        bloomThresholdList->setSelectedIndex(
+            static_cast<size_t>(pendingBloomThreshold));
+    }
+
+    const float curIntensity = Maze::get().getBloomIntensity();
+    const auto  iIt = std::ranges::find(bloomIntensities, curIntensity);
+    pendingBloomIntensity =
+        iIt != bloomIntensities.end() ?
+            static_cast<int>(iIt - bloomIntensities.begin()) :
+            1;
+    if (bloomIntensityList) {
+        bloomIntensityList->setSelectedIndex(
+            static_cast<size_t>(pendingBloomIntensity));
+    }
 
     const auto currentShadowRes =
         Maze::get().getMazeLayer()->getDirectionalLightShadowMapRes();
@@ -914,7 +1076,8 @@ void OptionLayer::updateChangeStatus() {
     const bool checkboxChanged =
         pendingFullscreen != Maze::get().isFullscreen() ||
         pendingVsync != Maze::get().hasVerticalSync() ||
-        pendingFxaa != Maze::get().isFxaaEnabled();
+        pendingFxaa != Maze::get().isFxaaEnabled() ||
+        pendingBloomEnabled != Maze::get().isBloomEnabled();
 
     const auto window = Maze::get().getWindow();
     const auto curW   = window->getWidth();
@@ -957,7 +1120,15 @@ void OptionLayer::updateChangeStatus() {
         shadowResolutions[static_cast<size_t>(pendingShadowResIndex)] !=
         currentShadowRes;
 
-    hasUnappliedChanges = checkboxChanged || resolutionChanged || shadowChanged;
+    const bool bloomThresholdChanged =
+        bloomThresholds[static_cast<size_t>(pendingBloomThreshold)] !=
+        Maze::get().getBloomThreshold();
+    const bool bloomIntensityChanged =
+        bloomIntensities[static_cast<size_t>(pendingBloomIntensity)] !=
+        Maze::get().getBloomIntensity();
+    hasUnappliedChanges = checkboxChanged || resolutionChanged ||
+                          shadowChanged || bloomThresholdChanged ||
+                          bloomIntensityChanged;
     returnButton->setMessage(hasUnappliedChanges ? applyMessage :
                                                    returnMessage);
 }

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -1036,7 +1036,10 @@ void OptionLayer::syncPendingCheckboxState() {
     pendingBloomEnabled = Maze::get().isBloomEnabled();
 
     const float curThreshold = Maze::get().getBloomThreshold();
-    const auto  tIt          = std::ranges::find(bloomThresholds, curThreshold);
+    const auto  tIt =
+        std::ranges::find_if(bloomThresholds, [curThreshold](float v) {
+            return std::abs(v - curThreshold) < 0.01F;
+        });
     pendingBloomThreshold =
         tIt != bloomThresholds.end() ?
             static_cast<int>(tIt - bloomThresholds.begin()) :
@@ -1047,7 +1050,10 @@ void OptionLayer::syncPendingCheckboxState() {
     }
 
     const float curIntensity = Maze::get().getBloomIntensity();
-    const auto  iIt = std::ranges::find(bloomIntensities, curIntensity);
+    const auto  iIt =
+        std::ranges::find_if(bloomIntensities, [curIntensity](float v) {
+            return std::abs(v - curIntensity) < 0.01F;
+        });
     pendingBloomIntensity =
         iIt != bloomIntensities.end() ?
             static_cast<int>(iIt - bloomIntensities.begin()) :

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -924,9 +924,7 @@ bool OptionLayer::onWindowResize(const WindowResizeEvent& event) {
         antiAliasingCheckbox->setSize(checkboxSize);
         fullScreenCheckbox->setSize(checkboxSize);
         verticalSyncCheckbox->setSize(checkboxSize);
-
-        const auto checkboxSize2 = static_cast<float>(fontSize);
-        bloomEnabledCheckbox->setSize(checkboxSize2);
+        bloomEnabledCheckbox->setSize(checkboxSize);
 
         const float maxCycleValueWidth = computeMaxCycleValueWidth();
 

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -52,9 +52,6 @@ constexpr std::string_view applyMessage  = "Apply";
 
 constexpr std::array<uint32_t, 4> shadowResolutions = { 512, 1024, 2048, 4096 };
 
-constexpr std::array<float, 3> bloomThresholds  = { 0.6F, 0.8F, 0.95F };
-constexpr std::array<float, 4> bloomIntensities = { 0.5F, 1.0F, 2.0F, 3.0F };
-
 constexpr std::string_view cameraName = "intro";
 constexpr std::string_view fontName   = "inter";
 constexpr std::string_view fontPath   = "/fonts/inter.ttf";
@@ -162,8 +159,7 @@ float computeMaxCycleValueWidth() {
 
 void saveVideoSettings(const uint32_t width, const uint32_t height,
                        const bool fullscreen, const bool vsync, const bool fxaa,
-                       const uint32_t shadowRes, const bool bloomEnabled,
-                       const float bloomThreshold, const float bloomIntensity) {
+                       const uint32_t shadowRes) {
     using sponge::core::Settings;
     Settings::set("video.width", width);
     Settings::set("video.height", height);
@@ -171,9 +167,6 @@ void saveVideoSettings(const uint32_t width, const uint32_t height,
     Settings::set("video.vsync", vsync);
     Settings::set("video.fxaa", fxaa);
     Settings::set("video.shadowRes", shadowRes);
-    Settings::set("video.bloomEnabled", bloomEnabled);
-    Settings::set("video.bloomThreshold", std::to_string(bloomThreshold));
-    Settings::set("video.bloomIntensity", std::to_string(bloomIntensity));
     Settings::save();
 }
 
@@ -187,9 +180,6 @@ YGNodeRef resolutionNode     = nullptr;
 YGNodeRef shadowQualityNode  = nullptr;
 YGNodeRef verticalSyncNode   = nullptr;
 YGNodeRef fullScreenNode     = nullptr;
-YGNodeRef bloomEnabledNode   = nullptr;
-YGNodeRef bloomThresholdNode = nullptr;
-YGNodeRef bloomIntensityNode = nullptr;
 YGNodeRef returnNode         = nullptr;
 YGNodeRef rootNode           = nullptr;
 YGNodeRef titleNode          = nullptr;
@@ -269,16 +259,13 @@ void OptionLayer::onAttach() {
         return child;
     };
 
-    aspectRatioNode    = makeMenuNode(menuBackgroundNode, 0);
-    resolutionNode     = makeMenuNode(menuBackgroundNode, 1);
-    fullScreenNode     = makeMenuNode(menuBackgroundNode, 2);
-    verticalSyncNode   = makeMenuNode(menuBackgroundNode, 3);
-    antiAliasingNode   = makeMenuNode(menuBackgroundNode, 4);
-    shadowQualityNode  = makeMenuNode(menuBackgroundNode, 5);
-    bloomEnabledNode   = makeMenuNode(menuBackgroundNode, 6);
-    bloomThresholdNode = makeMenuNode(menuBackgroundNode, 7);
-    bloomIntensityNode = makeMenuNode(menuBackgroundNode, 8);
-    returnNode         = makeMenuNode(menuBackgroundNode, 9);
+    aspectRatioNode   = makeMenuNode(menuBackgroundNode, 0);
+    resolutionNode    = makeMenuNode(menuBackgroundNode, 1);
+    fullScreenNode    = makeMenuNode(menuBackgroundNode, 2);
+    verticalSyncNode  = makeMenuNode(menuBackgroundNode, 3);
+    antiAliasingNode  = makeMenuNode(menuBackgroundNode, 4);
+    shadowQualityNode = makeMenuNode(menuBackgroundNode, 5);
+    returnNode        = makeMenuNode(menuBackgroundNode, 6);
 
     availableResolutions = Maze::get().getAvailableResolutions();
 
@@ -309,12 +296,6 @@ void OptionLayer::onAttach() {
     antiAliasingCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
     fullScreenCheckbox   = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
     verticalSyncCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
-    bloomEnabledCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
-    bloomThresholdList   = std::make_unique<ui::SelectList>(selectCreateInfo);
-    bloomIntensityList   = std::make_unique<ui::SelectList>(selectCreateInfo);
-
-    bloomThresholdList->setItems({ "Low", "Medium", "High" });
-    bloomIntensityList->setItems({ "Low", "Normal", "High", "Extra" });
 
     std::vector<std::string> arItems;
     arItems.reserve(validAspectRatioFilters.size());
@@ -424,16 +405,6 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                     pendingShadowResIndex =
                         static_cast<int>(shadowQualityList->getSelectedIndex());
                     updateChangeStatus();
-                } else if (selectedItem == OptionMenuItem::BloomThreshold) {
-                    bloomThresholdList->selectPrev();
-                    pendingBloomThreshold = static_cast<int>(
-                        bloomThresholdList->getSelectedIndex());
-                    updateChangeStatus();
-                } else if (selectedItem == OptionMenuItem::BloomIntensity) {
-                    bloomIntensityList->selectPrev();
-                    pendingBloomIntensity = static_cast<int>(
-                        bloomIntensityList->getSelectedIndex());
-                    updateChangeStatus();
                 }
             }
             if (input.isActive(GameAction::MenuRight)) {
@@ -448,16 +419,6 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                     shadowQualityList->selectNext();
                     pendingShadowResIndex =
                         static_cast<int>(shadowQualityList->getSelectedIndex());
-                    updateChangeStatus();
-                } else if (selectedItem == OptionMenuItem::BloomThreshold) {
-                    bloomThresholdList->selectNext();
-                    pendingBloomThreshold = static_cast<int>(
-                        bloomThresholdList->getSelectedIndex());
-                    updateChangeStatus();
-                } else if (selectedItem == OptionMenuItem::BloomIntensity) {
-                    bloomIntensityList->selectNext();
-                    pendingBloomIntensity = static_cast<int>(
-                        bloomIntensityList->getSelectedIndex());
                     updateChangeStatus();
                 }
             }
@@ -488,9 +449,6 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                     updateChangeStatus();
                 } else if (selectedItem == OptionMenuItem::AntiAliasing) {
                     pendingFxaa = !pendingFxaa;
-                    updateChangeStatus();
-                } else if (selectedItem == OptionMenuItem::BloomEnabled) {
-                    pendingBloomEnabled = !pendingBloomEnabled;
                     updateChangeStatus();
                 }
             }
@@ -527,12 +485,6 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
         getNodeLayout(antiAliasingNode, menuBgX, menuBgY);
     const auto [sqX, sqY, sqW, sqH] =
         getNodeLayout(shadowQualityNode, menuBgX, menuBgY);
-    const auto [beX, beY, beW, beH] =
-        getNodeLayout(bloomEnabledNode, menuBgX, menuBgY);
-    const auto [btX, btY, btW, btH] =
-        getNodeLayout(bloomThresholdNode, menuBgX, menuBgY);
-    const auto [biX, biY, biW, biH] =
-        getNodeLayout(bloomIntensityNode, menuBgX, menuBgY);
     const auto [retX, retY, retW, retH] =
         getNodeLayout(returnNode, menuBgX, menuBgY);
 
@@ -601,22 +553,6 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
     renderDots(shadowResolutions.size(),
                shadowQualityList->getValueCenterX(sqX, sqW), sqY, sqH,
                shadowQualityList->getSelectedIndex(), currentShadowResIndex);
-
-    renderRowBackground(beX, beY, beW, beH, OptionMenuItem::BloomEnabled);
-    renderRowLabel(beX, beY, beH, "Bloom");
-    bloomEnabledCheckbox->onUpdate(beX, beY, beW, beH, pendingBloomEnabled);
-
-    renderRowBackground(btX, btY, btW, btH, OptionMenuItem::BloomThreshold);
-    bloomThresholdList->onUpdate(btX, btY, btW, btH, "Bloom Threshold");
-    renderDots(bloomThresholds.size(),
-               bloomThresholdList->getValueCenterX(btX, btW), btY, btH,
-               static_cast<size_t>(pendingBloomThreshold), std::nullopt);
-
-    renderRowBackground(biX, biY, biW, biH, OptionMenuItem::BloomIntensity);
-    bloomIntensityList->onUpdate(biX, biY, biW, biH, "Bloom Intensity");
-    renderDots(bloomIntensities.size(),
-               bloomIntensityList->getValueCenterX(biX, biW), biY, biH,
-               static_cast<size_t>(pendingBloomIntensity), std::nullopt);
 
     returnButton->setPosition({ retX, retY }, { retX + retW, retY + retH });
     if (selectedItem == OptionMenuItem::Return) {
@@ -787,60 +723,6 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         return true;
     }
 
-    const auto [beX2, beY2, beW2, beH2] = getNodeLayout(
-        bloomEnabledNode, menuBackgroundNodeX, menuBackgroundNodeY);
-
-    if (mouseX >= beX2 && mouseX <= beX2 + beW2 && mouseY >= beY2 &&
-        mouseY <= beY2 + beH2) {
-        selectedItem = OptionMenuItem::BloomEnabled;
-        if (bloomEnabledCheckbox->isInside(mouseX, mouseY, beX2, beY2, beW2,
-                                           beH2)) {
-            pendingBloomEnabled = !pendingBloomEnabled;
-            updateChangeStatus();
-        }
-        return true;
-    }
-
-    const auto [btX2, btY2, btW2, btH2] = getNodeLayout(
-        bloomThresholdNode, menuBackgroundNodeX, menuBackgroundNodeY);
-
-    if (mouseX >= btX2 && mouseX <= btX2 + btW2 && mouseY >= btY2 &&
-        mouseY <= btY2 + btH2) {
-        selectedItem = OptionMenuItem::BloomThreshold;
-        if (bloomThresholdList->isInsideLeft(mouseX, btX2, btW2)) {
-            bloomThresholdList->selectPrev();
-            pendingBloomThreshold =
-                static_cast<int>(bloomThresholdList->getSelectedIndex());
-            updateChangeStatus();
-        } else if (bloomThresholdList->isInsideRight(mouseX, btX2, btW2)) {
-            bloomThresholdList->selectNext();
-            pendingBloomThreshold =
-                static_cast<int>(bloomThresholdList->getSelectedIndex());
-            updateChangeStatus();
-        }
-        return true;
-    }
-
-    const auto [biX2, biY2, biW2, biH2] = getNodeLayout(
-        bloomIntensityNode, menuBackgroundNodeX, menuBackgroundNodeY);
-
-    if (mouseX >= biX2 && mouseX <= biX2 + biW2 && mouseY >= biY2 &&
-        mouseY <= biY2 + biH2) {
-        selectedItem = OptionMenuItem::BloomIntensity;
-        if (bloomIntensityList->isInsideLeft(mouseX, biX2, biW2)) {
-            bloomIntensityList->selectPrev();
-            pendingBloomIntensity =
-                static_cast<int>(bloomIntensityList->getSelectedIndex());
-            updateChangeStatus();
-        } else if (bloomIntensityList->isInsideRight(mouseX, biX2, biW2)) {
-            bloomIntensityList->selectNext();
-            pendingBloomIntensity =
-                static_cast<int>(bloomIntensityList->getSelectedIndex());
-            updateChangeStatus();
-        }
-        return true;
-    }
-
     return true;
 }
 
@@ -889,12 +771,6 @@ bool OptionLayer::onMouseMoved(const MouseMovedEvent& event) {
         hoveredItem = OptionMenuItem::AntiAliasing;
     } else if (isOver(shadowQualityNode)) {
         hoveredItem = OptionMenuItem::ShadowQuality;
-    } else if (isOver(bloomEnabledNode)) {
-        hoveredItem = OptionMenuItem::BloomEnabled;
-    } else if (isOver(bloomThresholdNode)) {
-        hoveredItem = OptionMenuItem::BloomThreshold;
-    } else if (isOver(bloomIntensityNode)) {
-        hoveredItem = OptionMenuItem::BloomIntensity;
     } else {
         hoveredItem = std::nullopt;
     }
@@ -917,22 +793,17 @@ bool OptionLayer::onWindowResize(const WindowResizeEvent& event) {
         aspectRatioList->setFontSize(fontSize);
         resolutionList->setFontSize(fontSize);
         shadowQualityList->setFontSize(fontSize);
-        bloomThresholdList->setFontSize(fontSize);
-        bloomIntensityList->setFontSize(fontSize);
 
         const auto checkboxSize = static_cast<float>(fontSize);
         antiAliasingCheckbox->setSize(checkboxSize);
         fullScreenCheckbox->setSize(checkboxSize);
         verticalSyncCheckbox->setSize(checkboxSize);
-        bloomEnabledCheckbox->setSize(checkboxSize);
 
         const float maxCycleValueWidth = computeMaxCycleValueWidth();
 
         aspectRatioList->setMaxValueWidth(maxCycleValueWidth);
         resolutionList->setMaxValueWidth(maxCycleValueWidth);
         shadowQualityList->setMaxValueWidth(maxCycleValueWidth);
-        bloomThresholdList->setMaxValueWidth(maxCycleValueWidth);
-        bloomIntensityList->setMaxValueWidth(maxCycleValueWidth);
     }
 
     if (isActive()) {
@@ -1010,19 +881,11 @@ void OptionLayer::applyChanges() {
     }
     Maze::get().setVerticalSync(pendingVsync);
     Maze::get().setFxaaEnabled(pendingFxaa);
-    Maze::get().setBloomEnabled(pendingBloomEnabled);
-    Maze::get().setBloomThreshold(
-        bloomThresholds[static_cast<size_t>(pendingBloomThreshold)]);
-    Maze::get().setBloomIntensity(
-        bloomIntensities[static_cast<size_t>(pendingBloomIntensity)]);
     const auto shadowRes =
         shadowResolutions[static_cast<size_t>(pendingShadowResIndex)];
     Maze::get().getMazeLayer()->setShadowMapRes(shadowRes);
-    saveVideoSettings(
-        saveWidth, saveHeight, pendingFullscreen, pendingVsync, pendingFxaa,
-        shadowRes, pendingBloomEnabled,
-        bloomThresholds[static_cast<size_t>(pendingBloomThreshold)],
-        bloomIntensities[static_cast<size_t>(pendingBloomIntensity)]);
+    saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
+                      pendingFxaa, shadowRes);
 
     syncPendingCheckboxState();
     hasUnappliedChanges = false;
@@ -1030,38 +893,9 @@ void OptionLayer::applyChanges() {
 }
 
 void OptionLayer::syncPendingCheckboxState() {
-    pendingFullscreen   = Maze::get().isFullscreen();
-    pendingVsync        = Maze::get().hasVerticalSync();
-    pendingFxaa         = Maze::get().isFxaaEnabled();
-    pendingBloomEnabled = Maze::get().isBloomEnabled();
-
-    const float curThreshold = Maze::get().getBloomThreshold();
-    const auto  tIt =
-        std::ranges::find_if(bloomThresholds, [curThreshold](float v) {
-            return std::abs(v - curThreshold) < 0.01F;
-        });
-    pendingBloomThreshold =
-        tIt != bloomThresholds.end() ?
-            static_cast<int>(tIt - bloomThresholds.begin()) :
-            1;
-    if (bloomThresholdList) {
-        bloomThresholdList->setSelectedIndex(
-            static_cast<size_t>(pendingBloomThreshold));
-    }
-
-    const float curIntensity = Maze::get().getBloomIntensity();
-    const auto  iIt =
-        std::ranges::find_if(bloomIntensities, [curIntensity](float v) {
-            return std::abs(v - curIntensity) < 0.01F;
-        });
-    pendingBloomIntensity =
-        iIt != bloomIntensities.end() ?
-            static_cast<int>(iIt - bloomIntensities.begin()) :
-            1;
-    if (bloomIntensityList) {
-        bloomIntensityList->setSelectedIndex(
-            static_cast<size_t>(pendingBloomIntensity));
-    }
+    pendingFullscreen = Maze::get().isFullscreen();
+    pendingVsync      = Maze::get().hasVerticalSync();
+    pendingFxaa       = Maze::get().isFxaaEnabled();
 
     const auto currentShadowRes =
         Maze::get().getMazeLayer()->getDirectionalLightShadowMapRes();
@@ -1080,8 +914,7 @@ void OptionLayer::updateChangeStatus() {
     const bool checkboxChanged =
         pendingFullscreen != Maze::get().isFullscreen() ||
         pendingVsync != Maze::get().hasVerticalSync() ||
-        pendingFxaa != Maze::get().isFxaaEnabled() ||
-        pendingBloomEnabled != Maze::get().isBloomEnabled();
+        pendingFxaa != Maze::get().isFxaaEnabled();
 
     const auto window = Maze::get().getWindow();
     const auto curW   = window->getWidth();
@@ -1124,15 +957,7 @@ void OptionLayer::updateChangeStatus() {
         shadowResolutions[static_cast<size_t>(pendingShadowResIndex)] !=
         currentShadowRes;
 
-    const bool bloomThresholdChanged =
-        bloomThresholds[static_cast<size_t>(pendingBloomThreshold)] !=
-        Maze::get().getBloomThreshold();
-    const bool bloomIntensityChanged =
-        bloomIntensities[static_cast<size_t>(pendingBloomIntensity)] !=
-        Maze::get().getBloomIntensity();
-    hasUnappliedChanges = checkboxChanged || resolutionChanged ||
-                          shadowChanged || bloomThresholdChanged ||
-                          bloomIntensityChanged;
+    hasUnappliedChanges = checkboxChanged || resolutionChanged || shadowChanged;
     returnButton->setMessage(hasUnappliedChanges ? applyMessage :
                                                    returnMessage);
 }

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -16,9 +16,6 @@ enum class OptionMenuItem : uint8_t {
     VerticalSync,
     AntiAliasing,
     ShadowQuality,
-    BloomEnabled,
-    BloomThreshold,
-    BloomIntensity,
     Return,
     Count
 };
@@ -47,9 +44,6 @@ private:
     bool pendingVsync          = false;
     bool pendingFxaa           = false;
     int  pendingShadowResIndex = 1;
-    bool pendingBloomEnabled   = true;
-    int  pendingBloomThreshold = 1;
-    int  pendingBloomIntensity = 1;
 
     std::unique_ptr<ui::SelectList> aspectRatioList;
     std::unique_ptr<ui::SelectList> resolutionList;
@@ -57,9 +51,6 @@ private:
     std::unique_ptr<ui::Checkbox>   antiAliasingCheckbox;
     std::unique_ptr<ui::Checkbox>   fullScreenCheckbox;
     std::unique_ptr<ui::Checkbox>   verticalSyncCheckbox;
-    std::unique_ptr<ui::Checkbox>   bloomEnabledCheckbox;
-    std::unique_ptr<ui::SelectList> bloomThresholdList;
-    std::unique_ptr<ui::SelectList> bloomIntensityList;
 
     void renderRowBackground(float x, float y, float w, float h,
                              OptionMenuItem item) const;

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -16,6 +16,9 @@ enum class OptionMenuItem : uint8_t {
     VerticalSync,
     AntiAliasing,
     ShadowQuality,
+    BloomEnabled,
+    BloomThreshold,
+    BloomIntensity,
     Return,
     Count
 };
@@ -44,6 +47,9 @@ private:
     bool pendingVsync          = false;
     bool pendingFxaa           = false;
     int  pendingShadowResIndex = 1;
+    bool pendingBloomEnabled   = true;
+    int  pendingBloomThreshold = 1;
+    int  pendingBloomIntensity = 1;
 
     std::unique_ptr<ui::SelectList> aspectRatioList;
     std::unique_ptr<ui::SelectList> resolutionList;
@@ -51,6 +57,9 @@ private:
     std::unique_ptr<ui::Checkbox>   antiAliasingCheckbox;
     std::unique_ptr<ui::Checkbox>   fullScreenCheckbox;
     std::unique_ptr<ui::Checkbox>   verticalSyncCheckbox;
+    std::unique_ptr<ui::Checkbox>   bloomEnabledCheckbox;
+    std::unique_ptr<ui::SelectList> bloomThresholdList;
+    std::unique_ptr<ui::SelectList> bloomIntensityList;
 
     void renderRowBackground(float x, float y, float w, float h,
                              OptionMenuItem item) const;

--- a/game/src/maze.cpp
+++ b/game/src/maze.cpp
@@ -32,6 +32,12 @@ bool Maze::onUserCreate() {
     splashScreenLayer->setActive(true);
 
     setFxaaEnabled(sponge::core::Settings::getBool("video.fxaa", true));
+    setBloomEnabled(
+        sponge::core::Settings::getBool("video.bloomEnabled", true));
+    setBloomThreshold(std::stof(
+        sponge::core::Settings::getString("video.bloomThreshold", "0.8")));
+    setBloomIntensity(std::stof(
+        sponge::core::Settings::getString("video.bloomIntensity", "1.0")));
 
     return true;
 }

--- a/game/src/maze.hpp
+++ b/game/src/maze.hpp
@@ -62,6 +62,30 @@ public:
         mazeLayer->setFxaaEnabled(val);
     }
 
+    bool isBloomEnabled() const {
+        return mazeLayer->isBloomEnabled();
+    }
+
+    void setBloomEnabled(bool val) {
+        mazeLayer->setBloomEnabled(val);
+    }
+
+    float getBloomThreshold() const {
+        return mazeLayer->getBloomThreshold();
+    }
+
+    void setBloomThreshold(float val) {
+        mazeLayer->setBloomThreshold(val);
+    }
+
+    float getBloomIntensity() const {
+        return mazeLayer->getBloomIntensity();
+    }
+
+    void setBloomIntensity(float val) {
+        mazeLayer->setBloomIntensity(val);
+    }
+
     void exit() {
         isRunning = false;
     }

--- a/game/src/thread/mazeframe.hpp
+++ b/game/src/thread/mazeframe.hpp
@@ -38,6 +38,7 @@ struct MazeRenderFrame {
     // Game objects: model matrices and resolved model handles. Handles are
     // resolved once at load; no per-frame name lookup.
     std::vector<glm::mat4> objectModelMatrices;
+    std::vector<glm::vec3> objectEmissives;
     std::vector<std::shared_ptr<sponge::platform::opengl::scene::Model>>
         objectModels;
 

--- a/game/src/thread/mazeframe.hpp
+++ b/game/src/thread/mazeframe.hpp
@@ -42,7 +42,10 @@ struct MazeRenderFrame {
         objectModels;
 
     // Post-processing
-    bool fxaaEnabled{ false };
+    bool  fxaaEnabled{ false };
+    bool  bloomEnabled{ false };
+    float bloomThreshold{ 0.8F };
+    float bloomIntensity{ 1.0F };
 };
 
 }  // namespace game::thread

--- a/sponge/CMakeLists.txt
+++ b/sponge/CMakeLists.txt
@@ -3,6 +3,7 @@ include(GNUInstallDirs)
 
 file(
         GLOB HEADER_FILES
+        CONFIGURE_DEPENDS
         LIST_DIRECTORIES false
         src/*.hpp
         src/core/*.hpp
@@ -16,6 +17,7 @@ file(
 
 file(
         GLOB SOURCE_FILES
+        CONFIGURE_DEPENDS
         LIST_DIRECTORIES false
         src/core/*.cpp src/event/*.cpp src/input/*.cpp src/layer/*.cpp
         src/logging/*.cpp src/scene/*.cpp src/thread/*.cpp)
@@ -24,12 +26,14 @@ file(
 message(STATUS "Including OpenGL platform files")
 file(
         GLOB OPENGL_HEADERS
+        CONFIGURE_DEPENDS
         LIST_DIRECTORIES false
         src/platform/opengl/debug/*.hpp src/platform/opengl/renderer/*.hpp
         src/platform/opengl/scene/*.hpp)
 list(APPEND HEADER_FILES ${OPENGL_HEADERS})
 file(
         GLOB OPENGL_SOURCES
+        CONFIGURE_DEPENDS
         LIST_DIRECTORIES false
         deps/glad2/src/gl.c src/platform/opengl/debug/*.cpp
         src/platform/opengl/renderer/*.cpp src/platform/opengl/scene/*.cpp)

--- a/sponge/src/platform/opengl/scene/bloom.cpp
+++ b/sponge/src/platform/opengl/scene/bloom.cpp
@@ -173,7 +173,7 @@ void Bloom::renderQuad() const {
     vao->unbind();
 }
 
-void Bloom::process() const {
+void Bloom::process(const float threshold) const {
     glDisable(GL_DEPTH_TEST);
     glActiveTexture(GL_TEXTURE0);
 
@@ -216,11 +216,12 @@ void Bloom::process() const {
     }
     upShader->unbind();
 
+    glViewport(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height));
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glEnable(GL_DEPTH_TEST);
 }
 
-void Bloom::apply() const {
+void Bloom::apply(const float intensity) const {
     glDisable(GL_DEPTH_TEST);
 
     compositeShader->bind();

--- a/sponge/src/platform/opengl/scene/bloom.cpp
+++ b/sponge/src/platform/opengl/scene/bloom.cpp
@@ -1,0 +1,253 @@
+#include "platform/opengl/scene/bloom.hpp"
+
+#include "logging/log.hpp"
+#include "platform/opengl/renderer/assetmanager.hpp"
+#include "platform/opengl/renderer/gl.hpp"
+
+#include <array>
+
+namespace {
+constexpr std::array quadVertices = {
+    -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
+    -1.F, 1.F,  0.F, 1.F, 1.F, 1.F,  1.F, 1.F,
+};
+constexpr uint32_t quadVertexCount = 4;
+constexpr uint32_t quadStride      = 4 * sizeof(float);
+}  // namespace
+
+namespace sponge::platform::opengl::scene {
+using renderer::AssetManager;
+
+Bloom::Bloom(const uint32_t width, const uint32_t height) :
+    width(width), height(height) {
+    initialize();
+}
+
+Bloom::~Bloom() {
+    destroyFramebuffers();
+}
+
+void Bloom::initialize() {
+    auto makeShader = [](std::string_view name, const char* frag) {
+        return AssetManager::createShader(renderer::ShaderCreateInfo{
+            .name               = std::string(name),
+            .vertexShaderPath   = "/shaders/glsl/blur.vert.glsl",
+            .fragmentShaderPath = frag,
+        });
+    };
+
+    extractShader =
+        makeShader(extractShaderName, "/shaders/glsl/bloom_extract.frag.glsl");
+    downShader =
+        makeShader(downShaderName, "/shaders/glsl/bloom_down.frag.glsl");
+    upShader = makeShader(upShaderName, "/shaders/glsl/bloom_up.frag.glsl");
+    compositeShader = makeShader(compositeShaderName,
+                                 "/shaders/glsl/bloom_composite.frag.glsl");
+
+    vao = renderer::VertexArray::create();
+    vao->bind();
+    vbo = std::make_unique<renderer::VertexBuffer>(quadVertices.data(),
+                                                   sizeof(quadVertices));
+    vbo->bind();
+
+    // blur.vert.glsl uses layout(location=0) aPos, layout(location=1)
+    // aTexCoords
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, quadStride,
+                          reinterpret_cast<const void*>(0));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, quadStride,
+                          reinterpret_cast<const void*>(2 * sizeof(float)));
+
+    vao->unbind();
+
+    createFramebuffers();
+}
+
+void Bloom::createFramebuffers() {
+    // Scene capture FBO at full resolution (HDR)
+    glGenTextures(1, &sceneColorTexture);
+    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
+                 static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    glGenRenderbuffers(1, &sceneDepthRbo);
+    glBindRenderbuffer(GL_RENDERBUFFER, sceneDepthRbo);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24,
+                          static_cast<GLsizei>(width),
+                          static_cast<GLsizei>(height));
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+    glGenFramebuffers(1, &sceneFbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           sceneColorTexture, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                              GL_RENDERBUFFER, sceneDepthRbo);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        SPONGE_GL_CRITICAL("Bloom scene framebuffer is not complete!");
+    }
+
+    // Mip-chain FBOs: level i at (width >> (i+1)) x (height >> (i+1))
+    glGenFramebuffers(numLevels, downFbos.data());
+    glGenTextures(numLevels, downTextures.data());
+    glGenFramebuffers(numLevels, upFbos.data());
+    glGenTextures(numLevels, upTextures.data());
+
+    auto makeMipTex = [](uint32_t tex, GLsizei w, GLsizei h) {
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, w, h, 0, GL_RGB, GL_FLOAT,
+                     nullptr);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glBindTexture(GL_TEXTURE_2D, 0);
+    };
+
+    for (int i = 0; i < numLevels; i++) {
+        const auto w = static_cast<GLsizei>(width >> (i + 1));
+        const auto h = static_cast<GLsizei>(height >> (i + 1));
+
+        makeMipTex(downTextures[i], w, h);
+        glBindFramebuffer(GL_FRAMEBUFFER, downFbos[i]);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                               GL_TEXTURE_2D, downTextures[i], 0);
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) !=
+            GL_FRAMEBUFFER_COMPLETE) {
+            SPONGE_GL_CRITICAL("Bloom down framebuffer {} is not complete!", i);
+        }
+
+        makeMipTex(upTextures[i], w, h);
+        glBindFramebuffer(GL_FRAMEBUFFER, upFbos[i]);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                               GL_TEXTURE_2D, upTextures[i], 0);
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) !=
+            GL_FRAMEBUFFER_COMPLETE) {
+            SPONGE_GL_CRITICAL("Bloom up framebuffer {} is not complete!", i);
+        }
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void Bloom::destroyFramebuffers() {
+    if (sceneFbo != 0) {
+        glDeleteFramebuffers(1, &sceneFbo);
+        sceneFbo = 0;
+    }
+    if (sceneColorTexture != 0) {
+        glDeleteTextures(1, &sceneColorTexture);
+        sceneColorTexture = 0;
+    }
+    if (sceneDepthRbo != 0) {
+        glDeleteRenderbuffers(1, &sceneDepthRbo);
+        sceneDepthRbo = 0;
+    }
+    glDeleteFramebuffers(numLevels, downFbos.data());
+    glDeleteTextures(numLevels, downTextures.data());
+    glDeleteFramebuffers(numLevels, upFbos.data());
+    glDeleteTextures(numLevels, upTextures.data());
+    downFbos.fill(0);
+    downTextures.fill(0);
+    upFbos.fill(0);
+    upTextures.fill(0);
+}
+
+void Bloom::begin() const {
+    glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
+}
+
+void Bloom::end() const {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void Bloom::renderQuad() const {
+    vao->bind();
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
+    vao->unbind();
+}
+
+void Bloom::process() const {
+    glDisable(GL_DEPTH_TEST);
+    glActiveTexture(GL_TEXTURE0);
+
+    // Extract bright pixels → down[0] at (w/2, h/2)
+    glBindFramebuffer(GL_FRAMEBUFFER, downFbos[0]);
+    glViewport(0, 0, static_cast<GLsizei>(width >> 1),
+               static_cast<GLsizei>(height >> 1));
+    extractShader->bind();
+    extractShader->setInteger("scene", 0);
+    extractShader->setFloat("threshold", threshold);
+    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
+    renderQuad();
+    extractShader->unbind();
+
+    // Downsample: down[i-1] → down[i]
+    downShader->bind();
+    downShader->setInteger("image", 0);
+    downShader->setFloat("offset", 1.0F);
+    for (int i = 1; i < numLevels; i++) {
+        glBindFramebuffer(GL_FRAMEBUFFER, downFbos[i]);
+        glViewport(0, 0, static_cast<GLsizei>(width >> (i + 1)),
+                   static_cast<GLsizei>(height >> (i + 1)));
+        glBindTexture(GL_TEXTURE_2D, downTextures[i - 1]);
+        renderQuad();
+    }
+    downShader->unbind();
+
+    // Upsample: from deepest down level back up to up[0]
+    upShader->bind();
+    upShader->setInteger("image", 0);
+    upShader->setFloat("offset", 1.0F);
+    for (int i = numLevels - 1; i >= 0; i--) {
+        glBindFramebuffer(GL_FRAMEBUFFER, upFbos[i]);
+        glViewport(0, 0, static_cast<GLsizei>(width >> (i + 1)),
+                   static_cast<GLsizei>(height >> (i + 1)));
+        const uint32_t src =
+            (i == numLevels - 1) ? downTextures[i] : upTextures[i + 1];
+        glBindTexture(GL_TEXTURE_2D, src);
+        renderQuad();
+    }
+    upShader->unbind();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glEnable(GL_DEPTH_TEST);
+}
+
+void Bloom::apply() const {
+    glDisable(GL_DEPTH_TEST);
+
+    compositeShader->bind();
+    compositeShader->setInteger("scene", 0);
+    compositeShader->setInteger("bloomTex", 1);
+    compositeShader->setFloat("intensity", intensity);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, upTextures[0]);
+
+    renderQuad();
+    compositeShader->unbind();
+
+    glActiveTexture(GL_TEXTURE0);
+    glEnable(GL_DEPTH_TEST);
+}
+
+void Bloom::resize(const uint32_t newWidth, const uint32_t newHeight) {
+    if (width == newWidth && height == newHeight) {
+        return;
+    }
+    width  = newWidth;
+    height = newHeight;
+    destroyFramebuffers();
+    createFramebuffers();
+}
+
+}  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/bloom.hpp
+++ b/sponge/src/platform/opengl/scene/bloom.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "platform/opengl/renderer/shader.hpp"
+#include "platform/opengl/renderer/vertexarray.hpp"
+#include "platform/opengl/renderer/vertexbuffer.hpp"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace sponge::platform::opengl::scene {
+
+class Bloom {
+public:
+    Bloom() = delete;
+    Bloom(uint32_t width, uint32_t height);
+    ~Bloom();
+
+    Bloom(const Bloom&)            = delete;
+    Bloom& operator=(const Bloom&) = delete;
+
+    void begin() const;
+    void end() const;
+    void process() const;
+    void apply() const;
+
+    uint32_t getSceneTexture() const {
+        return sceneColorTexture;
+    }
+
+    uint32_t getBloomTexture() const {
+        return upTextures[0];
+    }
+
+    void resize(uint32_t newWidth, uint32_t newHeight);
+
+    bool isEnabled() const {
+        return enabled;
+    }
+
+    void setEnabled(bool val) {
+        enabled = val;
+    }
+
+    float getThreshold() const {
+        return threshold;
+    }
+
+    void setThreshold(float val) {
+        threshold = val;
+    }
+
+    float getIntensity() const {
+        return intensity;
+    }
+
+    void setIntensity(float val) {
+        intensity = val;
+    }
+
+private:
+    static constexpr std::string_view extractShaderName   = "bloom_extract";
+    static constexpr std::string_view downShaderName      = "bloom_down";
+    static constexpr std::string_view upShaderName        = "bloom_up";
+    static constexpr std::string_view compositeShaderName = "bloom_composite";
+    static constexpr int              numLevels           = 5;
+
+    std::shared_ptr<renderer::Shader>       extractShader;
+    std::shared_ptr<renderer::Shader>       downShader;
+    std::shared_ptr<renderer::Shader>       upShader;
+    std::shared_ptr<renderer::Shader>       compositeShader;
+    std::unique_ptr<renderer::VertexArray>  vao;
+    std::unique_ptr<renderer::VertexBuffer> vbo;
+
+    uint32_t sceneFbo          = 0;
+    uint32_t sceneColorTexture = 0;
+    uint32_t sceneDepthRbo     = 0;
+
+    std::array<uint32_t, numLevels> downFbos{};
+    std::array<uint32_t, numLevels> downTextures{};
+    std::array<uint32_t, numLevels> upFbos{};
+    std::array<uint32_t, numLevels> upTextures{};
+
+    uint32_t width     = 0;
+    uint32_t height    = 0;
+    bool     enabled   = true;
+    float    threshold = 0.8F;
+    float    intensity = 1.0F;
+
+    void initialize();
+    void createFramebuffers();
+    void destroyFramebuffers();
+    void renderQuad() const;
+};
+
+}  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/bloom.hpp
+++ b/sponge/src/platform/opengl/scene/bloom.hpp
@@ -22,8 +22,8 @@ public:
 
     void begin() const;
     void end() const;
-    void process() const;
-    void apply() const;
+    void process(float threshold) const;
+    void apply(float intensity) const;
 
     uint32_t getSceneTexture() const {
         return sceneColorTexture;

--- a/sponge/src/platform/opengl/scene/bloom.hpp
+++ b/sponge/src/platform/opengl/scene/bloom.hpp
@@ -35,30 +35,6 @@ public:
 
     void resize(uint32_t newWidth, uint32_t newHeight);
 
-    bool isEnabled() const {
-        return enabled;
-    }
-
-    void setEnabled(bool val) {
-        enabled = val;
-    }
-
-    float getThreshold() const {
-        return threshold;
-    }
-
-    void setThreshold(float val) {
-        threshold = val;
-    }
-
-    float getIntensity() const {
-        return intensity;
-    }
-
-    void setIntensity(float val) {
-        intensity = val;
-    }
-
 private:
     static constexpr std::string_view extractShaderName   = "bloom_extract";
     static constexpr std::string_view downShaderName      = "bloom_down";
@@ -82,11 +58,8 @@ private:
     std::array<uint32_t, numLevels> upFbos{};
     std::array<uint32_t, numLevels> upTextures{};
 
-    uint32_t width     = 0;
-    uint32_t height    = 0;
-    bool     enabled   = true;
-    float    threshold = 0.8F;
-    float    intensity = 1.0F;
+    uint32_t width  = 0;
+    uint32_t height = 0;
 
     void initialize();
     void createFramebuffers();

--- a/sponge/src/platform/opengl/scene/fxaa.cpp
+++ b/sponge/src/platform/opengl/scene/fxaa.cpp
@@ -64,6 +64,7 @@ void FXAA::initialize() {
     }
 
     shader->setInteger("screenTexture", 0);
+    shader->setFloat("bloomIntensity", 0.0f);
 
     shader->unbind();
     vao->unbind();
@@ -149,6 +150,32 @@ void FXAA::apply() const {
     glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
     vao->unbind();
 
+    shader->unbind();
+
+    glEnable(GL_DEPTH_TEST);
+}
+
+void FXAA::applyWithBloom(const uint32_t sceneTexId, const uint32_t bloomTexId,
+                          const float intensity) const {
+    glDisable(GL_DEPTH_TEST);
+
+    shader->bind();
+    shader->setFloat2("rcpFrame", glm::vec2(1.0f / static_cast<float>(width),
+                                            1.0f / static_cast<float>(height)));
+    shader->setInteger("screenTexture", 0);
+    shader->setInteger("bloomTex", 1);
+    shader->setFloat("bloomIntensity", intensity);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, sceneTexId);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, bloomTexId);
+
+    vao->bind();
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
+    vao->unbind();
+
+    glActiveTexture(GL_TEXTURE0);
     shader->unbind();
 
     glEnable(GL_DEPTH_TEST);

--- a/sponge/src/platform/opengl/scene/fxaa.cpp
+++ b/sponge/src/platform/opengl/scene/fxaa.cpp
@@ -64,7 +64,7 @@ void FXAA::initialize() {
     }
 
     shader->setInteger("screenTexture", 0);
-    shader->setFloat("bloomIntensity", 0.0f);
+    shader->setInteger("bloomTex", 1);
 
     shader->unbind();
     vao->unbind();
@@ -162,8 +162,6 @@ void FXAA::applyWithBloom(const uint32_t sceneTexId, const uint32_t bloomTexId,
     shader->bind();
     shader->setFloat2("rcpFrame", glm::vec2(1.0f / static_cast<float>(width),
                                             1.0f / static_cast<float>(height)));
-    shader->setInteger("screenTexture", 0);
-    shader->setInteger("bloomTex", 1);
     shader->setFloat("bloomIntensity", intensity);
 
     glActiveTexture(GL_TEXTURE0);

--- a/sponge/src/platform/opengl/scene/fxaa.cpp
+++ b/sponge/src/platform/opengl/scene/fxaa.cpp
@@ -142,6 +142,7 @@ void FXAA::apply() const {
     shader->bind();
     shader->setFloat2("rcpFrame", glm::vec2(1.0f / static_cast<float>(width),
                                             1.0f / static_cast<float>(height)));
+    shader->setFloat("bloomIntensity", 0.0f);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, colorTexture);

--- a/sponge/src/platform/opengl/scene/fxaa.hpp
+++ b/sponge/src/platform/opengl/scene/fxaa.hpp
@@ -22,6 +22,8 @@ public:
     void begin() const;
     void end() const;
     void apply() const;
+    void applyWithBloom(uint32_t sceneTexId, uint32_t bloomTexId,
+                        float intensity) const;
 
     void resize(uint32_t newWidth, uint32_t newHeight);
 

--- a/sponge/src/sponge.hpp
+++ b/sponge/src/sponge.hpp
@@ -38,6 +38,7 @@
 #include "platform/opengl/renderer/vertexarray.hpp"
 #include "platform/opengl/renderer/vertexbuffer.hpp"
 #include "platform/opengl/scene/bitmapfont.hpp"
+#include "platform/opengl/scene/bloom.hpp"
 #include "platform/opengl/scene/cube.hpp"
 #include "platform/opengl/scene/fxaa.hpp"
 #include "platform/opengl/scene/mesh.hpp"


### PR DESCRIPTION
## Summary

- Adds a Dual Kawase bloom post-processing effect with a 5-level downsample/upsample mip chain (`Bloom` class in `sponge/src/platform/opengl/scene/`)
- Extends FXAA with `applyWithBloom()` so bloom and FXAA can composite in a single pass; all four render paths (bloom+FXAA, bloom only, FXAA only, neither) are wired in `MazeLayer::onRender()`
- Exposes bloom controls (enabled, threshold, intensity) in the Options screen with settings persistence; adds `emissive` field to `GameObject` so individual objects can exceed the bloom threshold — cube3 ships with a warm orange-white glow
- Fixes `file(GLOB)` calls in both CMakeLists with `CONFIGURE_DEPENDS` so new source files are picked up automatically without a manual reconfigure

## Implementation notes

- `process(float threshold)` and `apply(float intensity)` take parameters rather than reading members, keeping the render thread free of data races with the update thread
- Bloom FBOs use `GL_RGB16F` for HDR headroom; viewport is restored to full resolution after the mip-chain passes
- Emissive is added to PBR output after Reinhard tone mapping so values land in the HDR scene FBO above the extraction threshold