### PR TITLE
Clustered forward lighting

### DIFF
--- a/assets/shaders/slang/bloom.slang
+++ b/assets/shaders/slang/bloom.slang
@@ -34,12 +34,15 @@ float4 downFragMain(FSInput input) : SV_Target
 // Progressive upsample: blend the blurred coarse level with this level's
 // downsample so no single coarse mip dominates (its texel structure would
 // show as straight-edged rectangles). accumulate=0 at the deepest level.
+// SCATTER weights the coarse chain: higher = wider, softer glow.
+static const float SCATTER = 0.7;
+
 [shader("fragment")]
 float4 upFragMain(FSInput input) : SV_Target
 {
     float3 blurred = kawaseUp(image, input.texCoords, offset).rgb;
     float3 down    = bloomTex.Sample(input.texCoords).rgb;
-    return float4(lerp(blurred, (blurred + down) * 0.5, accumulate), 1.0);
+    return float4(lerp(blurred, lerp(down, blurred, SCATTER), accumulate), 1.0);
 }
 
 [shader("fragment")]

--- a/assets/shaders/slang/bloom.slang
+++ b/assets/shaders/slang/bloom.slang
@@ -1,11 +1,13 @@
 // bloom.slang — brightness extraction, Dual Kawase bloom pipeline, composite
 #include "include/kawase.slang"
+#include "include/dither.slang"
 
 [[vk::binding(0)]] Sampler2D<float4> image;
 [[vk::binding(1)]] Sampler2D<float4> bloomTex;
 uniform float threshold;
 uniform float offset;
 uniform float intensity;
+uniform float accumulate;
 
 struct FSInput { float2 texCoords : TEXCOORD0; }
 
@@ -14,7 +16,13 @@ float4 extractFragMain(FSInput input) : SV_Target
 {
     float3 color      = image.Sample(input.texCoords).rgb;
     float  brightness = dot(color, float3(0.2126, 0.7152, 0.0722));
-    return brightness > threshold ? float4(color, 1.0) : float4(0.0, 0.0, 0.0, 1.0);
+    // Soft knee (Karis) — a hard threshold leaves energy cliffs that survive
+    // the blur chain as visible mip-texel edges.
+    float knee = threshold * 0.5;
+    float soft = clamp(brightness - threshold + knee, 0.0, 2.0 * knee);
+    soft       = soft * soft / (4.0 * knee + 1e-4);
+    float contribution = max(soft, brightness - threshold);
+    return float4(color * (contribution / max(brightness, 1e-4)), 1.0);
 }
 
 [shader("fragment")]
@@ -23,16 +31,21 @@ float4 downFragMain(FSInput input) : SV_Target
     return float4(kawaseDown(image, input.texCoords, offset).rgb, 1.0);
 }
 
+// Progressive upsample: blend the blurred coarse level with this level's
+// downsample so no single coarse mip dominates (its texel structure would
+// show as straight-edged rectangles). accumulate=0 at the deepest level.
 [shader("fragment")]
 float4 upFragMain(FSInput input) : SV_Target
 {
-    return float4(kawaseUp(image, input.texCoords, offset).rgb, 1.0);
+    float3 blurred = kawaseUp(image, input.texCoords, offset).rgb;
+    float3 down    = bloomTex.Sample(input.texCoords).rgb;
+    return float4(lerp(blurred, (blurred + down) * 0.5, accumulate), 1.0);
 }
 
 [shader("fragment")]
-float4 compositeFragMain(FSInput input) : SV_Target
+float4 compositeFragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target
 {
     float3 color = image.Sample(input.texCoords).rgb;
     float3 bloom = bloomTex.Sample(input.texCoords).rgb;
-    return float4(color + bloom * intensity, 1.0);
+    return float4(dither8(color + bloom * intensity, fragCoord.xy), 1.0);
 }

--- a/assets/shaders/slang/cluster_assign.slang
+++ b/assets/shaders/slang/cluster_assign.slang
@@ -1,0 +1,70 @@
+// cluster_assign.slang — volume tiled forward light culling (reference; see cluster_assign.comp.glsl)
+// Note: compiled as hand-written GLSL; slangc emits unsupported extensions on this driver.
+#include "include/clustered.slang"
+
+struct PointLightGPU
+{
+    float3 color;
+    float  pad0;
+    float3 position;       // world-space
+    int    attenuationIndex;
+    float4 pad1;
+}
+
+// std430-compatible: explicit padding so float3 → 16-byte slot.
+// Must match ClusterAABB in clusteredlights.hpp.
+struct ClusterAABB
+{
+    float3 minBounds;
+    float  padMin;
+    float3 maxBounds;
+    float  padMax;
+}
+
+// Must match ComputeParams in clusteredlights.hpp.
+struct ComputeParams
+{
+    float4x4 view;
+    float    near;
+    float    far;
+    int      numLights;
+    int      pad;
+}
+
+[[vk::binding(3)]] StructuredBuffer<PointLightGPU>  lightBuffer;    // read
+[[vk::binding(4)]] RWStructuredBuffer<uint2>         lightGrid;      // write
+[[vk::binding(5)]] RWStructuredBuffer<uint>          lightIndices;   // write
+[[vk::binding(6)]] StructuredBuffer<ClusterAABB>     clusterAABBs;   // read
+[[vk::binding(7)]] StructuredBuffer<ComputeParams>   computeParams;  // read
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void csMain(uint3 tid : SV_DispatchThreadID)
+{
+    int ci = int(tid.x);
+    if (ci >= TILES_X * TILES_Y * TILES_Z) {
+        return;
+    }
+
+    ComputeParams p    = computeParams[0];
+    ClusterAABB   aabb = clusterAABBs[ci];
+    uint          base = uint(ci) * uint(MAX_LIGHTS_PER_CLUSTER);
+    int           count = 0;
+
+    for (int i = 0; i < p.numLights && count < MAX_LIGHTS_PER_CLUSTER; ++i)
+    {
+        float3 vsPos = mul(p.view, float4(lightBuffer[i].position, 1.0)).xyz;
+
+        int   aidx = clamp(lightBuffer[i].attenuationIndex, 0, 10);
+        float r    = attenuationRadius[aidx];
+
+        float3 closest = clamp(vsPos, aabb.minBounds, aabb.maxBounds);
+        if (length(vsPos - closest) <= r)
+        {
+            lightIndices[base + uint(count)] = uint(i);
+            count++;
+        }
+    }
+
+    lightGrid[ci] = uint2(base, uint(count));
+}

--- a/assets/shaders/slang/cluster_assign.slang
+++ b/assets/shaders/slang/cluster_assign.slang
@@ -21,14 +21,17 @@ struct ClusterAABB
     float  padMax;
 }
 
-// Must match ComputeParams in clusteredlights.hpp.
+// Must match ComputeParams in clusteredlights.hpp. View passed as explicit
+// rows — SSBO matrix layout on nested structs is driver-inconsistent.
 struct ComputeParams
 {
-    float4x4 view;
-    float    near;
-    float    far;
-    int      numLights;
-    int      pad;
+    float4 viewRow0;
+    float4 viewRow1;
+    float4 viewRow2;
+    float  near;
+    float  far;
+    int    numLights;
+    int    pad;
 }
 
 [[vk::binding(3)]] StructuredBuffer<PointLightGPU>  lightBuffer;    // read
@@ -53,7 +56,9 @@ void csMain(uint3 tid : SV_DispatchThreadID)
 
     for (int i = 0; i < p.numLights && count < MAX_LIGHTS_PER_CLUSTER; ++i)
     {
-        float3 vsPos = mul(p.view, float4(lightBuffer[i].position, 1.0)).xyz;
+        float4 wp    = float4(lightBuffer[i].position, 1.0);
+        float3 vsPos = float3(dot(p.viewRow0, wp), dot(p.viewRow1, wp),
+                              dot(p.viewRow2, wp));
 
         int   aidx = clamp(lightBuffer[i].attenuationIndex, 0, 10);
         float r    = attenuationRadius[aidx];

--- a/assets/shaders/slang/cluster_assign.slang
+++ b/assets/shaders/slang/cluster_assign.slang
@@ -31,7 +31,7 @@ struct ComputeParams
     float  near;
     float  far;
     int    numLights;
-    int    pad;
+    int    numClusters;
 }
 
 [[vk::binding(3)]] StructuredBuffer<PointLightGPU>  lightBuffer;    // read
@@ -39,20 +39,29 @@ struct ComputeParams
 [[vk::binding(5)]] RWStructuredBuffer<uint>          lightIndices;   // write
 [[vk::binding(6)]] StructuredBuffer<ClusterAABB>     clusterAABBs;   // read
 [[vk::binding(7)]] StructuredBuffer<ComputeParams>   computeParams;  // read
+[[vk::binding(8)]] StructuredBuffer<uint>            tileFlags;      // read
 
 [shader("compute")]
 [numthreads(64, 1, 1)]
 void csMain(uint3 tid : SV_DispatchThreadID)
 {
-    int ci = int(tid.x);
-    if (ci >= TILES_X * TILES_Y * TILES_Z) {
+    int           ci = int(tid.x);
+    ComputeParams p  = computeParams[0];
+    if (ci >= p.numClusters) {
         return;
     }
 
-    ComputeParams p    = computeParams[0];
-    ClusterAABB   aabb = clusterAABBs[ci];
-    uint          base = uint(ci) * uint(MAX_LIGHTS_PER_CLUSTER);
-    int           count = 0;
+    uint base = uint(ci) * uint(MAX_LIGHTS_PER_CLUSTER);
+
+    // Active-tile culling: skip clusters no visible fragment landed in
+    // (flags written by the depth prepass).
+    if (tileFlags[ci] == 0U) {
+        lightGrid[ci] = uint2(base, 0U);
+        return;
+    }
+
+    ClusterAABB aabb  = clusterAABBs[ci];
+    int         count = 0;
 
     for (int i = 0; i < p.numLights && count < MAX_LIGHTS_PER_CLUSTER; ++i)
     {

--- a/assets/shaders/slang/depthprepass.slang
+++ b/assets/shaders/slang/depthprepass.slang
@@ -1,0 +1,16 @@
+// depthprepass.slang — camera-space depth-only prepass
+uniform float4x4 mvp;
+
+struct VSInput  { float3 position : POSITION; }
+struct VSOutput { float4 pos : SV_Position; }
+
+[shader("vertex")]
+VSOutput vertMain(VSInput input)
+{
+    VSOutput o;
+    o.pos = mul(mvp, float4(input.position, 1.0));
+    return o;
+}
+
+[shader("fragment")]
+void fragMain() {}

--- a/assets/shaders/slang/depthprepass.slang
+++ b/assets/shaders/slang/depthprepass.slang
@@ -1,16 +1,45 @@
-// depthprepass.slang — camera-space depth-only prepass
+// depthprepass.slang — camera-space depth-only prepass + active-tile marking
+#include "include/clustered.slang"
+
 uniform float4x4 mvp;
+uniform float4x4 modelView;
+
+// Fragment-stage params in a named ConstantBuffer so the vertex and fragment
+// loose-uniform blocks cannot disagree (see uniforms.slang).
+struct PrepassParams
+{
+    float2 screenSize;
+    float  clusterNear;
+    float  clusterFar;
+    int    tilesZ;
+};
+[[vk::binding(2)]] ConstantBuffer<PrepassParams> prepassParams;
+
+// Active volume-tile flags, one uint per cluster — consumed by
+// cluster_assign.slang so light assignment skips clusters with no fragments.
+[[vk::binding(8)]] RWStructuredBuffer<uint> tileFlags;
 
 struct VSInput  { float3 position : POSITION; }
-struct VSOutput { float4 pos : SV_Position; }
+struct VSOutput
+{
+    float4 pos   : SV_Position;
+    float  viewZ : TEXCOORD0;  // positive view-space depth
+}
 
 [shader("vertex")]
 VSOutput vertMain(VSInput input)
 {
     VSOutput o;
-    o.pos = mul(mvp, float4(input.position, 1.0));
+    o.pos   = mul(mvp, float4(input.position, 1.0));
+    o.viewZ = -mul(modelView, float4(input.position, 1.0)).z;
     return o;
 }
 
 [shader("fragment")]
-void fragMain() {}
+void fragMain(VSOutput input, float4 fragCoord : SV_Position)
+{
+    int ci = clusterIndex(fragCoord.xy, input.viewZ,
+                          prepassParams.screenSize, prepassParams.clusterNear,
+                          prepassParams.clusterFar, prepassParams.tilesZ);
+    tileFlags[ci] = 1U;
+}

--- a/assets/shaders/slang/fxaa.slang
+++ b/assets/shaders/slang/fxaa.slang
@@ -1,5 +1,6 @@
 // fxaa.slang — fullscreen quad vertex + FXAA 3.11 (quality preset 12) + bloom overlay
 // FXAA based on Timothy Lottes / NVIDIA, adapted to Slang.
+#include "include/dither.slang"
 
 struct VSInput
 {
@@ -155,12 +156,13 @@ float4 fxaaPass(float2 uv)
 struct FSInput { float2 texCoords : TEXCOORD0; }
 
 [shader("fragment")]
-float4 fragMain(FSInput input) : SV_Target
+float4 fragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target
 {
     float4 color = fxaaPass(input.texCoords);
     if (bloomIntensity > 0.0)
     {
         color.rgb += bloomTex.Sample(input.texCoords).rgb * bloomIntensity;
     }
+    color.rgb = dither8(color.rgb, fragCoord.xy);
     return color;
 }

--- a/assets/shaders/slang/fxaa.slang
+++ b/assets/shaders/slang/fxaa.slang
@@ -31,7 +31,7 @@ uniform float     bloomIntensity;
 static const float FXAA_SUBPIX             = 0.75;
 static const float FXAA_EDGE_THRESHOLD     = 0.125;
 static const float FXAA_EDGE_THRESHOLD_MIN = 0.0625;
-static const float kSteps[5]               = { 1.5, 2.0, 2.0, 2.0, 8.0 };
+static const float steps[5]               = { 1.5, 2.0, 2.0, 2.0, 8.0 };
 
 // Green-channel-weighted luma (Lottes formula — blue excluded)
 float fxaaLuma(float3 rgb) { return rgb.y * (0.587 / 0.299) + rgb.x; }
@@ -102,8 +102,8 @@ float4 fxaaPass(float2 uv)
 
     float2 offNP = horzSpan ? float2(rcpFrame.x, 0.0) : float2(0.0, rcpFrame.y);
 
-    float2 posN      = posP - offNP * kSteps[0];
-    float2 posPos    = posP + offNP * kSteps[0];
+    float2 posN      = posP - offNP * steps[0];
+    float2 posPos    = posP + offNP * steps[0];
     float  lumaEndN  = fxaaLuma(screenTexture.Sample(posN  ).rgb) - localAvg;
     float  lumaEndP  = fxaaLuma(screenTexture.Sample(posPos).rgb) - localAvg;
     bool   doneN     = abs(lumaEndN) >= gradientScaled;
@@ -112,12 +112,12 @@ float4 fxaaPass(float2 uv)
     for (int i = 1; i < 5; i++)
     {
         if (!doneN) {
-            posN    -= offNP * kSteps[i];
+            posN    -= offNP * steps[i];
             lumaEndN = fxaaLuma(screenTexture.Sample(posN  ).rgb) - localAvg;
             doneN    = abs(lumaEndN) >= gradientScaled;
         }
         if (!doneP) {
-            posPos  += offNP * kSteps[i];
+            posPos  += offNP * steps[i];
             lumaEndP = fxaaLuma(screenTexture.Sample(posPos).rgb) - localAvg;
             doneP    = abs(lumaEndP) >= gradientScaled;
         }

--- a/assets/shaders/slang/include/clustered.slang
+++ b/assets/shaders/slang/include/clustered.slang
@@ -1,34 +1,29 @@
 // assets/shaders/slang/include/clustered.slang
 #pragma once
+#include "lighting.slang"
 
 // Grid dimensions — must match kTilesX/Y/Z in clusteredlights.hpp and the GLSL compute shader.
 static const int TILES_X = 16;
 static const int TILES_Y = 9;
 static const int TILES_Z = 24;
 
-// Max lights per cluster — must match kMaxLightsPerCluster in clusteredlights.hpp.
-static const int MAX_LIGHTS_PER_CLUSTER = 128;
+// Max lights per cluster — must match maxLightsPerCluster in clusteredlights.hpp.
+// Sized >= the max scene light count so per-cluster truncation cannot occur.
+static const int MAX_LIGHTS_PER_CLUSTER = 512;
 
-// Conservative culling radii (world units) per attenuation index.
-static const float attenuationRadius[11] = {
-    7.0,  13.0,  20.0,  32.0,  50.0,  65.0,
-    100.0, 160.0, 200.0, 325.0, 600.0
-};
-
-// Linearise gl_FragCoord.z (window-space depth [0,1]) to positive view-space depth.
-float linearDepth(float windowZ, float near, float far)
-{
-    return 2.0 * near * far / (far + near - (2.0 * windowZ - 1.0) * (far - near));
-}
+// Culling radii live in lighting.slang (attenuationRadius) — shared with the
+// radiance window so culled lights are exactly zero at the boundary.
 
 // Returns the 1-D cluster index for the given fragment.
-// windowZ: SV_Position.z (window-space depth [0,1]).
+// viewZ: positive view-space depth — dot(worldPos - cameraPos, cameraForward).
+// Note: decoding gl_FragCoord.z instead was tried and fails — it disagrees
+// with the view-space slice AABBs on this pipeline (verified empirically).
 // Z subdivision formula must match buildClusterAABBs() in clusteredlights.cpp.
-int clusterIndex(float2 fragCoord, float windowZ, float2 screenSize, float near, float far)
+int clusterIndex(float2 fragCoord, float viewZ, float2 screenSize, float near, float far)
 {
     int   x = clamp(int(fragCoord.x / screenSize.x * TILES_X), 0, TILES_X - 1);
     int   y = clamp(int(fragCoord.y / screenSize.y * TILES_Y), 0, TILES_Y - 1);
-    float d = linearDepth(windowZ, near, far);
+    float d = max(viewZ, near);
     int   z = clamp(int(log(d / near) / log(far / near) * float(TILES_Z)), 0, TILES_Z - 1);
     return x + y * TILES_X + z * TILES_X * TILES_Y;
 }

--- a/assets/shaders/slang/include/clustered.slang
+++ b/assets/shaders/slang/include/clustered.slang
@@ -1,0 +1,34 @@
+// assets/shaders/slang/include/clustered.slang
+#pragma once
+
+// Grid dimensions — must match kTilesX/Y/Z in clusteredlights.hpp and the GLSL compute shader.
+static const int TILES_X = 8;
+static const int TILES_Y = 4;
+static const int TILES_Z = 8;
+
+// Max lights per cluster — must match kMaxLightsPerCluster in clusteredlights.hpp.
+static const int MAX_LIGHTS_PER_CLUSTER = 128;
+
+// Conservative culling radii (world units) per attenuation index.
+static const float attenuationRadius[11] = {
+    7.0,  13.0,  20.0,  32.0,  50.0,  65.0,
+    100.0, 160.0, 200.0, 325.0, 600.0
+};
+
+// Linearise gl_FragCoord.z (window-space depth [0,1]) to positive view-space depth.
+float linearDepth(float windowZ, float near, float far)
+{
+    return 2.0 * near * far / (far + near - (2.0 * windowZ - 1.0) * (far - near));
+}
+
+// Returns the 1-D cluster index for the given fragment.
+// windowZ: SV_Position.z (window-space depth [0,1]).
+// Z subdivision formula must match buildClusterAABBs() in clusteredlights.cpp.
+int clusterIndex(float2 fragCoord, float windowZ, float2 screenSize, float near, float far)
+{
+    int   x = clamp(int(fragCoord.x / screenSize.x * TILES_X), 0, TILES_X - 1);
+    int   y = clamp(int(fragCoord.y / screenSize.y * TILES_Y), 0, TILES_Y - 1);
+    float d = linearDepth(windowZ, near, far);
+    int   z = clamp(int(log(d / near) / log(far / near) * float(TILES_Z)), 0, TILES_Z - 1);
+    return x + y * TILES_X + z * TILES_X * TILES_Y;
+}

--- a/assets/shaders/slang/include/clustered.slang
+++ b/assets/shaders/slang/include/clustered.slang
@@ -2,10 +2,11 @@
 #pragma once
 #include "lighting.slang"
 
-// Grid dimensions — must match kTilesX/Y/Z in clusteredlights.hpp and the GLSL compute shader.
+// Screen tile grid — must match tilesX/Y in clusteredlights.hpp. The z-slice
+// count is runtime (derived from the FOV, van Oosten eq. 8.2) and passed as
+// tilesZ.
 static const int TILES_X = 16;
 static const int TILES_Y = 9;
-static const int TILES_Z = 24;
 
 // Max lights per cluster — must match maxLightsPerCluster in clusteredlights.hpp.
 // Sized >= the max scene light count so per-cluster truncation cannot occur.
@@ -18,12 +19,18 @@ static const int MAX_LIGHTS_PER_CLUSTER = 512;
 // viewZ: positive view-space depth — dot(worldPos - cameraPos, cameraForward).
 // Note: decoding gl_FragCoord.z instead was tried and fails — it disagrees
 // with the view-space slice AABBs on this pipeline (verified empirically).
+// clusterNear: near bound of the cluster grid (not the camera near plane);
+// fragments closer than it clamp into slice 0, whose AABB extends to the
+// camera near plane.
 // Z subdivision formula must match buildClusterAABBs() in clusteredlights.cpp.
-int clusterIndex(float2 fragCoord, float viewZ, float2 screenSize, float near, float far)
+int clusterIndex(float2 fragCoord, float viewZ, float2 screenSize,
+                 float clusterNear, float far, int tilesZ)
 {
     int   x = clamp(int(fragCoord.x / screenSize.x * TILES_X), 0, TILES_X - 1);
     int   y = clamp(int(fragCoord.y / screenSize.y * TILES_Y), 0, TILES_Y - 1);
-    float d = max(viewZ, near);
-    int   z = clamp(int(log(d / near) / log(far / near) * float(TILES_Z)), 0, TILES_Z - 1);
+    float d = max(viewZ, clusterNear);
+    int   z = clamp(int(log(d / clusterNear) / log(far / clusterNear) *
+                        float(tilesZ)),
+                    0, tilesZ - 1);
     return x + y * TILES_X + z * TILES_X * TILES_Y;
 }

--- a/assets/shaders/slang/include/clustered.slang
+++ b/assets/shaders/slang/include/clustered.slang
@@ -2,9 +2,9 @@
 #pragma once
 
 // Grid dimensions — must match kTilesX/Y/Z in clusteredlights.hpp and the GLSL compute shader.
-static const int TILES_X = 8;
-static const int TILES_Y = 4;
-static const int TILES_Z = 8;
+static const int TILES_X = 16;
+static const int TILES_Y = 9;
+static const int TILES_Z = 24;
 
 // Max lights per cluster — must match kMaxLightsPerCluster in clusteredlights.hpp.
 static const int MAX_LIGHTS_PER_CLUSTER = 128;

--- a/assets/shaders/slang/include/dither.slang
+++ b/assets/shaders/slang/include/dither.slang
@@ -1,0 +1,10 @@
+#pragma once
+
+// Interleaved gradient noise (Jimenez 2014), ±0.5 LSB at 8-bit — breaks up
+// banding in dim gradients. Apply at every pass that writes an 8-bit target.
+float3 dither8(float3 color, float2 fragCoord)
+{
+    float ign = frac(52.9829189 *
+                     frac(dot(fragCoord, float2(0.06711056, 0.00583715))));
+    return color + (ign - 0.5) / 255.0;
+}

--- a/assets/shaders/slang/include/lighting.slang
+++ b/assets/shaders/slang/include/lighting.slang
@@ -4,7 +4,7 @@ static const float M_PI = 3.14159265359;
 
 // Attenuation coefficients [constant, linear, quadratic] per distance range.
 // See https://learnopengl.com/Lighting/Light-casters
-static const float3 kLightAttenuation[11] = {
+static const float3 lightAttenuation[11] = {
     float3(1.0, 0.70,  1.800),  float3(1.0, 0.35,  0.440),
     float3(1.0, 0.22,  0.200),  float3(1.0, 0.14,  0.070),
     float3(1.0, 0.09,  0.032),  float3(1.0, 0.07,  0.017),
@@ -58,7 +58,7 @@ extension PointLight : ILight
     {
         float  dist = length(position - worldPos);
         int    idx  = clamp(attenuationIndex, 0, 10);
-        float3 att  = kLightAttenuation[idx];
+        float3 att  = lightAttenuation[idx];
         float  atten = 1.0 / (att.x + att.y * dist + att.z * dist * dist);
         return color * atten;
     }

--- a/assets/shaders/slang/include/lighting.slang
+++ b/assets/shaders/slang/include/lighting.slang
@@ -13,6 +13,13 @@ static const float3 lightAttenuation[11] = {
     float3(1.0, 0.007, 0.0002)
 };
 
+// Culling radii (world units) per attenuation index. Radiance is windowed to
+// zero at this radius so cluster culling produces no visible seams.
+static const float attenuationRadius[11] = {
+    7.0,  13.0,  20.0,  32.0,  50.0,  65.0,
+    100.0, 160.0, 200.0, 325.0, 600.0
+};
+
 // ---------------------------------------------------------------------------
 // Light interface — all light types conform to this.
 // evaluatePBR<L:ILight>() is monomorphized per concrete type at compile time.
@@ -60,7 +67,12 @@ extension PointLight : ILight
         int    idx  = clamp(attenuationIndex, 0, 10);
         float3 att  = lightAttenuation[idx];
         float  atten = 1.0 / (att.x + att.y * dist + att.z * dist * dist);
-        return color * atten;
+        // Window to zero at the culling radius (Karis falloff) so lights
+        // culled per-cluster never leave a hard seam at cluster boundaries.
+        float  dr     = dist / attenuationRadius[idx];
+        float  dr2    = dr * dr;
+        float  window = saturate(1.0 - dr2 * dr2);
+        return color * atten * window * window;
     }
 }
 

--- a/assets/shaders/slang/include/shadows.slang
+++ b/assets/shaders/slang/include/shadows.slang
@@ -8,7 +8,9 @@ float shadowEVSM(
 {
     float3 proj = fragPosLightSpace.xyz / fragPosLightSpace.w;
     proj = proj * 0.5 + 0.5;
-    if (proj.z > 1.0 || proj.z < 0.0)
+    // Outside the shadow frustum (xy or z) there is no occlusion information;
+    // sampling clamped edge texels would falsely shadow everything beyond it.
+    if (any(proj < 0.0) || any(proj > 1.0))
     {
         return 0.0;
     }

--- a/assets/shaders/slang/include/ui_uniforms.slang
+++ b/assets/shaders/slang/include/ui_uniforms.slang
@@ -1,0 +1,20 @@
+#pragma once
+
+struct QuadParams
+{
+    float4x4 projection;   // vertex
+    float4   corners;
+    float    cornerRadius;
+    float4   color;
+    float    borderWidth;
+    float4   borderColor;
+};
+[[vk::binding(3)]] ConstantBuffer<QuadParams> quadParams;
+
+struct SpriteParams
+{
+    float4x4 projection;   // vertex
+    float    alpha;
+    float3   textColor;    // text fragment only
+};
+[[vk::binding(4)]] ConstantBuffer<SpriteParams> spriteParams;

--- a/assets/shaders/slang/include/uniforms.slang
+++ b/assets/shaders/slang/include/uniforms.slang
@@ -37,5 +37,6 @@ struct PbrParams
     float            nearPlane;
     float            farPlane;
     float2           screenSize;
+    float3           viewForward;  // world-space camera forward, normalized
 };
 [[vk::binding(2)]] ConstantBuffer<PbrParams> params;

--- a/assets/shaders/slang/include/uniforms.slang
+++ b/assets/shaders/slang/include/uniforms.slang
@@ -34,25 +34,8 @@ struct PbrParams
     float3           emissive;
     DirectionalLight directionalLight;
     int              numLights;
-    PointLight       pointLights[6];
+    float            nearPlane;
+    float            farPlane;
+    float2           screenSize;
 };
 [[vk::binding(2)]] ConstantBuffer<PbrParams> params;
-
-struct QuadParams
-{
-    float4x4 projection;   // vertex
-    float4   corners;
-    float    cornerRadius;
-    float4   color;
-    float    borderWidth;
-    float4   borderColor;
-};
-[[vk::binding(3)]] ConstantBuffer<QuadParams> quadParams;
-
-struct SpriteParams
-{
-    float4x4 projection;   // vertex
-    float    alpha;
-    float3   textColor;    // text fragment only
-};
-[[vk::binding(4)]] ConstantBuffer<SpriteParams> spriteParams;

--- a/assets/shaders/slang/include/uniforms.slang
+++ b/assets/shaders/slang/include/uniforms.slang
@@ -34,9 +34,10 @@ struct PbrParams
     float3           emissive;
     DirectionalLight directionalLight;
     int              numLights;
-    float            nearPlane;
+    float            clusterNear;  // near bound of the cluster grid
     float            farPlane;
     float2           screenSize;
     float3           viewForward;  // world-space camera forward, normalized
+    int              tilesZ;       // runtime cluster z-slice count
 };
 [[vk::binding(2)]] ConstantBuffer<PbrParams> params;

--- a/assets/shaders/slang/pbr.slang
+++ b/assets/shaders/slang/pbr.slang
@@ -76,7 +76,8 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target
                              params.viewForward);
         int   ci       = clusterIndex(fragCoord.xy, viewZ,
                                       params.screenSize,
-                                      params.nearPlane, params.farPlane);
+                                      params.clusterNear, params.farPlane,
+                                      params.tilesZ);
         uint2 tile     = lightGrid[ci];
         uint  tileEnd  = tile.x + tile.y;
         for (uint j = tile.x; j < tileEnd; ++j)

--- a/assets/shaders/slang/pbr.slang
+++ b/assets/shaders/slang/pbr.slang
@@ -2,6 +2,7 @@
 #include "include/uniforms.slang"
 #include "include/shadows.slang"
 #include "include/clustered.slang"
+#include "include/dither.slang"
 
 struct PointLightGPU
 {
@@ -15,6 +16,7 @@ struct PointLightGPU
 [[vk::binding(3)]] StructuredBuffer<PointLightGPU> lightBuffer;
 [[vk::binding(4)]] StructuredBuffer<uint2>         lightGrid;
 [[vk::binding(5)]] StructuredBuffer<uint>          lightIndices;
+
 
 struct VSInput
 {
@@ -70,7 +72,9 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target
     // Clustered point lights
     if (params.numLights > 0)
     {
-        int   ci       = clusterIndex(fragCoord.xy, fragCoord.z,
+        float viewZ    = dot(input.worldPosition - params.viewPos,
+                             params.viewForward);
+        int   ci       = clusterIndex(fragCoord.xy, viewZ,
                                       params.screenSize,
                                       params.nearPlane, params.farPlane);
         uint2 tile     = lightGrid[ci];
@@ -96,6 +100,8 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target
 
     // Gamma correction
     color = pow(color, float3(1.0 / 2.2));
+
+    color = dither8(color, fragCoord.xy);
 
     return float4(color + params.emissive, 1.0);
 }

--- a/assets/shaders/slang/pbr.slang
+++ b/assets/shaders/slang/pbr.slang
@@ -1,6 +1,20 @@
 // pbr.slang — PBR vertex + fragment shader
 #include "include/uniforms.slang"
 #include "include/shadows.slang"
+#include "include/clustered.slang"
+
+struct PointLightGPU
+{
+    float3 color;
+    float  pad0;
+    float3 position;
+    int    attenuationIndex;
+    float4 pad1;
+}
+
+[[vk::binding(3)]] StructuredBuffer<PointLightGPU> lightBuffer;
+[[vk::binding(4)]] StructuredBuffer<uint2>         lightGrid;
+[[vk::binding(5)]] StructuredBuffer<uint>          lightIndices;
 
 struct VSInput
 {
@@ -31,12 +45,11 @@ VSOutput vertMain(VSInput input)
     return output;
 }
 
-// Explicit binding pins the texture unit the C++ side binds to.
 [[vk::binding(0)]] Sampler2D<float4> texture_diffuse1;
 [[vk::binding(1)]] Sampler2D<float2> shadowMap;
 
 [shader("fragment")]
-float4 fragMain(VSOutput input) : SV_Target
+float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target
 {
     float3 texColor = pow(texture_diffuse1.Sample(input.texCoords).rgb, float3(2.2));
     float3 albedo   = lerp(texColor, float3(1.0), float(params.hasNoTexture));
@@ -54,10 +67,25 @@ float4 fragMain(VSOutput input) : SV_Target
     }
     Lo += dirContrib * (1.0 - shadow) * float(params.directionalLight.enabled);
 
-    // Point lights
-    for (int i = 0; i < params.numLights; i++)
+    // Clustered point lights
+    if (params.numLights > 0)
     {
-        Lo += evaluatePBR(params.pointLights[i], input.worldPosition, albedo, N, V, params.metallic, params.roughness);
+        int   ci       = clusterIndex(fragCoord.xy, fragCoord.z,
+                                      params.screenSize,
+                                      params.nearPlane, params.farPlane);
+        uint2 tile     = lightGrid[ci];
+        uint  tileEnd  = tile.x + tile.y;
+        for (uint j = tile.x; j < tileEnd; ++j)
+        {
+            uint          li    = lightIndices[j];
+            PointLightGPU gpu   = lightBuffer[li];
+            PointLight    pl;
+            pl.color            = gpu.color;
+            pl.position         = gpu.position;
+            pl.attenuationIndex = gpu.attenuationIndex;
+            Lo += evaluatePBR(pl, input.worldPosition, albedo, N, V,
+                              params.metallic, params.roughness);
+        }
     }
 
     float3 ambient = float3(params.ambientStrength) * albedo * params.ao;

--- a/assets/shaders/slang/rectangle.slang
+++ b/assets/shaders/slang/rectangle.slang
@@ -1,5 +1,5 @@
 // rectangle.slang — UI rounded-rect vertex + SDF fragment shader
-#include "include/uniforms.slang"
+#include "include/ui_uniforms.slang"
 
 struct VSInput
 {

--- a/assets/shaders/slang/sprite.slang
+++ b/assets/shaders/slang/sprite.slang
@@ -1,5 +1,5 @@
 // sprite.slang — sprite and text vertex + fragment shaders
-#include "include/uniforms.slang"
+#include "include/ui_uniforms.slang"
 
 struct VSInput
 {

--- a/cmake/CompileSlang.cmake
+++ b/cmake/CompileSlang.cmake
@@ -16,7 +16,7 @@ file(MAKE_DIRECTORY "${SLANG_OUTPUT_DIR}")
 function(compile_slang_shader SLANG_FILE ENTRY_POINT OUTPUT_NAME)
     set(INPUT  "${SLANG_SOURCE_DIR}/${SLANG_FILE}")
     set(OUTPUT "${SLANG_OUTPUT_DIR}/${OUTPUT_NAME}")
-    file(GLOB SLANG_INCLUDES "${SLANG_SOURCE_DIR}/include/*.slang")
+    file(GLOB SLANG_INCLUDES CONFIGURE_DEPENDS "${SLANG_SOURCE_DIR}/include/*.slang")
     add_custom_command(
         OUTPUT  "${OUTPUT}"
         COMMAND "${SLANGC_EXECUTABLE}"

--- a/cmake/CompileSlang.cmake
+++ b/cmake/CompileSlang.cmake
@@ -37,6 +37,30 @@ endfunction()
 
 set(SLANG_COMPILED_OUTPUTS "")
 
+# Usage: compile_slang_compute_shader(<slang-file> <entry-point> <output-name>)
+function(compile_slang_compute_shader SLANG_FILE ENTRY_POINT OUTPUT_NAME)
+    set(INPUT  "${SLANG_SOURCE_DIR}/${SLANG_FILE}")
+    set(OUTPUT "${SLANG_OUTPUT_DIR}/${OUTPUT_NAME}")
+    file(GLOB SLANG_INCLUDES "${SLANG_SOURCE_DIR}/include/*.slang")
+    add_custom_command(
+        OUTPUT  "${OUTPUT}"
+        COMMAND "${SLANGC_EXECUTABLE}"
+                "${INPUT}"
+                -entry "${ENTRY_POINT}"
+                -stage compute
+                -target glsl
+                -profile glsl_450
+                -matrix-layout-column-major
+                "$<$<CONFIG:Release>:-line-directive-mode;none>"
+                -o "${OUTPUT}"
+        DEPENDS "${INPUT}" ${SLANG_INCLUDES}
+        COMMENT "Compiling Slang compute shader ${SLANG_FILE} [${ENTRY_POINT}] to ${OUTPUT_NAME}"
+        VERBATIM
+        COMMAND_EXPAND_LISTS
+    )
+    set(SLANG_COMPILED_OUTPUTS "${SLANG_COMPILED_OUTPUTS};${OUTPUT}" PARENT_SCOPE)
+endfunction()
+
 # screenquad vertex (shared by blur, bloom, and fxaa passes)
 compile_slang_shader(fxaa.slang                vertMain   screenquad.vert.glsl)
 
@@ -72,6 +96,13 @@ compile_slang_shader(sprite.slang              vertMain      sprite.vert.glsl)
 # Light cube
 compile_slang_shader(cube.slang                fragMain   cube.frag.glsl)
 compile_slang_shader(cube.slang                vertMain   cube.vert.glsl)
+
+# Depth prepass (depth-only)
+compile_slang_shader(depthprepass.slang vertMain depthprepass.vert.glsl)
+compile_slang_shader(depthprepass.slang fragMain depthprepass.frag.glsl)
+
+# Cluster light assignment compute shader
+compile_slang_compute_shader(cluster_assign.slang csMain cluster_assign.comp.glsl)
 
 add_custom_target(compile_shaders ALL
     DEPENDS ${SLANG_COMPILED_OUTPUTS}

--- a/cmake/CompileSlang.cmake
+++ b/cmake/CompileSlang.cmake
@@ -37,30 +37,6 @@ endfunction()
 
 set(SLANG_COMPILED_OUTPUTS "")
 
-# Usage: compile_slang_compute_shader(<slang-file> <entry-point> <output-name>)
-function(compile_slang_compute_shader SLANG_FILE ENTRY_POINT OUTPUT_NAME)
-    set(INPUT  "${SLANG_SOURCE_DIR}/${SLANG_FILE}")
-    set(OUTPUT "${SLANG_OUTPUT_DIR}/${OUTPUT_NAME}")
-    file(GLOB SLANG_INCLUDES "${SLANG_SOURCE_DIR}/include/*.slang")
-    add_custom_command(
-        OUTPUT  "${OUTPUT}"
-        COMMAND "${SLANGC_EXECUTABLE}"
-                "${INPUT}"
-                -entry "${ENTRY_POINT}"
-                -stage compute
-                -target glsl
-                -profile glsl_450
-                -matrix-layout-column-major
-                "$<$<CONFIG:Release>:-line-directive-mode;none>"
-                -o "${OUTPUT}"
-        DEPENDS "${INPUT}" ${SLANG_INCLUDES}
-        COMMENT "Compiling Slang compute shader ${SLANG_FILE} [${ENTRY_POINT}] to ${OUTPUT_NAME}"
-        VERBATIM
-        COMMAND_EXPAND_LISTS
-    )
-    set(SLANG_COMPILED_OUTPUTS "${SLANG_COMPILED_OUTPUTS};${OUTPUT}" PARENT_SCOPE)
-endfunction()
-
 # screenquad vertex (shared by blur, bloom, and fxaa passes)
 compile_slang_shader(fxaa.slang                vertMain   screenquad.vert.glsl)
 
@@ -94,15 +70,15 @@ compile_slang_shader(sprite.slang              textFragMain  text.frag.glsl)
 compile_slang_shader(sprite.slang              vertMain      sprite.vert.glsl)
 
 # Light cube
-compile_slang_shader(cube.slang                fragMain   cube.frag.glsl)
-compile_slang_shader(cube.slang                vertMain   cube.vert.glsl)
+compile_slang_shader(cube.slang                fragMain      cube.frag.glsl)
+compile_slang_shader(cube.slang                vertMain      cube.vert.glsl)
 
 # Depth prepass (depth-only)
-compile_slang_shader(depthprepass.slang vertMain depthprepass.vert.glsl)
-compile_slang_shader(depthprepass.slang fragMain depthprepass.frag.glsl)
+compile_slang_shader(depthprepass.slang        vertMain      depthprepass.vert.glsl)
+compile_slang_shader(depthprepass.slang        fragMain      depthprepass.frag.glsl)
 
 # Cluster light assignment compute shader
-compile_slang_compute_shader(cluster_assign.slang csMain cluster_assign.comp.glsl)
+compile_slang_shader(cluster_assign.slang      csMain        cluster_assign.comp.glsl)
 
 add_custom_target(compile_shaders ALL
     DEPENDS ${SLANG_COMPILED_OUTPUTS}

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -170,9 +170,10 @@ if (CMAKE_SKIP_INSTALL_RULES)
 endif ()
 
 if (APPLE)
-    add_custom_command(
-            TARGET game
-            POST_BUILD
+    # Always-run target (file(COPY) skips up-to-date files) so shader edits
+    # deploy even when the game target does not relink.
+    add_custom_target(
+            copy_assets
             COMMAND ${CMAKE_COMMAND}
                 -D DST_DIR=$<TARGET_BUNDLE_CONTENT_DIR:game>/Resources
                 -D EXCLUDE_SUBDIR=slang
@@ -181,6 +182,8 @@ if (APPLE)
                 -P "${CMAKE_SOURCE_DIR}/cmake/CopyAssets.cmake"
             COMMENT "Copying assets to bundle content folder"
             VERBATIM)
+    add_dependencies(copy_assets compile_shaders)
+    add_dependencies(game copy_assets)
 
     install(TARGETS game BUNDLE DESTINATION .)
 
@@ -193,9 +196,10 @@ if (APPLE)
         fixup_bundle(\"${APPS}\" \"${LIBS}\" \"${DIRS}\"\)"
             COMPONENT Runtime)
 else ()
-    add_custom_command(
-            TARGET game
-            POST_BUILD
+    # Always-run target (file(COPY) skips up-to-date files) so shader edits
+    # deploy even when the game target does not relink.
+    add_custom_target(
+            copy_assets
             COMMAND ${CMAKE_COMMAND}
                 -D DST_DIR=$<TARGET_FILE_DIR:game>/assets
                 -D EXCLUDE_SUBDIR=slang
@@ -204,6 +208,8 @@ else ()
                 -P "${CMAKE_SOURCE_DIR}/cmake/CopyAssets.cmake"
             COMMENT "Copying assets to target folder"
             VERBATIM)
+    add_dependencies(copy_assets compile_shaders)
+    add_dependencies(game copy_assets)
 
     install(TARGETS game RUNTIME DESTINATION .)
     install(FILES $<TARGET_RUNTIME_DLLS:game> DESTINATION .)

--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -102,7 +102,6 @@ void ImGuiLayer::showAppInfoWindow(const float width) {
     if (ImGui::Begin("App Info", &hasAppInfoMenu, windowFlags)) {
         showInfoSection();
         showLightsSection();
-        showShadowMapSection();
         showResourcesSection();
     }
     ImGui::End();
@@ -362,13 +361,6 @@ void ImGuiLayer::showAttenuationSlider(int32_t& attenuationIndex) {
 
     if (ImGui::SliderInt("Distance", &attenuationIndex, 0, 10, label.c_str())) {
         Maze::get().getMazeLayer()->setAttenuationIndex(attenuationIndex);
-    }
-}
-
-void ImGuiLayer::showShadowMapSection() {
-    if (ImGui::CollapsingHeader("Shadow Map")) {
-        ImGui::Image(Maze::get().getMazeLayer()->getShadowMapTextureId(),
-                     ImVec2(appInfoWidth * .85F, appInfoWidth * .85F));
     }
 }
 

--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -311,7 +311,7 @@ void ImGuiLayer::showPointLightControls() {
     const auto mazeLayer        = Maze::get().getMazeLayer();
     auto       numLights        = mazeLayer->getNumLights();
     int32_t    attenuationIndex = mazeLayer->getAttenuationIndex();
-    if (ImGui::SliderInt("Lights ", &numLights, 0, 6)) {
+    if (ImGui::SliderInt("Lights ", &numLights, 0, 500)) {
         mazeLayer->setNumLights(numLights);
     }
 

--- a/game/src/layer/imgui/imguilayer.hpp
+++ b/game/src/layer/imgui/imguilayer.hpp
@@ -40,7 +40,6 @@ private:
     static void showPointLightControls();
     static void showAttenuationSlider(int32_t& attenuationIndex);
 
-    static void showShadowMapSection();
     static void showResourcesSection();
 
     // Resource tables

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -168,7 +168,9 @@ void MazeLayer::onAttach() {
     createDepthPrepassFbo(w, h);
 
     shader->bind();
-    shader->setFloat("nearPlane", camera->getNear());
+    shader->setFloat(
+        "clusterNear",
+        sponge::platform::opengl::scene::ClusteredLights::clusterNear);
     shader->setFloat("farPlane", camera->getFar());
     shader->setFloat2("screenSize",
                       glm::vec2(static_cast<float>(w), static_cast<float>(h)));
@@ -351,15 +353,18 @@ void MazeLayer::onRender() {
         renderSceneToDepthMap(frame);
     }
 
-    // Phase 2: depth prepass
+    // Phase 2: depth prepass (also marks active volume tiles)
+    if (clusteredLights) {
+        clusteredLights->prepare(frame.cameraProjection);
+    }
     renderDepthPrepass(frame);
 
     // Phase 3: light culling
     if (clusteredLights && frame.numLights > 0) {
-        clusteredLights->update(
-            frame.lightPositions.data(), frame.lightColors.data(),
-            frame.lightAttenuationIndices.data(), frame.numLights,
-            frame.cameraView, frame.cameraProjection);
+        clusteredLights->update(frame.lightPositions.data(),
+                                frame.lightColors.data(),
+                                frame.lightAttenuationIndices.data(),
+                                frame.numLights, frame.cameraView);
     }
 
     // Phase 4: opaque pass
@@ -640,6 +645,8 @@ void MazeLayer::renderGameObjects(const thread::MazeRenderFrame& frame) const {
     shader->setFloat3("viewForward",
                       -glm::vec3(frame.cameraView[0][2], frame.cameraView[1][2],
                                  frame.cameraView[2][2]));
+    shader->setInteger("tilesZ",
+                       clusteredLights ? clusteredLights->getTilesZ() : 1);
 
     if (frame.shadowEnabled && frame.shadowCastShadow) {
         shader->setMat4("lightSpaceMatrix", frame.lightSpaceMatrix);
@@ -696,9 +703,20 @@ void MazeLayer::renderDepthPrepass(const thread::MazeRenderFrame& frame) const {
     glClear(GL_DEPTH_BUFFER_BIT);
 
     depthPrepassShader->bind();
+    depthPrepassShader->setFloat2(
+        "screenSize", glm::vec2(static_cast<float>(frame.screenWidth),
+                                static_cast<float>(frame.screenHeight)));
+    depthPrepassShader->setFloat(
+        "clusterNear",
+        sponge::platform::opengl::scene::ClusteredLights::clusterNear);
+    depthPrepassShader->setFloat("clusterFar", frame.farPlane);
+    depthPrepassShader->setInteger(
+        "tilesZ", clusteredLights ? clusteredLights->getTilesZ() : 1);
     for (size_t i = 0; i < frame.objectModels.size(); ++i) {
         depthPrepassShader->setMat4("mvp", frame.cameraMVP *
                                                frame.objectModelMatrices[i]);
+        depthPrepassShader->setMat4(
+            "modelView", frame.cameraView * frame.objectModelMatrices[i]);
         frame.objectModels[i]->render(depthPrepassShader);
     }
     depthPrepassShader->unbind();

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -577,10 +577,6 @@ void MazeLayer::setRoughness(const float val) {
     shader->unbind();
 }
 
-uint32_t MazeLayer::getShadowMapTextureId() const {
-    return shadowMap->getDepthMapTextureId();
-}
-
 void MazeLayer::onWindowFocus(const WindowFocusEvent& event) {
     if (!event.isFocused()) {
         mouseButtonPressed = false;

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <memory>
+#include <random>
 #include <string>
 
 namespace {
@@ -25,16 +26,10 @@ constexpr auto cubeScale = glm::vec3(.1F);
 
 constexpr std::string_view cameraName = "maze";
 
-game::scene::DirectionalLight          directionalLight;
-std::array<game::scene::PointLight, 6> pointLights;
+constexpr int32_t maxPointLights = 500;
 
-struct LightUniforms {
-    std::string position;
-    std::string color;
-    std::string attenuationIndex;
-};
-
-std::array<LightUniforms, 6> lightUniformNames;
+game::scene::DirectionalLight                       directionalLight;
+std::array<game::scene::PointLight, maxPointLights> pointLights;
 
 using game::layer::GameObject;
 
@@ -86,20 +81,13 @@ using sponge::input::InputSnapshot;
 using sponge::platform::glfw::core::Application;
 using sponge::platform::opengl::renderer::AssetManager;
 using sponge::platform::opengl::scene::Bloom;
+using sponge::platform::opengl::scene::ClusteredLights;
 using sponge::platform::opengl::scene::Cube;
 using sponge::platform::opengl::scene::FXAA;
 using sponge::platform::opengl::scene::Mesh;
 using sponge::platform::opengl::scene::ShadowMap;
 
-MazeLayer::MazeLayer() : Layer("maze") {
-    for (int32_t i = 0; i < 6; i++) {
-        const std::string base  = "pointLights[" + std::to_string(i) + "].";
-        auto&             names = lightUniformNames.at(i);
-        names.position          = base + "position";
-        names.color             = base + "color";
-        names.attenuationIndex  = base + "attenuationIndex";
-    }
-}
+MazeLayer::MazeLayer() : Layer("maze") {}
 
 void MazeLayer::onAttach() {
     for (auto& gameObject : gameObjects) {
@@ -164,12 +152,40 @@ void MazeLayer::onAttach() {
     queueResize(Maze::get().getWindow()->getWidth(),
                 Maze::get().getWindow()->getHeight());
 
+    const auto w = static_cast<int>(Maze::get().getWindow()->getWidth());
+    const auto h = static_cast<int>(Maze::get().getWindow()->getHeight());
+    screenWidth  = w;
+    screenHeight = h;
+    clusteredLights =
+        std::make_unique<ClusteredLights>(camera->getNear(), camera->getFar());
+
+    depthPrepassShader = AssetManager::createShader({
+        .name               = "depthprepass",
+        .vertexShaderPath   = "/shaders/glsl/depthprepass.vert.glsl",
+        .fragmentShaderPath = "/shaders/glsl/depthprepass.frag.glsl",
+        .geometryShaderPath = "",
+    });
+    createDepthPrepassFbo(w, h);
+
+    shader->bind();
+    shader->setFloat("nearPlane", camera->getNear());
+    shader->setFloat("farPlane", camera->getFar());
+    shader->setFloat2("screenSize",
+                      glm::vec2(static_cast<float>(w), static_cast<float>(h)));
+    shader->unbind();
+
     setNumLights(numLights);
-    updateShaderLights();
 }
 
 void MazeLayer::onDetach() {
-    // nothing
+    if (depthPrepassTexture != 0) {
+        glDeleteTextures(1, &depthPrepassTexture);
+        depthPrepassTexture = 0;
+    }
+    if (depthPrepassFbo != 0) {
+        glDeleteFramebuffers(1, &depthPrepassFbo);
+        depthPrepassFbo = 0;
+    }
 }
 
 void MazeLayer::onEvent(Event& event) {
@@ -252,8 +268,14 @@ bool MazeLayer::onUpdate(const double elapsedTime) {
 void MazeLayer::captureRenderFrame(const uint32_t slotIndex) {
     auto& frame = renderFrames[slotIndex];
 
-    frame.cameraMVP = camera->getMVP();
-    frame.cameraPos = camera->getPosition();
+    frame.cameraMVP        = camera->getMVP();
+    frame.cameraView       = camera->getViewMatrix();
+    frame.cameraProjection = camera->getProjectionMatrix();
+    frame.cameraPos        = camera->getPosition();
+    frame.nearPlane        = camera->getNear();
+    frame.farPlane         = camera->getFar();
+    frame.screenWidth      = screenWidth;
+    frame.screenHeight     = screenHeight;
 
     frame.shadowEnabled    = directionalLight.enabled;
     frame.shadowCastShadow = directionalLight.castShadow;
@@ -308,6 +330,15 @@ void MazeLayer::onRender() {
         if (bloom) {
             bloom->resize(w, h);
         }
+        screenWidth  = static_cast<int32_t>(w);
+        screenHeight = static_cast<int32_t>(h);
+        createDepthPrepassFbo(static_cast<int>(w), static_cast<int>(h));
+
+        const auto shader = Mesh::getShader();
+        shader->bind();
+        shader->setFloat2("screenSize", glm::vec2(static_cast<float>(w),
+                                                  static_cast<float>(h)));
+        shader->unbind();
         pendingResize.store(false, std::memory_order_relaxed);
     }
 
@@ -315,17 +346,51 @@ void MazeLayer::onRender() {
     const auto& frame =
         renderFrames[renderReadIndex.load(std::memory_order_acquire)];
 
+    // Phase 1: shadow map
     if (frame.shadowEnabled && frame.shadowCastShadow) {
         renderSceneToDepthMap(frame);
     }
 
+    // Phase 2: depth prepass
+    renderDepthPrepass(frame);
+
+    // Phase 3: light culling
+    if (clusteredLights && frame.numLights > 0) {
+        clusteredLights->update(
+            frame.lightPositions.data(), frame.lightColors.data(),
+            frame.lightAttenuationIndices.data(), frame.numLights,
+            frame.cameraView, frame.cameraProjection);
+    }
+
+    // Phase 4: opaque pass
+    const bool hasFbo = (frame.bloomEnabled && bloom != nullptr) ||
+                        (frame.fxaaEnabled && fxaa != nullptr);
     if (frame.bloomEnabled && bloom) {
         bloom->begin();
     } else if (frame.fxaaEnabled && fxaa) {
         fxaa->begin();
     }
 
+    if (hasFbo) {
+        // Blit prepass depth into the post-processing FBO so the opaque pass
+        // can use GL_LEQUAL (zero overdraw). Both FBOs use
+        // GL_DEPTH_COMPONENT24.
+        blitDepthToCurrentFbo(frame.screenWidth, frame.screenHeight);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glDepthFunc(GL_LEQUAL);
+        glDepthMask(GL_FALSE);
+    } else {
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    }
+
     renderGameObjects(frame);
+
+    if (hasFbo) {
+        glDepthMask(GL_TRUE);
+        glDepthFunc(GL_LESS);
+    }
+
+    // Transparent pass (placeholder)
     renderLightCubes(frame);
 
     if (frame.bloomEnabled && bloom) {
@@ -466,17 +531,28 @@ int32_t MazeLayer::getNumLights() const {
 void MazeLayer::setNumLights(const int32_t val) {
     numLights = val;
 
+    std::mt19937                          rng(42U);
+    std::uniform_real_distribution<float> jitterAngle(-0.4F, 0.4F);
+    std::uniform_real_distribution<float> jitterRadius(-0.5F, 0.5F);
+
     for (int32_t i = 0; i < numLights; i++) {
-        auto& light    = pointLights.at(i);
-        light.color    = glm::vec3(1.F);
-        light.position = glm::vec3(rotate(glm::mat4(1.F),
-                                          glm::two_pi<float>() * i / numLights,
-                                          glm::vec3(0.F, 1.F, 0.F)) *
-                                   glm::vec4(0.F, 2.75F, -3.F, 1.F));
+        const float t =
+            numLights > 1 ? static_cast<float>(i) / (numLights - 1) : 0.F;
+        const float radius = 1.5F + t * 13.5F + jitterRadius(rng);
+        const float angle =
+            glm::two_pi<float>() * i / numLights + jitterAngle(rng);
+        auto& light = pointLights.at(i);
+        light.color = glm::vec3(1.F);
+        light.position =
+            glm::vec3(rotate(glm::mat4(1.F), angle, glm::vec3(0.F, 1.F, 0.F)) *
+                      glm::vec4(0.F, 2.75F, -radius, 1.F));
         light.attenuationIndex = attenuationIndex;
     }
 
-    updateShaderLights();
+    const auto shader = Mesh::getShader();
+    shader->bind();
+    shader->setInteger("numLights", numLights);
+    shader->unbind();
 }
 
 float MazeLayer::getRoughness() const {
@@ -547,10 +623,14 @@ void MazeLayer::queueResize(const uint32_t w, const uint32_t h) const {
 }
 
 void MazeLayer::renderGameObjects(const thread::MazeRenderFrame& frame) const {
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
     const auto shader = Mesh::getShader();
     shader->bind();
+    if (clusteredLights) {
+        clusteredLights->bindSSBOs();
+    }
+    shader->setFloat2("screenSize",
+                      glm::vec2(static_cast<float>(frame.screenWidth),
+                                static_cast<float>(frame.screenHeight)));
     shader->setFloat3("viewPos", frame.cameraPos);
 
     if (frame.shadowEnabled && frame.shadowCastShadow) {
@@ -572,6 +652,60 @@ void MazeLayer::renderGameObjects(const thread::MazeRenderFrame& frame) const {
     }
 
     shader->unbind();
+}
+
+void MazeLayer::createDepthPrepassFbo(const int w, const int h) {
+    if (depthPrepassTexture != 0) {
+        glDeleteTextures(1, &depthPrepassTexture);
+    }
+    if (depthPrepassFbo != 0) {
+        glDeleteFramebuffers(1, &depthPrepassFbo);
+    }
+
+    glGenTextures(1, &depthPrepassTexture);
+    glBindTexture(GL_TEXTURE_2D, depthPrepassTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24,
+                 static_cast<GLsizei>(w), static_cast<GLsizei>(h), 0,
+                 GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    glGenFramebuffers(1, &depthPrepassFbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, depthPrepassFbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
+                           depthPrepassTexture, 0);
+    glDrawBuffer(GL_NONE);
+    glReadBuffer(GL_NONE);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void MazeLayer::renderDepthPrepass(const thread::MazeRenderFrame& frame) const {
+    glBindFramebuffer(GL_FRAMEBUFFER, depthPrepassFbo);
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    glDepthMask(GL_TRUE);
+    glDepthFunc(GL_LESS);
+    glClear(GL_DEPTH_BUFFER_BIT);
+
+    depthPrepassShader->bind();
+    for (size_t i = 0; i < frame.objectModels.size(); ++i) {
+        depthPrepassShader->setMat4("mvp", frame.cameraMVP *
+                                               frame.objectModelMatrices[i]);
+        frame.objectModels[i]->render(depthPrepassShader);
+    }
+    depthPrepassShader->unbind();
+
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void MazeLayer::blitDepthToCurrentFbo(const int w, const int h) const {
+    GLint drawFbo = 0;
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFbo);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, depthPrepassFbo);
+    glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(drawFbo));
 }
 
 void MazeLayer::renderLightCubes(const thread::MazeRenderFrame& frame) const {
@@ -637,25 +771,6 @@ void MazeLayer::updateCamera(const InputSnapshot& snap,
             camera->mouseMove({ lookH, lookV });
         }
     }
-}
-
-void MazeLayer::updateShaderLights() const {
-    const auto shader = Mesh::getShader();
-
-    shader->bind();
-
-    shader->setInteger("numLights", numLights);
-
-    for (int32_t i = 0; i < numLights; i++) {
-        shader->setFloat3(lightUniformNames.at(i).position,
-                          pointLights.at(i).position);
-        shader->setFloat3(lightUniformNames.at(i).color,
-                          pointLights.at(i).color);
-        shader->setInteger(lightUniformNames.at(i).attenuationIndex,
-                           pointLights.at(i).attenuationIndex);
-    }
-
-    shader->unbind();
 }
 
 bool MazeLayer::isFxaaEnabled() const {

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -636,6 +636,10 @@ void MazeLayer::renderGameObjects(const thread::MazeRenderFrame& frame) const {
                       glm::vec2(static_cast<float>(frame.screenWidth),
                                 static_cast<float>(frame.screenHeight)));
     shader->setFloat3("viewPos", frame.cameraPos);
+    // World-space camera forward = -(third row of the view matrix).
+    shader->setFloat3("viewForward",
+                      -glm::vec3(frame.cameraView[0][2], frame.cameraView[1][2],
+                                 frame.cameraView[2][2]));
 
     if (frame.shadowEnabled && frame.shadowCastShadow) {
         shader->setMat4("lightSpaceMatrix", frame.lightSpaceMatrix);

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -407,6 +407,10 @@ void MazeLayer::onRender() {
         fxaa->end();
         fxaa->apply();
     }
+
+    if (hasFbo) {
+        glDepthFunc(GL_LEQUAL);
+    }
 }
 
 float MazeLayer::getAmbientOcclusion() const {

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -146,17 +146,19 @@ private:
 
     std::atomic<int32_t> screenWidth{ 0 };
     std::atomic<int32_t> screenHeight{ 0 };
-    float                ambientStrength    = .25F;
-    float                ao                 = .25F;
-    int32_t              attenuationIndex   = 4;
-    bool                 fxaaEnabled        = true;
-    bool                 bloomEnabled       = true;
-    float                bloomThreshold     = 0.8F;
-    float                bloomIntensity     = 1.0F;
-    bool                 metallic           = false;
-    bool                 mouseButtonPressed = false;
-    int32_t              numLights          = 0;
-    float                roughness          = .5F;
+    float                ambientStrength  = .25F;
+    float                ao               = .25F;
+    int32_t              attenuationIndex = 4;
+    bool                 fxaaEnabled      = true;
+    bool                 bloomEnabled     = true;
+    float                bloomThreshold   = 0.8F;
+    // Compensates the soft-knee extract, which passes only above-threshold
+    // energy (the old hard threshold passed the full pixel color).
+    float   bloomIntensity     = 2.5F;
+    bool    metallic           = false;
+    bool    mouseButtonPressed = false;
+    int32_t numLights          = 0;
+    float   roughness          = .5F;
 #ifdef ENABLE_IMGUI
     bool isImguiOpen = true;
 #endif

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -93,8 +93,6 @@ public:
 
     void setRoughness(float val);
 
-    uint32_t getShadowMapTextureId() const;
-
     bool isFxaaEnabled() const;
 
     void setFxaaEnabled(bool val);

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "input/inputsnapshot.hpp"
+#include "platform/opengl/scene/clusteredlights.hpp"
 #include "scene/gamecamera.hpp"
 #include "sponge.hpp"
 #include "thread/mazeframe.hpp"
@@ -114,7 +115,13 @@ private:
     std::vector<glm::mat4>             objectModelMatrices;
     std::vector<glm::vec3>             objectEmissives;
     std::vector<std::shared_ptr<sponge::platform::opengl::scene::Model>>
-                                                                objectModels;
+        objectModels;
+    std::unique_ptr<sponge::platform::opengl::scene::ClusteredLights>
+        clusteredLights;
+    std::shared_ptr<sponge::platform::opengl::renderer::Shader>
+             depthPrepassShader;
+    uint32_t depthPrepassFbo{ 0 };
+    uint32_t depthPrepassTexture{ 0 };
     std::unique_ptr<sponge::platform::opengl::scene::Cube>      cube;
     std::unique_ptr<sponge::platform::opengl::scene::FXAA>      fxaa;
     std::unique_ptr<sponge::platform::opengl::scene::Bloom>     bloom;
@@ -139,17 +146,19 @@ private:
     void captureRenderFrame(uint32_t slotIndex);
     void queueResize(uint32_t w, uint32_t h) const;
 
-    float   ambientStrength    = .25F;
-    float   ao                 = .25F;
-    int32_t attenuationIndex   = 4;
-    bool    fxaaEnabled        = true;
-    bool    bloomEnabled       = true;
-    float   bloomThreshold     = 0.8F;
-    float   bloomIntensity     = 1.0F;
-    bool    metallic           = false;
-    bool    mouseButtonPressed = false;
-    int32_t numLights          = 0;
-    float   roughness          = .5F;
+    std::atomic<int32_t> screenWidth{ 0 };
+    std::atomic<int32_t> screenHeight{ 0 };
+    float                ambientStrength    = .25F;
+    float                ao                 = .25F;
+    int32_t              attenuationIndex   = 4;
+    bool                 fxaaEnabled        = true;
+    bool                 bloomEnabled       = true;
+    float                bloomThreshold     = 0.8F;
+    float                bloomIntensity     = 1.0F;
+    bool                 metallic           = false;
+    bool                 mouseButtonPressed = false;
+    int32_t              numLights          = 0;
+    float                roughness          = .5F;
 #ifdef ENABLE_IMGUI
     bool isImguiOpen = true;
 #endif
@@ -166,6 +175,12 @@ private:
 
     bool onWindowResize(const sponge::event::WindowResizeEvent& event) const;
 
+    void createDepthPrepassFbo(int w, int h);
+
+    void renderDepthPrepass(const thread::MazeRenderFrame& frame) const;
+
+    void blitDepthToCurrentFbo(int w, int h) const;
+
     void renderGameObjects(const thread::MazeRenderFrame& frame) const;
 
     void renderLightCubes(const thread::MazeRenderFrame& frame) const;
@@ -174,7 +189,5 @@ private:
 
     void updateCamera(const sponge::input::InputSnapshot& snap,
                       double                              elapsedTime) const;
-
-    void updateShaderLights() const;
 };
 }  // namespace game::layer

--- a/game/src/maze.cpp
+++ b/game/src/maze.cpp
@@ -37,7 +37,7 @@ bool Maze::onUserCreate() {
     setBloomThreshold(std::stof(
         sponge::core::Settings::getString("video.bloomThreshold", "0.8")));
     setBloomIntensity(std::stof(
-        sponge::core::Settings::getString("video.bloomIntensity", "1.0")));
+        sponge::core::Settings::getString("video.bloomIntensity", "2.5")));
 
     return true;
 }

--- a/game/src/scene/gamecamera.hpp
+++ b/game/src/scene/gamecamera.hpp
@@ -26,6 +26,22 @@ public:
         return cameraPos;
     }
 
+    const glm::mat4& getViewMatrix() const {
+        return view;
+    }
+
+    const glm::mat4& getProjectionMatrix() const {
+        return projection;
+    }
+
+    float getNear() const {
+        return zNear;
+    }
+
+    float getFar() const {
+        return zFar;
+    }
+
     float getFov() const {
         return fov;
     }

--- a/game/src/thread/mazeframe.hpp
+++ b/game/src/thread/mazeframe.hpp
@@ -52,7 +52,7 @@ struct MazeRenderFrame {
     bool  fxaaEnabled{ false };
     bool  bloomEnabled{ false };
     float bloomThreshold{ 0.8F };
-    float bloomIntensity{ 1.0F };
+    float bloomIntensity{ 2.5F };
 };
 
 }  // namespace game::thread

--- a/game/src/thread/mazeframe.hpp
+++ b/game/src/thread/mazeframe.hpp
@@ -21,7 +21,13 @@ namespace game::thread {
 struct MazeRenderFrame {
     // Camera
     glm::mat4 cameraMVP{ 1.F };
+    glm::mat4 cameraView{ 1.F };
+    glm::mat4 cameraProjection{ 1.F };
     glm::vec3 cameraPos{ 0.F };
+    float     nearPlane{ 0.1F };
+    float     farPlane{ 100.F };
+    int       screenWidth{ 0 };
+    int       screenHeight{ 0 };
 
     // Directional light / shadow
     bool      shadowEnabled{ false };
@@ -29,11 +35,11 @@ struct MazeRenderFrame {
     glm::vec3 lightDirection{ 0.F, -1.F, 0.F };
     glm::mat4 lightSpaceMatrix{ 1.F };
 
-    // Point lights (up to 6)
-    int32_t                  numLights{ 0 };
-    std::array<glm::vec3, 6> lightPositions{};
-    std::array<glm::vec3, 6> lightColors{};
-    std::array<int32_t, 6>   lightAttenuationIndices{};
+    // Point lights (up to 500)
+    int32_t                    numLights{ 0 };
+    std::array<glm::vec3, 500> lightPositions{};
+    std::array<glm::vec3, 500> lightColors{};
+    std::array<int32_t, 500>   lightAttenuationIndices{};
 
     // Game objects: model matrices and resolved model handles. Handles are
     // resolved once at load; no per-frame name lookup.

--- a/sponge/src/platform/glfw/core/inputmanager.cpp
+++ b/sponge/src/platform/glfw/core/inputmanager.cpp
@@ -347,10 +347,10 @@ void InputManager::buildDefaultBindings() {
     auto& menu     = bindingMaps[+InputContext::Menu];
     auto& gameplay = bindingMaps[+InputContext::Gameplay];
 
-    constexpr float kSpeed = 0.075f;  // keyboard movement speed
-    constexpr float mSpeed = 0.125f;  // mouse look sensitivity
-    constexpr float gpLook = 0.5f;    // gamepad look sensitivity
-    constexpr float gpDZ   = 0.2f;    // gamepad axis deadzone
+    constexpr float keyboardSpeed   = 0.075f;  // keyboard movement speed
+    constexpr float mouseSpeed      = 0.125f;  // mouse look sensitivity
+    constexpr float gamepadLook     = 0.5f;    // gamepad look sensitivity
+    constexpr float gamepadDeadZone = 0.2f;    // gamepad axis deadzone
 
     // ── Menu ──────────────────────────────────────────────────────────────
     menu[+GameAction::MenuUp] = {
@@ -366,7 +366,7 @@ void InputManager::buildDefaultBindings() {
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
                       .axisScale = -1.f,
-                      .deadzone  = gpDZ },
+                      .deadzone  = gamepadDeadZone },
     };
     menu[+GameAction::MenuDown] = {
         InputBinding{ .type      = BindingType::Key,
@@ -381,7 +381,7 @@ void InputManager::buildDefaultBindings() {
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
                       .axisScale = 1.f,
-                      .deadzone  = gpDZ },
+                      .deadzone  = gamepadDeadZone },
     };
     menu[+GameAction::MenuLeft] = {
         InputBinding{ .type      = BindingType::Key,
@@ -432,64 +432,66 @@ void InputManager::buildDefaultBindings() {
     gameplay[+GameAction::MoveForward] = {
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_W,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_Up,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
-                      .axisScale = -kSpeed,
-                      .deadzone  = gpDZ },
+                      .axisScale = -keyboardSpeed,
+                      .deadzone  = gamepadDeadZone },
     };
     gameplay[+GameAction::MoveBack] = {
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_S,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_Down,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
-                      .axisScale = kSpeed,
-                      .deadzone  = gpDZ },
+                      .axisScale = keyboardSpeed,
+                      .deadzone  = gamepadDeadZone },
     };
     gameplay[+GameAction::MoveLeft] = {
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_A,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_Left,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_X,
-                      .axisScale = -kSpeed,
-                      .deadzone  = gpDZ },
+                      .axisScale = -keyboardSpeed,
+                      .deadzone  = gamepadDeadZone },
     };
     gameplay[+GameAction::MoveRight] = {
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_D,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::Key,
                       .rawCode   = +KeyCode::SpongeKey_Right,
-                      .axisScale = kSpeed },
+                      .axisScale = keyboardSpeed },
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_X,
-                      .axisScale = kSpeed,
-                      .deadzone  = gpDZ },
+                      .axisScale = keyboardSpeed,
+                      .deadzone  = gamepadDeadZone },
     };
     gameplay[+GameAction::LookHorizontal] = {
-        InputBinding{ .type = BindingType::MouseAxisX, .axisScale = mSpeed },
+        InputBinding{ .type      = BindingType::MouseAxisX,
+                      .axisScale = mouseSpeed },
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_RIGHT_X,
-                      .axisScale = gpLook,
-                      .deadzone  = gpDZ },
+                      .axisScale = gamepadLook,
+                      .deadzone  = gamepadDeadZone },
     };
     gameplay[+GameAction::LookVertical] = {
-        InputBinding{ .type = BindingType::MouseAxisY, .axisScale = mSpeed },
+        InputBinding{ .type      = BindingType::MouseAxisY,
+                      .axisScale = mouseSpeed },
         InputBinding{ .type      = BindingType::GamepadAxis,
                       .rawCode   = GLFW_GAMEPAD_AXIS_RIGHT_Y,
-                      .axisScale = gpLook,
-                      .deadzone  = gpDZ },
+                      .axisScale = gamepadLook,
+                      .deadzone  = gamepadDeadZone },
     };
     gameplay[+GameAction::Pause] = {
         InputBinding{ .type      = BindingType::Key,

--- a/sponge/src/platform/opengl/renderer/computeshader.cpp
+++ b/sponge/src/platform/opengl/renderer/computeshader.cpp
@@ -1,0 +1,99 @@
+// sponge/src/platform/opengl/renderer/computeshader.cpp
+#include "platform/opengl/renderer/computeshader.hpp"
+
+#include "core/file.hpp"
+#include "platform/opengl/renderer/gl.hpp"
+#include "platform/opengl/renderer/shaderutils.hpp"
+
+#include <cassert>
+#include <vector>
+
+namespace sponge::platform::opengl::renderer {
+
+ComputeShader::ComputeShader(const std::string& name,
+                             const std::string& glslPath) {
+    shaderName = name;
+
+    const std::string source =
+        loadGlslSource(core::File::getResourceDir() + glslPath);
+    assert(!source.empty());
+
+    const char*    srcPtr = source.c_str();
+    const uint32_t cs     = glCreateShader(GL_COMPUTE_SHADER);
+    assert(cs != 0);
+
+    glShaderSource(cs, 1, &srcPtr, nullptr);
+    glCompileShader(cs);
+
+    int32_t result = GL_FALSE;
+    glGetShaderiv(cs, GL_COMPILE_STATUS, &result);
+    if (result == GL_FALSE) {
+        int length = 0;
+        glGetShaderiv(cs, GL_INFO_LOG_LENGTH, &length);
+        if (length > 0) {
+            std::vector<GLchar> msg(length);
+            glGetShaderInfoLog(cs, length, &length, msg.data());
+            SPONGE_GL_ERROR("Compute shader compile failed [{}]: {}", name,
+                            msg.data());
+        }
+        glDeleteShader(cs);
+        return;
+    }
+
+    program = glCreateProgram();
+    glAttachShader(program, cs);
+    glLinkProgram(program);
+
+    glGetProgramiv(program, GL_LINK_STATUS, &result);
+    if (result == GL_FALSE) {
+        int length = 0;
+        glGetProgramiv(program, GL_INFO_LOG_LENGTH, &length);
+        if (length > 0) {
+            std::vector<GLchar> msg(length);
+            glGetProgramInfoLog(program, length, &length, msg.data());
+            SPONGE_GL_ERROR("Compute shader link failed [{}]: {}", name,
+                            msg.data());
+        }
+        glDeleteProgram(program);
+        program = 0;
+    }
+
+    if (program != 0) {
+        glDetachShader(program, cs);
+    }
+    glDeleteShader(cs);
+}
+
+ComputeShader::~ComputeShader() {
+    if (program != 0) {
+        glDeleteProgram(program);
+    }
+}
+
+ComputeShader::ComputeShader(ComputeShader&& other) noexcept {
+    program       = other.program;
+    shaderName    = std::move(other.shaderName);
+    other.program = 0;
+}
+
+ComputeShader& ComputeShader::operator=(ComputeShader&& other) noexcept {
+    if (this != &other) {
+        if (program != 0) {
+            glDeleteProgram(program);
+        }
+        program       = other.program;
+        shaderName    = std::move(other.shaderName);
+        other.program = 0;
+    }
+    return *this;
+}
+
+void ComputeShader::dispatch(const uint32_t groupsX, const uint32_t groupsY,
+                             const uint32_t groupsZ) const {
+    assert(program != 0);
+    glUseProgram(program);
+    glDispatchCompute(groupsX, groupsY, groupsZ);
+    glUseProgram(0);
+}
+
+}  // namespace sponge::platform::opengl::renderer

--- a/sponge/src/platform/opengl/renderer/computeshader.hpp
+++ b/sponge/src/platform/opengl/renderer/computeshader.hpp
@@ -1,0 +1,34 @@
+// sponge/src/platform/opengl/renderer/computeshader.hpp
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace sponge::platform::opengl::renderer {
+
+class ComputeShader final {
+public:
+    ComputeShader(const std::string& name, const std::string& glslPath);
+    ~ComputeShader();
+
+    ComputeShader(const ComputeShader&)            = delete;
+    ComputeShader& operator=(const ComputeShader&) = delete;
+    ComputeShader(ComputeShader&& other) noexcept;
+    ComputeShader& operator=(ComputeShader&& other) noexcept;
+
+    // Dispatch groupsX * groupsY * groupsZ work groups.
+    // Caller must issue glMemoryBarrier after if SSBOs are read by later
+    // stages.
+    void dispatch(uint32_t groupsX, uint32_t groupsY = 1,
+                  uint32_t groupsZ = 1) const;
+
+    uint32_t getId() const {
+        return program;
+    }
+
+private:
+    uint32_t    program = 0;
+    std::string shaderName;
+};
+
+}  // namespace sponge::platform::opengl::renderer

--- a/sponge/src/platform/opengl/renderer/shader.cpp
+++ b/sponge/src/platform/opengl/renderer/shader.cpp
@@ -2,13 +2,13 @@
 
 #include "logging/log.hpp"
 #include "platform/opengl/renderer/gl.hpp"
+#include "platform/opengl/renderer/shaderutils.hpp"
 
 #include <glm/gtc/type_ptr.hpp>
 
 #include <array>
 #include <cassert>
 #include <cstring>
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -23,14 +23,14 @@ Shader::Shader(const ShaderCreateInfo& createInfo) {
 
     SPONGE_GL_INFO("Loading vertex shader file: [{}, {}]", createInfo.name,
                    createInfo.vertexShaderPath);
-    const std::string vertexSource = loadSourceFromFile(
-        createInfo.assetsFolder + createInfo.vertexShaderPath);
+    const std::string vertexSource =
+        loadGlslSource(createInfo.assetsFolder + createInfo.vertexShaderPath);
     assert(!vertexSource.empty());
 
     SPONGE_GL_INFO("Loading fragment shader file: [{}, {}]", createInfo.name,
                    createInfo.fragmentShaderPath);
-    const std::string fragmentSource = loadSourceFromFile(
-        createInfo.assetsFolder + createInfo.fragmentShaderPath);
+    const std::string fragmentSource =
+        loadGlslSource(createInfo.assetsFolder + createInfo.fragmentShaderPath);
     assert(!fragmentSource.empty());
 
     const uint32_t vs = compileShader(GL_VERTEX_SHADER, vertexSource);
@@ -41,7 +41,7 @@ Shader::Shader(const ShaderCreateInfo& createInfo) {
         SPONGE_GL_INFO("Loading geometry shader file: [{}, {}]",
                        createInfo.name, createInfo.geometryShaderPath);
 
-        const std::string geometrySource = loadSourceFromFile(
+        const std::string geometrySource = loadGlslSource(
             createInfo.assetsFolder + createInfo.geometryShaderPath);
         assert(!geometrySource.empty());
 
@@ -325,29 +325,6 @@ GLint Shader::getUniformLocation(const std::string_view name) const {
     uniformLocations.emplace(std::move(nameStr), location);
 
     return location;
-}
-
-std::string Shader::loadSourceFromFile(const std::string& path) const {
-    assert(!path.empty());
-
-    std::string code;
-    if (std::ifstream file(path, std::ios::in | std::ios::binary);
-        file.good()) {
-        file.seekg(0, std::ios::end);
-        const auto size = file.tellg();
-        if (size <= 0) {
-            SPONGE_GL_ERROR("Unable to determine size of file: {}", path);
-            return code;
-        }
-        file.seekg(0, std::ios::beg);
-        code.resize(size);
-        file.read(code.data(), size);
-        file.close();
-    } else {
-        SPONGE_GL_ERROR("Unable to open file: {}", path);
-    }
-
-    return code;
 }
 
 }  // namespace sponge::platform::opengl::renderer

--- a/sponge/src/platform/opengl/renderer/shader.hpp
+++ b/sponge/src/platform/opengl/renderer/shader.hpp
@@ -52,8 +52,6 @@ private:
     uint32_t    compileShader(GLenum type, const std::string& source) const;
     uint32_t    linkProgram(uint32_t vs, uint32_t fs,
                             std::optional<uint32_t> gs = std::nullopt) const;
-    std::string loadSourceFromFile(const std::string& path) const;
-
     uint32_t    program = 0;
     std::string shaderName;
 

--- a/sponge/src/platform/opengl/renderer/shaderutils.hpp
+++ b/sponge/src/platform/opengl/renderer/shaderutils.hpp
@@ -1,0 +1,30 @@
+// sponge/src/platform/opengl/renderer/shaderutils.hpp
+#pragma once
+
+#include "logging/log.hpp"
+
+#include <fstream>
+#include <string>
+
+namespace sponge::platform::opengl::renderer {
+
+inline std::string loadGlslSource(const std::string& path) {
+    std::string code;
+    if (std::ifstream file(path, std::ios::in | std::ios::binary);
+        file.good()) {
+        file.seekg(0, std::ios::end);
+        const auto size = file.tellg();
+        if (size <= 0) {
+            SPONGE_GL_ERROR("Unable to determine size of file: {}", path);
+            return code;
+        }
+        file.seekg(0, std::ios::beg);
+        code.resize(size);
+        file.read(code.data(), size);
+    } else {
+        SPONGE_GL_ERROR("Unable to open shader file: {}", path);
+    }
+    return code;
+}
+
+}  // namespace sponge::platform::opengl::renderer

--- a/sponge/src/platform/opengl/renderer/ssbo.cpp
+++ b/sponge/src/platform/opengl/renderer/ssbo.cpp
@@ -1,0 +1,48 @@
+#include "platform/opengl/renderer/ssbo.hpp"
+
+#include "platform/opengl/renderer/gl.hpp"
+
+namespace sponge::platform::opengl::renderer {
+
+SSBO::SSBO(const std::size_t bytes) {
+    glGenBuffers(1, &id);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
+    glBufferData(GL_SHADER_STORAGE_BUFFER, static_cast<GLsizeiptr>(bytes),
+                 nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
+
+SSBO::SSBO(SSBO&& other) noexcept {
+    id       = other.id;
+    other.id = 0;
+}
+
+SSBO& SSBO::operator=(SSBO&& other) noexcept {
+    if (this != &other) {
+        if (id != 0) {
+            glDeleteBuffers(1, &id);
+        }
+        id       = other.id;
+        other.id = 0;
+    }
+    return *this;
+}
+
+SSBO::~SSBO() {
+    if (id != 0) {
+        glDeleteBuffers(1, &id);
+    }
+}
+
+void SSBO::update(const void* data, const std::size_t bytes) const {
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
+    glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, static_cast<GLsizeiptr>(bytes),
+                    data);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
+
+void SSBO::bindBase(const uint32_t binding) const {
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, binding, id);
+}
+
+}  // namespace sponge::platform::opengl::renderer

--- a/sponge/src/platform/opengl/renderer/ssbo.hpp
+++ b/sponge/src/platform/opengl/renderer/ssbo.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace sponge::platform::opengl::renderer {
+
+class SSBO final {
+public:
+    explicit SSBO(std::size_t bytes);
+    ~SSBO();
+
+    SSBO(const SSBO&)            = delete;
+    SSBO& operator=(const SSBO&) = delete;
+    SSBO(SSBO&& other) noexcept;
+    SSBO& operator=(SSBO&& other) noexcept;
+
+    void update(const void* data, std::size_t bytes) const;
+    void bindBase(uint32_t binding) const;
+
+    uint32_t getId() const {
+        return id;
+    }
+
+private:
+    mutable uint32_t id = 0;
+};
+
+}  // namespace sponge::platform::opengl::renderer

--- a/sponge/src/platform/opengl/scene/bitmapfont.cpp
+++ b/sponge/src/platform/opengl/scene/bitmapfont.cpp
@@ -8,12 +8,12 @@
 #include <string_view>
 
 namespace {
-constexpr size_t kMaxLength   = 256;
-constexpr size_t kIndexCount  = 6;
-constexpr size_t kVertexCount = 8;
+constexpr size_t maxLength   = 256;
+constexpr size_t indexCount  = 6;
+constexpr size_t vertexCount = 8;
 
-std::array<uint32_t, kMaxLength * kIndexCount>   batchIndices;
-std::array<glm::vec2, kMaxLength * kVertexCount> batchVertices;
+std::array<uint32_t, maxLength * indexCount>   batchIndices;
+std::array<glm::vec2, maxLength * vertexCount> batchVertices;
 }  // namespace
 
 namespace sponge::platform::opengl::scene {
@@ -34,11 +34,11 @@ BitmapFont::BitmapFont(const FontCreateInfo& createInfo) {
     vao->bind();
 
     vbo = std::make_unique<renderer::VertexBuffer>(
-        nullptr, kMaxLength * kVertexCount * sizeof(glm::vec2));
+        nullptr, maxLength * vertexCount * sizeof(glm::vec2));
     vbo->bind();
 
     ebo = std::make_unique<renderer::IndexBuffer>(
-        nullptr, kMaxLength * kIndexCount * sizeof(uint32_t));
+        nullptr, maxLength * indexCount * sizeof(uint32_t));
     ebo->bind();
 
     constexpr uint32_t pos = 0;
@@ -80,7 +80,7 @@ uint32_t BitmapFont::getHeight(const uint32_t size) const {
 uint32_t BitmapFont::getLength(const std::string_view text,
                                const uint32_t         size) {
     const auto str =
-        text.length() > kMaxLength ? text.substr(0, kMaxLength) : text;
+        text.length() > maxLength ? text.substr(0, maxLength) : text;
 
     float penX = 0.0F;
     for (const auto& shapedGlyph : atlas.shape(str, size)) {
@@ -105,7 +105,7 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
     assert(passTargetSize != 0);
 
     const auto str =
-        text.length() > kMaxLength ? text.substr(0, kMaxLength) : text;
+        text.length() > maxLength ? text.substr(0, maxLength) : text;
 
     const float ascender   = atlas.getAscender(passTargetSize);
     float       penX       = position.x;
@@ -127,7 +127,7 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
             const float uRight  = glyphInfo->uvLeft + glyphInfo->uvWidth;
             const float vBottom = glyphInfo->uvTop + glyphInfo->uvHeight;
 
-            const std::array<glm::vec2, kVertexCount> vertices{
+            const std::array<glm::vec2, vertexCount> vertices{
                 { { xpos, ypos + glyphHeight },
                   { uLeft, vBottom },
                   { xpos, ypos },
@@ -140,16 +140,16 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
 
             std::copy(vertices.begin(), vertices.end(),
                       batchVertices.begin() +
-                          static_cast<ptrdiff_t>(glyphCount * kVertexCount));
+                          static_cast<ptrdiff_t>(glyphCount * vertexCount));
 
-            const std::array<uint32_t, kIndexCount> indices = {
+            const std::array<uint32_t, indexCount> indices = {
                 glyphCount * 4, (glyphCount * 4) + 2, (glyphCount * 4) + 1,
                 glyphCount * 4, (glyphCount * 4) + 3, (glyphCount * 4) + 2
             };
 
             std::copy(indices.begin(), indices.end(),
                       batchIndices.begin() +
-                          static_cast<ptrdiff_t>(glyphCount * kIndexCount));
+                          static_cast<ptrdiff_t>(glyphCount * indexCount));
             glyphCount++;
         }
 
@@ -163,10 +163,10 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
     shader->setFloat3("textColor", color);
 
     vbo->update(batchVertices.data(),
-                glyphCount * kVertexCount * sizeof(glm::vec2));
-    ebo->update(batchIndices.data(), glyphCount * kIndexCount);
+                glyphCount * vertexCount * sizeof(glm::vec2));
+    ebo->update(batchIndices.data(), glyphCount * indexCount);
 
-    glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(glyphCount * kIndexCount),
+    glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(glyphCount * indexCount),
                    GL_UNSIGNED_INT, nullptr);
 }
 

--- a/sponge/src/platform/opengl/scene/bloom.cpp
+++ b/sponge/src/platform/opengl/scene/bloom.cpp
@@ -199,19 +199,25 @@ void Bloom::process(const float threshold) const {
     }
     downShader->unbind();
 
-    // Upsample: from deepest down level back up to up[0]
+    // Upsample: from deepest down level back up to up[0], accumulating each
+    // level's downsample so the coarsest mip's texel structure never shows.
     upShader->bind();
     upShader->setFloat("offset", 1.0F);
     for (int i = numLevels - 1; i >= 0; i--) {
         glBindFramebuffer(GL_FRAMEBUFFER, upFbos[i]);
         glViewport(0, 0, static_cast<GLsizei>(width >> (i + 1)),
                    static_cast<GLsizei>(height >> (i + 1)));
+        upShader->setFloat("accumulate", i == numLevels - 1 ? 0.F : 1.F);
+        glActiveTexture(GL_TEXTURE1);
+        glBindTexture(GL_TEXTURE_2D, downTextures[i]);
+        glActiveTexture(GL_TEXTURE0);
         const uint32_t src =
             (i == numLevels - 1) ? downTextures[i] : upTextures[i + 1];
         glBindTexture(GL_TEXTURE_2D, src);
         renderQuad();
     }
     upShader->unbind();
+    glActiveTexture(GL_TEXTURE0);
 
     glViewport(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height));
     glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/sponge/src/platform/opengl/scene/clusteredlights.cpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.cpp
@@ -1,0 +1,148 @@
+// sponge/src/platform/opengl/scene/clusteredlights.cpp
+#include "platform/opengl/scene/clusteredlights.hpp"
+
+#include "platform/opengl/renderer/gl.hpp"
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace sponge::platform::opengl::scene {
+
+namespace {
+constexpr int kMaxLights = 500;
+}  // namespace
+
+ClusteredLights::ClusteredLights(const float near, const float far) :
+    near(near),
+    far(far),
+    clusterAABBs(kNumClusters),
+    lightBuffer(static_cast<std::size_t>(kMaxLights) * sizeof(PointLightGPU)),
+    lightGrid(static_cast<std::size_t>(kNumClusters) * sizeof(glm::uvec2)),
+    lightIndices(static_cast<std::size_t>(kNumClusters) * kMaxLightsPerCluster *
+                 sizeof(uint32_t)),
+    clusterAABBsSSBO(static_cast<std::size_t>(kNumClusters) *
+                     sizeof(ClusterAABB)),
+    computeParamsSSBO(sizeof(ComputeParams)),
+    assignShader("cluster_assign", "/shaders/glsl/cluster_assign.comp.glsl") {}
+
+void ClusteredLights::buildClusterAABBs(const glm::mat4& projection) {
+    const glm::mat4 invProj = glm::inverse(projection);
+
+    for (int z = 0; z < kTilesZ; ++z) {
+        // Z subdivision: sliceNear_k = near * pow(far/near, k/kTilesZ).
+        // Must match clusterIndex() in clustered.slang.
+        const float sliceNear =
+            near * std::pow(far / near, static_cast<float>(z) / kTilesZ);
+        const float sliceFar =
+            near * std::pow(far / near, static_cast<float>(z + 1) / kTilesZ);
+
+        for (int y = 0; y < kTilesY; ++y) {
+            for (int x = 0; x < kTilesX; ++x) {
+                const float ndcXMin =
+                    2.F * static_cast<float>(x) / kTilesX - 1.F;
+                const float ndcXMax =
+                    2.F * static_cast<float>(x + 1) / kTilesX - 1.F;
+                const float ndcYMin =
+                    2.F * static_cast<float>(y) / kTilesY - 1.F;
+                const float ndcYMax =
+                    2.F * static_cast<float>(y + 1) / kTilesY - 1.F;
+
+                // Unproject screen corners to unit view-space direction
+                // vectors.
+                auto unprojectCorner = [&](float nx, float ny) -> glm::vec3 {
+                    const glm::vec4 ndc{ nx, ny, -1.F, 1.F };
+                    auto            v = invProj * ndc;
+                    v /= v.w;
+                    return glm::normalize(glm::vec3(v));
+                };
+
+                const glm::vec3 dir00 = unprojectCorner(ndcXMin, ndcYMin);
+                const glm::vec3 dir10 = unprojectCorner(ndcXMax, ndcYMin);
+                const glm::vec3 dir01 = unprojectCorner(ndcXMin, ndcYMax);
+                const glm::vec3 dir11 = unprojectCorner(ndcXMax, ndcYMax);
+
+                // Scale each corner direction to the near and far depth planes.
+                auto scaleToDepth = [](const glm::vec3& dir,
+                                       float            d) -> glm::vec3 {
+                    return dir * (d / std::abs(dir.z));
+                };
+
+                glm::vec3 minB{ std::numeric_limits<float>::max() };
+                glm::vec3 maxB{ -std::numeric_limits<float>::max() };
+
+                for (const auto& dir : { dir00, dir10, dir01, dir11 }) {
+                    for (const float d : { sliceNear, sliceFar }) {
+                        const glm::vec3 pt = scaleToDepth(dir, d);
+                        minB               = glm::min(minB, pt);
+                        maxB               = glm::max(maxB, pt);
+                    }
+                }
+
+                const int idx = x + y * kTilesX + z * kTilesX * kTilesY;
+                clusterAABBs[static_cast<std::size_t>(idx)] = {
+                    .minBounds = minB,
+                    .padMin    = 0.F,
+                    .maxBounds = maxB,
+                    .padMax    = 0.F,
+                };
+            }
+        }
+    }
+
+    clusterAABBsSSBO.update(clusterAABBs.data(),
+                            static_cast<std::size_t>(kNumClusters) *
+                                sizeof(ClusterAABB));
+}
+
+void ClusteredLights::update(const glm::vec3* positions,
+                             const glm::vec3* colors,
+                             const int* attenuationIndices, const int numLights,
+                             const glm::mat4& view,
+                             const glm::mat4& projection) {
+    if (projection != lastProjection) {
+        buildClusterAABBs(projection);
+        lastProjection = projection;
+    }
+
+    std::vector<PointLightGPU> gpuLights(static_cast<std::size_t>(numLights));
+    for (int i = 0; i < numLights; ++i) {
+        gpuLights[static_cast<std::size_t>(i)] = {
+            .color            = colors[i],
+            .pad0             = 0.F,
+            .position         = positions[i],
+            .attenuationIndex = attenuationIndices[i],
+            .pad1             = {},
+        };
+    }
+    lightBuffer.update(gpuLights.data(), static_cast<std::size_t>(numLights) *
+                                             sizeof(PointLightGPU));
+
+    const ComputeParams params{
+        .view      = view,
+        .near      = near,
+        .far       = far,
+        .numLights = numLights,
+        .pad       = 0,
+    };
+    computeParamsSSBO.update(&params, sizeof(ComputeParams));
+
+    lightBuffer.bindBase(3);
+    lightGrid.bindBase(4);
+    lightIndices.bindBase(5);
+    clusterAABBsSSBO.bindBase(6);
+    computeParamsSSBO.bindBase(7);
+
+    // 256 clusters / 64 threads per group = 4 dispatch groups.
+    assignShader.dispatch(static_cast<uint32_t>(kNumClusters / 64));
+
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+}
+
+void ClusteredLights::bindSSBOs() const {
+    lightBuffer.bindBase(3);
+    lightGrid.bindBase(4);
+    lightIndices.bindBase(5);
+}
+
+}  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/clusteredlights.cpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.cpp
@@ -10,18 +10,18 @@
 namespace sponge::platform::opengl::scene {
 
 namespace {
-constexpr int kMaxLights = 500;
+constexpr int maxLights = 500;
 }  // namespace
 
 ClusteredLights::ClusteredLights(const float near, const float far) :
     near(near),
     far(far),
-    clusterAABBs(kNumClusters),
-    lightBuffer(static_cast<std::size_t>(kMaxLights) * sizeof(PointLightGPU)),
-    lightGrid(static_cast<std::size_t>(kNumClusters) * sizeof(glm::uvec2)),
-    lightIndices(static_cast<std::size_t>(kNumClusters) * kMaxLightsPerCluster *
+    clusterAABBs(numClusters),
+    lightBuffer(static_cast<std::size_t>(maxLights) * sizeof(PointLightGPU)),
+    lightGrid(static_cast<std::size_t>(numClusters) * sizeof(glm::uvec2)),
+    lightIndices(static_cast<std::size_t>(numClusters) * maxLightsPerCluster *
                  sizeof(uint32_t)),
-    clusterAABBsSSBO(static_cast<std::size_t>(kNumClusters) *
+    clusterAABBsSSBO(static_cast<std::size_t>(numClusters) *
                      sizeof(ClusterAABB)),
     computeParamsSSBO(sizeof(ComputeParams)),
     assignShader("cluster_assign", "/shaders/glsl/cluster_assign.comp.glsl") {}
@@ -29,24 +29,24 @@ ClusteredLights::ClusteredLights(const float near, const float far) :
 void ClusteredLights::buildClusterAABBs(const glm::mat4& projection) {
     const glm::mat4 invProj = glm::inverse(projection);
 
-    for (int z = 0; z < kTilesZ; ++z) {
+    for (int z = 0; z < tilesZ; ++z) {
         // Z subdivision: sliceNear_k = near * pow(far/near, k/kTilesZ).
         // Must match clusterIndex() in clustered.slang.
         const float sliceNear =
-            near * std::pow(far / near, static_cast<float>(z) / kTilesZ);
+            near * std::pow(far / near, static_cast<float>(z) / tilesZ);
         const float sliceFar =
-            near * std::pow(far / near, static_cast<float>(z + 1) / kTilesZ);
+            near * std::pow(far / near, static_cast<float>(z + 1) / tilesZ);
 
-        for (int y = 0; y < kTilesY; ++y) {
-            for (int x = 0; x < kTilesX; ++x) {
+        for (int y = 0; y < tilesY; ++y) {
+            for (int x = 0; x < tilesX; ++x) {
                 const float ndcXMin =
-                    2.F * static_cast<float>(x) / kTilesX - 1.F;
+                    2.F * static_cast<float>(x) / tilesX - 1.F;
                 const float ndcXMax =
-                    2.F * static_cast<float>(x + 1) / kTilesX - 1.F;
+                    2.F * static_cast<float>(x + 1) / tilesX - 1.F;
                 const float ndcYMin =
-                    2.F * static_cast<float>(y) / kTilesY - 1.F;
+                    2.F * static_cast<float>(y) / tilesY - 1.F;
                 const float ndcYMax =
-                    2.F * static_cast<float>(y + 1) / kTilesY - 1.F;
+                    2.F * static_cast<float>(y + 1) / tilesY - 1.F;
 
                 // Unproject screen corners to unit view-space direction
                 // vectors.
@@ -79,7 +79,7 @@ void ClusteredLights::buildClusterAABBs(const glm::mat4& projection) {
                     }
                 }
 
-                const int idx = x + y * kTilesX + z * kTilesX * kTilesY;
+                const int idx = x + y * tilesX + z * tilesX * tilesY;
                 clusterAABBs[static_cast<std::size_t>(idx)] = {
                     .minBounds = minB,
                     .padMin    = 0.F,
@@ -91,7 +91,7 @@ void ClusteredLights::buildClusterAABBs(const glm::mat4& projection) {
     }
 
     clusterAABBsSSBO.update(clusterAABBs.data(),
-                            static_cast<std::size_t>(kNumClusters) *
+                            static_cast<std::size_t>(numClusters) *
                                 sizeof(ClusterAABB));
 }
 
@@ -134,7 +134,7 @@ void ClusteredLights::update(const glm::vec3* positions,
     computeParamsSSBO.bindBase(7);
 
     // 256 clusters / 64 threads per group = 4 dispatch groups.
-    assignShader.dispatch(static_cast<uint32_t>(kNumClusters / 64));
+    assignShader.dispatch(static_cast<uint32_t>(numClusters / 64));
 
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 }

--- a/sponge/src/platform/opengl/scene/clusteredlights.cpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.cpp
@@ -16,26 +16,59 @@ constexpr int maxLights = 500;
 ClusteredLights::ClusteredLights(const float near, const float far) :
     near(near),
     far(far),
-    clusterAABBs(numClusters),
+    clusterAABBs(maxClusters),
     lightBuffer(static_cast<std::size_t>(maxLights) * sizeof(PointLightGPU)),
-    lightGrid(static_cast<std::size_t>(numClusters) * sizeof(glm::uvec2)),
-    lightIndices(static_cast<std::size_t>(numClusters) * maxLightsPerCluster *
+    lightGrid(static_cast<std::size_t>(maxClusters) * sizeof(glm::uvec2)),
+    lightIndices(static_cast<std::size_t>(maxClusters) * maxLightsPerCluster *
                  sizeof(uint32_t)),
-    clusterAABBsSSBO(static_cast<std::size_t>(numClusters) *
+    clusterAABBsSSBO(static_cast<std::size_t>(maxClusters) *
                      sizeof(ClusterAABB)),
     computeParamsSSBO(sizeof(ComputeParams)),
+    tileFlags(static_cast<std::size_t>(maxClusters) * sizeof(uint32_t)),
     assignShader("cluster_assign", "/shaders/glsl/cluster_assign.comp.glsl") {}
+
+void ClusteredLights::prepare(const glm::mat4& projection) {
+    if (projection != lastProjection) {
+        buildClusterAABBs(projection);
+        lastProjection = projection;
+    }
+
+    // Clear active-tile flags for this frame's depth prepass, and make the
+    // clear visible to the prepass fragment shader's writes.
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, tileFlags.getId());
+    glClearBufferData(GL_SHADER_STORAGE_BUFFER, GL_R32UI, GL_RED_INTEGER,
+                      GL_UNSIGNED_INT, nullptr);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+
+    tileFlags.bindBase(8);
+}
 
 void ClusteredLights::buildClusterAABBs(const glm::mat4& projection) {
     const glm::mat4 invProj = glm::inverse(projection);
 
+    // FOV-derived z-slice count (van Oosten eq. 8.2) so tiles are roughly
+    // cubic. For glm perspective projections, projection[1][1] = 1/tan(fov/2).
+    const float tanHalfFov = 1.F / projection[1][1];
+    tilesZ                 = glm::clamp(
+        static_cast<int>(std::ceil(
+            std::log(far / clusterNear) /
+            std::log(1.F + 2.F * tanHalfFov / static_cast<float>(tilesY)))),
+        1, maxTilesZ);
+    numClusters = tilesX * tilesY * tilesZ;
+
     for (int z = 0; z < tilesZ; ++z) {
-        // Z subdivision: sliceNear_k = near * pow(far/near, k/kTilesZ).
-        // Must match clusterIndex() in clustered.slang.
+        // Z subdivision: sliceNear_k = clusterNear * pow(far/clusterNear,
+        // k/tilesZ). Must match clusterIndex() in clustered.slang. Slice 0
+        // extends to the camera near plane so fragments closer than
+        // clusterNear (which clamp into slice 0) are still inside its AABB.
         const float sliceNear =
-            near * std::pow(far / near, static_cast<float>(z) / tilesZ);
+            z == 0 ? near :
+                     clusterNear * std::pow(far / clusterNear,
+                                            static_cast<float>(z) / tilesZ);
         const float sliceFar =
-            near * std::pow(far / near, static_cast<float>(z + 1) / tilesZ);
+            clusterNear *
+            std::pow(far / clusterNear, static_cast<float>(z + 1) / tilesZ);
 
         for (int y = 0; y < tilesY; ++y) {
             for (int x = 0; x < tilesX; ++x) {
@@ -98,13 +131,7 @@ void ClusteredLights::buildClusterAABBs(const glm::mat4& projection) {
 void ClusteredLights::update(const glm::vec3* positions,
                              const glm::vec3* colors,
                              const int* attenuationIndices, const int numLights,
-                             const glm::mat4& view,
-                             const glm::mat4& projection) {
-    if (projection != lastProjection) {
-        buildClusterAABBs(projection);
-        lastProjection = projection;
-    }
-
+                             const glm::mat4& view) {
     std::vector<PointLightGPU> gpuLights(static_cast<std::size_t>(numLights));
     for (int i = 0; i < numLights; ++i) {
         gpuLights[static_cast<std::size_t>(i)] = {
@@ -120,13 +147,13 @@ void ClusteredLights::update(const glm::vec3* positions,
 
     // glm is column-major: row r of the view matrix is (view[c][r] for c 0..3).
     const ComputeParams params{
-        .viewRow0  = { view[0][0], view[1][0], view[2][0], view[3][0] },
-        .viewRow1  = { view[0][1], view[1][1], view[2][1], view[3][1] },
-        .viewRow2  = { view[0][2], view[1][2], view[2][2], view[3][2] },
-        .near      = near,
-        .far       = far,
-        .numLights = numLights,
-        .pad       = 0,
+        .viewRow0    = { view[0][0], view[1][0], view[2][0], view[3][0] },
+        .viewRow1    = { view[0][1], view[1][1], view[2][1], view[3][1] },
+        .viewRow2    = { view[0][2], view[1][2], view[2][2], view[3][2] },
+        .near        = near,
+        .far         = far,
+        .numLights   = numLights,
+        .numClusters = numClusters,
     };
     computeParamsSSBO.update(&params, sizeof(ComputeParams));
 
@@ -135,9 +162,12 @@ void ClusteredLights::update(const glm::vec3* positions,
     lightIndices.bindBase(5);
     clusterAABBsSSBO.bindBase(6);
     computeParamsSSBO.bindBase(7);
+    tileFlags.bindBase(8);
 
-    // 256 clusters / 64 threads per group = 4 dispatch groups.
-    assignShader.dispatch(static_cast<uint32_t>(numClusters / 64));
+    // Make the depth prepass's tile-flag writes visible to the compute pass.
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+
+    assignShader.dispatch(static_cast<uint32_t>((numClusters + 63) / 64));
 
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 }

--- a/sponge/src/platform/opengl/scene/clusteredlights.cpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.cpp
@@ -118,8 +118,11 @@ void ClusteredLights::update(const glm::vec3* positions,
     lightBuffer.update(gpuLights.data(), static_cast<std::size_t>(numLights) *
                                              sizeof(PointLightGPU));
 
+    // glm is column-major: row r of the view matrix is (view[c][r] for c 0..3).
     const ComputeParams params{
-        .view      = view,
+        .viewRow0  = { view[0][0], view[1][0], view[2][0], view[3][0] },
+        .viewRow1  = { view[0][1], view[1][1], view[2][1], view[3][1] },
+        .viewRow2  = { view[0][2], view[1][2], view[2][2], view[3][2] },
         .near      = near,
         .far       = far,
         .numLights = numLights,

--- a/sponge/src/platform/opengl/scene/clusteredlights.hpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.hpp
@@ -1,0 +1,90 @@
+// sponge/src/platform/opengl/scene/clusteredlights.hpp
+#pragma once
+
+#include "platform/opengl/renderer/computeshader.hpp"
+#include "platform/opengl/renderer/ssbo.hpp"
+
+#include <glm/glm.hpp>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace sponge::platform::opengl::scene {
+
+class ClusteredLights {
+public:
+    // Grid dimensions — must match TILES_X/Y/Z in clustered.slang and
+    // cluster_assign.comp.glsl.
+    static constexpr int kTilesX      = 8;
+    static constexpr int kTilesY      = 4;
+    static constexpr int kTilesZ      = 8;
+    static constexpr int kNumClusters = kTilesX * kTilesY * kTilesZ;
+    static constexpr int kMaxLightsPerCluster =
+        128;  // must match MAX_LIGHTS_PER_CLUSTER
+
+    ClusteredLights(float near, float far);
+
+    // Dispatches the clustered light-culling compute shader.
+    void update(const glm::vec3* positions, const glm::vec3* colors,
+                const int* attenuationIndices, int numLights,
+                const glm::mat4& view, const glm::mat4& projection);
+
+    void bindSSBOs() const;
+
+private:
+    // std430 layout, 48 bytes — must match PointLightGPU in
+    // cluster_assign.comp.glsl
+    struct PointLightGPU {
+        glm::vec3            color;
+        float                pad0;
+        glm::vec3            position;
+        int                  attenuationIndex;
+        std::array<float, 4> pad1{};
+    };
+    static_assert(sizeof(PointLightGPU) == 48);
+
+    // std430-compatible: explicit padding so vec3 → 16-byte slot.
+    // Must match ClusterAABB in cluster_assign.comp.glsl.
+    struct ClusterAABB {
+        glm::vec3 minBounds;
+        float     padMin{ 0.F };
+        glm::vec3 maxBounds;
+        float     padMax{ 0.F };
+    };
+    static_assert(sizeof(ClusterAABB) == 32);
+
+    // std430 layout, 80 bytes — must match ComputeParams in
+    // cluster_assign.comp.glsl
+    struct ComputeParams {
+        glm::mat4 view{ 1.F };
+        float     near{ 0.F };
+        float     far{ 0.F };
+        int       numLights{ 0 };
+        int       pad{ 0 };
+    };
+    static_assert(sizeof(ComputeParams) == 80);
+
+    // Precomputes view-space AABBs for all clusters from the projection matrix.
+    // Called once per unique projection (e.g., on FOV/resize change).
+    // Z subdivision: sliceNear_k = near * pow(far/near, k/kTilesZ).
+    // Must match clusterIndex() in clustered.slang and the GLSL compute shader.
+    void buildClusterAABBs(const glm::mat4& projection);
+
+    float     near;
+    float     far;
+    glm::mat4 lastProjection{ 0.F };
+
+    std::vector<ClusterAABB> clusterAABBs;
+
+    renderer::SSBO lightBuffer;  // binding 3 — PointLightGPU[]
+    renderer::SSBO lightGrid;  // binding 4 — uvec2[] (base, count) per cluster
+    renderer::SSBO lightIndices;  // binding 5 — uint[] light index list
+    renderer::SSBO
+        clusterAABBsSSBO;  // binding 6 — ClusterAABB[] (compute input)
+    renderer::SSBO computeParamsSSBO;  // binding 7 — ComputeParams
+
+    renderer::ComputeShader assignShader;
+};
+
+}  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/clusteredlights.hpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.hpp
@@ -16,11 +16,11 @@ class ClusteredLights {
 public:
     // Grid dimensions — must match TILES_X/Y/Z in clustered.slang and
     // cluster_assign.comp.glsl.
-    static constexpr int kTilesX      = 8;
-    static constexpr int kTilesY      = 4;
-    static constexpr int kTilesZ      = 8;
-    static constexpr int kNumClusters = kTilesX * kTilesY * kTilesZ;
-    static constexpr int kMaxLightsPerCluster =
+    static constexpr int tilesX      = 8;
+    static constexpr int tilesY      = 4;
+    static constexpr int tilesZ      = 8;
+    static constexpr int numClusters = tilesX * tilesY * tilesZ;
+    static constexpr int maxLightsPerCluster =
         128;  // must match MAX_LIGHTS_PER_CLUSTER
 
     ClusteredLights(float near, float far);

--- a/sponge/src/platform/opengl/scene/clusteredlights.hpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.hpp
@@ -16,9 +16,9 @@ class ClusteredLights {
 public:
     // Grid dimensions — must match TILES_X/Y/Z in clustered.slang and
     // cluster_assign.comp.glsl.
-    static constexpr int tilesX      = 8;
-    static constexpr int tilesY      = 4;
-    static constexpr int tilesZ      = 8;
+    static constexpr int tilesX      = 16;
+    static constexpr int tilesY      = 9;
+    static constexpr int tilesZ      = 24;
     static constexpr int numClusters = tilesX * tilesY * tilesZ;
     static constexpr int maxLightsPerCluster =
         128;  // must match MAX_LIGHTS_PER_CLUSTER

--- a/sponge/src/platform/opengl/scene/clusteredlights.hpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.hpp
@@ -20,8 +20,10 @@ public:
     static constexpr int tilesY      = 9;
     static constexpr int tilesZ      = 24;
     static constexpr int numClusters = tilesX * tilesY * tilesZ;
-    static constexpr int maxLightsPerCluster =
-        128;  // must match MAX_LIGHTS_PER_CLUSTER
+    // Must match MAX_LIGHTS_PER_CLUSTER in clustered.slang. Sized >= the max
+    // scene light count so per-cluster truncation (visible cluster seams)
+    // cannot occur. ~7 MB of index storage at 512.
+    static constexpr int maxLightsPerCluster = 512;
 
     ClusteredLights(float near, float far);
 
@@ -54,16 +56,20 @@ private:
     };
     static_assert(sizeof(ClusterAABB) == 32);
 
-    // std430 layout, 80 bytes — must match ComputeParams in
-    // cluster_assign.comp.glsl
+    // std430 layout, 64 bytes — must match ComputeParams in
+    // cluster_assign.slang. The view transform is passed as explicit rows
+    // (not a mat4): SSBO matrix layout qualifiers on nested structs are
+    // driver-inconsistent, and a transposed read silently breaks culling.
     struct ComputeParams {
-        glm::mat4 view{ 1.F };
+        glm::vec4 viewRow0{ 0.F };
+        glm::vec4 viewRow1{ 0.F };
+        glm::vec4 viewRow2{ 0.F };
         float     near{ 0.F };
         float     far{ 0.F };
         int       numLights{ 0 };
         int       pad{ 0 };
     };
-    static_assert(sizeof(ComputeParams) == 80);
+    static_assert(sizeof(ComputeParams) == 64);
 
     // Precomputes view-space AABBs for all clusters from the projection matrix.
     // Called once per unique projection (e.g., on FOV/resize change).

--- a/sponge/src/platform/opengl/scene/clusteredlights.hpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.hpp
@@ -14,25 +14,38 @@ namespace sponge::platform::opengl::scene {
 
 class ClusteredLights {
 public:
-    // Grid dimensions — must match TILES_X/Y/Z in clustered.slang and
-    // cluster_assign.comp.glsl.
+    // Screen tile grid — must match TILES_X/Y in clustered.slang. The
+    // z-slice count is runtime, derived from the FOV so tiles are roughly
+    // cubic (van Oosten eq. 8.2); buffers are sized for maxTilesZ.
     static constexpr int tilesX      = 16;
     static constexpr int tilesY      = 9;
-    static constexpr int tilesZ      = 24;
-    static constexpr int numClusters = tilesX * tilesY * tilesZ;
+    static constexpr int maxTilesZ   = 96;  // FOV 30° needs 80 slices
+    static constexpr int maxClusters = tilesX * tilesY * maxTilesZ;
+    // Near bound of the cluster grid; slices below it are wasted on empty
+    // space in front of the camera. Slice 0's AABB extends to the camera
+    // near plane so closer fragments are still covered.
+    static constexpr float clusterNear = 1.F;
     // Must match MAX_LIGHTS_PER_CLUSTER in clustered.slang. Sized >= the max
     // scene light count so per-cluster truncation (visible cluster seams)
-    // cannot occur. ~7 MB of index storage at 512.
+    // cannot occur. ~28 MB of index storage at 512 x maxClusters.
     static constexpr int maxLightsPerCluster = 512;
 
     ClusteredLights(float near, float far);
 
+    // Rebuilds the grid if the projection changed and clears the active-tile
+    // flags. Call once per frame before the depth prepass writes tile flags.
+    void prepare(const glm::mat4& projection);
+
     // Dispatches the clustered light-culling compute shader.
     void update(const glm::vec3* positions, const glm::vec3* colors,
                 const int* attenuationIndices, int numLights,
-                const glm::mat4& view, const glm::mat4& projection);
+                const glm::mat4& view);
 
     void bindSSBOs() const;
+
+    int getTilesZ() const {
+        return tilesZ;
+    }
 
 private:
     // std430 layout, 48 bytes — must match PointLightGPU in
@@ -67,7 +80,7 @@ private:
         float     near{ 0.F };
         float     far{ 0.F };
         int       numLights{ 0 };
-        int       pad{ 0 };
+        int       numClusters{ 0 };
     };
     static_assert(sizeof(ComputeParams) == 64);
 
@@ -79,6 +92,8 @@ private:
 
     float     near;
     float     far;
+    int       tilesZ      = 1;
+    int       numClusters = tilesX * tilesY;
     glm::mat4 lastProjection{ 0.F };
 
     std::vector<ClusterAABB> clusterAABBs;
@@ -89,6 +104,7 @@ private:
     renderer::SSBO
         clusterAABBsSSBO;  // binding 6 — ClusterAABB[] (compute input)
     renderer::SSBO computeParamsSSBO;  // binding 7 — ComputeParams
+    renderer::SSBO tileFlags;          // binding 8 — uint[] active-tile flags
 
     renderer::ComputeShader assignShader;
 };

--- a/sponge/src/platform/opengl/scene/cube.cpp
+++ b/sponge/src/platform/opengl/scene/cube.cpp
@@ -49,10 +49,10 @@ Cube::Cube() {
                                                    sizeof(vertices));
     vbo->bind();
 
-    constexpr uint32_t kPositionLoc = 0;
-    glEnableVertexAttribArray(kPositionLoc);
-    glVertexAttribPointer(kPositionLoc, 3, GL_FLOAT, GL_FALSE,
-                          sizeof(glm::vec3), reinterpret_cast<const void*>(0));
+    constexpr uint32_t positionLoc = 0;
+    glEnableVertexAttribArray(positionLoc);
+    glVertexAttribPointer(positionLoc, 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3),
+                          reinterpret_cast<const void*>(0));
 
     shader->unbind();
     vao->unbind();

--- a/sponge/src/platform/opengl/scene/fxaa.cpp
+++ b/sponge/src/platform/opengl/scene/fxaa.cpp
@@ -47,13 +47,13 @@ void FXAA::initialize() {
                                                    sizeof(quadVertices));
     vbo->bind();
 
-    constexpr uint32_t kPositionLoc = 0;
-    constexpr uint32_t kTexCoordLoc = 1;
-    glEnableVertexAttribArray(kPositionLoc);
-    glVertexAttribPointer(kPositionLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
+    constexpr uint32_t positionLoc = 0;
+    constexpr uint32_t texCoordLoc = 1;
+    glEnableVertexAttribArray(positionLoc);
+    glVertexAttribPointer(positionLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
                           reinterpret_cast<const void*>(0));
-    glEnableVertexAttribArray(kTexCoordLoc);
-    glVertexAttribPointer(kTexCoordLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
+    glEnableVertexAttribArray(texCoordLoc);
+    glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
                           reinterpret_cast<const void*>(2 * sizeof(float)));
 
     shader->unbind();

--- a/sponge/src/platform/opengl/scene/mesh.cpp
+++ b/sponge/src/platform/opengl/scene/mesh.cpp
@@ -10,9 +10,9 @@
 
 namespace {
 // Slang-generated layout locations for pbr.vert.slang
-constexpr uint32_t kPositionLoc = 0;
-constexpr uint32_t kTexCoordLoc = 1;
-constexpr uint32_t kNormalLoc   = 2;
+constexpr uint32_t positionLoc = 0;
+constexpr uint32_t texCoordLoc = 1;
+constexpr uint32_t normalLoc   = 2;
 }  // namespace
 
 namespace sponge::platform::opengl::scene {
@@ -49,19 +49,19 @@ Mesh::Mesh(std::vector<Vertex>&& vertices, const std::size_t numVertices,
         this->vertices.data(), numVertices * sizeof(Vertex));
     vbo->bind();
 
-    glEnableVertexAttribArray(kPositionLoc);
-    glVertexAttribPointer(kPositionLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+    glEnableVertexAttribArray(positionLoc);
+    glVertexAttribPointer(positionLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
                           reinterpret_cast<const void*>(
                               offsetof(sponge::scene::Vertex, position)));
 
-    glEnableVertexAttribArray(kTexCoordLoc);
-    glVertexAttribPointer(kTexCoordLoc, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+    glEnableVertexAttribArray(texCoordLoc);
+    glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
                           reinterpret_cast<const void*>(
                               offsetof(sponge::scene::Vertex, texCoords)));
 
-    glEnableVertexAttribArray(kNormalLoc);
+    glEnableVertexAttribArray(normalLoc);
     glVertexAttribPointer(
-        kNormalLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+        normalLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
         reinterpret_cast<const void*>(offsetof(sponge::scene::Vertex, normal)));
 
     ebo = std::make_unique<renderer::IndexBuffer>(

--- a/sponge/src/platform/opengl/scene/quad.cpp
+++ b/sponge/src/platform/opengl/scene/quad.cpp
@@ -39,9 +39,9 @@ Quad::Quad() {
                                                   sizeof(indices));
     ebo->bind();
 
-    constexpr uint32_t kPositionLoc = 0;
-    glEnableVertexAttribArray(kPositionLoc);
-    glVertexAttribPointer(kPositionLoc, 2, GL_FLOAT, GL_FALSE,
+    constexpr uint32_t positionLoc = 0;
+    glEnableVertexAttribArray(positionLoc);
+    glVertexAttribPointer(positionLoc, 2, GL_FLOAT, GL_FALSE,
                           2 * sizeof(GLfloat),
                           reinterpret_cast<const void*>(0));
 

--- a/sponge/src/scene/fontatlas.cpp
+++ b/sponge/src/scene/fontatlas.cpp
@@ -13,11 +13,11 @@
 namespace sponge::scene {
 
 namespace {
-constexpr uint32_t kAtlasSize  = 1024;
-constexpr char32_t kFirstGlyph = 32;
-constexpr char32_t kLastGlyph  = 126;
+constexpr uint32_t atlasSize  = 1024;
+constexpr char32_t firstGlyph = 32;
+constexpr char32_t lastGlyph  = 126;
 
-constexpr std::array<char32_t, 1> kSupplementalGlyphs = {
+constexpr std::array<char32_t, 1> supplementalGlyphs = {
     0xD7,  // × MULTIPLICATION SIGN
 };
 }  // namespace
@@ -123,11 +123,11 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
             rects.push_back(rect);
         };
 
-        for (char32_t codepoint = kFirstGlyph; codepoint <= kLastGlyph;
+        for (char32_t codepoint = firstGlyph; codepoint <= lastGlyph;
              codepoint++) {
             rasterizeGlyph(codepoint);
         }
-        for (const char32_t codepoint : kSupplementalGlyphs) {
+        for (const char32_t codepoint : supplementalGlyphs) {
             rasterizeGlyph(codepoint);
         }
 
@@ -135,8 +135,8 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
         hbFonts[size]     = hbFont;
     }
 
-    textureWidth  = kAtlasSize;
-    textureHeight = kAtlasSize;
+    textureWidth  = atlasSize;
+    textureHeight = atlasSize;
     atlasBuffer.assign(textureWidth * textureHeight * 3, 0);
 
     std::vector<stbrp_node> nodes(textureWidth);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "maze",
   "version-string": "latest",
-  "builtin-baseline": "a0b1c8d3a477c1cb4813d8e127a56961707ca42b",
+  "builtin-baseline": "41b97d988ecdee7b2d8fd62feb7cc7fd1308fd86",
   "dependencies": [
     {
       "name": "fmt",


### PR DESCRIPTION
## Summary

Implements clustered (volume tiled) forward shading for point lights, following van Oosten, *Volume Tiled Forward Shading* (2017).

- 16x9 screen-tile grid with FOV-derived log-space z slices (roughly cubic volume tiles), view-space AABBs precomputed per projection
- compute-shader light assignment with conservative sphere/AABB tests; per-cluster capacity sized to the max scene light count so index lists never truncate
- active-tile culling: the depth prepass marks each fragment's cluster, and light assignment skips clusters with no visible fragments
- point-light radiance windowed to zero at the culling radius (Karis falloff) so per-cluster culling cannot leave seams

## Fixes surfaced while validating

- SSBO `mat4` in a nested struct is read transposed by the driver (GLSL `row_major` not honored) — the view transform is now passed as explicit `float4` rows
- fragment cluster z-slice derived from view-space depth; the `gl_FragCoord.z` decode disagrees with the slice AABBs on this pipeline
- EVSM shadow lookups guarded against fragments outside the shadow frustum xy
- bloom: soft-knee extraction and progressive upsample so coarse mip texel structure never shows; scatter and default intensity tuned to keep the previous glow strength
- interleaved gradient noise dither at final 8-bit writes to remove banding in dim gradients
- shader assets deploy via an always-run `copy_assets` target, so shader edits reach the runtime folder without relinking

## Testing

- verified per-fragment ground truth in a debug shader: every light in range of a fragment is present in its cluster's light list (renders black across the scene)
- exercised 0-500 lights across attenuation ranges 7-600, runtime FOV changes (grid rebuild), and window resize
- benchmarked at 500 lights: frame time within noise of the previous brute-force assignment in this scene (shading-dominated); assignment now scales with visible geometry instead of grid size