### PR TITLE
Format Slang shaders with clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,17 +34,18 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.44.0
+    rev: v1.48.0
     hooks:
       - id: typos
         exclude: .clang-tidy|assets/models|sponge/deps
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.0
+    rev: v22.1.5
     hooks:
       - id: clang-format
         args: [ --style=file, -i ]
-        files: "\\.(c|cpp|h|hpp|glsl)$"
+        types_or: [ file ]
+        files: "\\.(c|cpp|h|hpp|glsl|slang)$"
         exclude: sponge/deps
 
   - repo: https://github.com/cpplint/cpplint

--- a/assets/shaders/.clang-format
+++ b/assets/shaders/.clang-format
@@ -1,0 +1,6 @@
+---
+BasedOnStyle: InheritParentConfig
+AllowShortFunctionsOnASingleLine: All
+SortIncludes: Never
+ColumnLimit: 0
+...

--- a/assets/shaders/slang/bloom.slang
+++ b/assets/shaders/slang/bloom.slang
@@ -1,35 +1,39 @@
-// bloom.slang — brightness extraction, Dual Kawase bloom pipeline, composite
+// bloom.slang: brightness extraction, Dual Kawase bloom pipeline, composite
 #include "include/kawase.slang"
 #include "include/dither.slang"
 
 [[vk::binding(0)]] Sampler2D<float4> image;
 [[vk::binding(1)]] Sampler2D<float4> bloomTex;
-uniform float threshold;
-uniform float offset;
-uniform float intensity;
-uniform float accumulate;
+uniform float                        threshold;
+uniform float                        offset;
+uniform float                        intensity;
+uniform float                        accumulate;
 
-struct FSInput { float2 texCoords : TEXCOORD0; }
+struct FSInput {
+    float2 texCoords : TEXCOORD0;
+};
 
+// clang-format off
 [shader("fragment")]
-float4 extractFragMain(FSInput input) : SV_Target
-{
+float4 extractFragMain(FSInput input) : SV_Target {
+    // clang-format on
     float3 color      = image.Sample(input.texCoords).rgb;
     float  brightness = dot(color, float3(0.2126, 0.7152, 0.0722));
-    // Soft knee (Karis) — a hard threshold leaves energy cliffs that survive
+    // Soft knee (Karis): a hard threshold leaves energy cliffs that survive
     // the blur chain as visible mip-texel edges.
-    float knee = threshold * 0.5;
-    float soft = clamp(brightness - threshold + knee, 0.0, 2.0 * knee);
-    soft       = soft * soft / (4.0 * knee + 1e-4);
+    float knee         = threshold * 0.5;
+    float soft         = clamp(brightness - threshold + knee, 0.0, 2.0 * knee);
+    soft               = soft * soft / (4.0 * knee + 1e-4);
     float contribution = max(soft, brightness - threshold);
     return float4(color * (contribution / max(brightness, 1e-4)), 1.0);
-}
+};
 
+// clang-format off
 [shader("fragment")]
-float4 downFragMain(FSInput input) : SV_Target
-{
+float4 downFragMain(FSInput input) : SV_Target {
+    // clang-format on
     return float4(kawaseDown(image, input.texCoords, offset).rgb, 1.0);
-}
+};
 
 // Progressive upsample: blend the blurred coarse level with this level's
 // downsample so no single coarse mip dominates (its texel structure would
@@ -37,18 +41,20 @@ float4 downFragMain(FSInput input) : SV_Target
 // SCATTER weights the coarse chain: higher = wider, softer glow.
 static const float SCATTER = 0.7;
 
+// clang-format off
 [shader("fragment")]
-float4 upFragMain(FSInput input) : SV_Target
-{
+float4 upFragMain(FSInput input) : SV_Target {
+    // clang-format on
     float3 blurred = kawaseUp(image, input.texCoords, offset).rgb;
     float3 down    = bloomTex.Sample(input.texCoords).rgb;
     return float4(lerp(blurred, lerp(down, blurred, SCATTER), accumulate), 1.0);
-}
+};
 
+// clang-format off
 [shader("fragment")]
-float4 compositeFragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target
-{
+float4 compositeFragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target {
+    // clang-format on
     float3 color = image.Sample(input.texCoords).rgb;
     float3 bloom = bloomTex.Sample(input.texCoords).rgb;
     return float4(dither8(color + bloom * intensity, fragCoord.xy), 1.0);
-}
+};

--- a/assets/shaders/slang/blur.slang
+++ b/assets/shaders/slang/blur.slang
@@ -1,20 +1,24 @@
-// blur.slang — Dual Kawase blur for EVSM shadow maps (RG channels)
+// blur.slang: Dual Kawase blur for EVSM shadow maps (RG channels)
 // Sampler2D<float4> is valid for RG32F; hardware pads B=0, A=1
 #include "include/kawase.slang"
 
 [[vk::binding(0)]] Sampler2D<float4> image;
-uniform float offset;
+uniform float                        offset;
 
-struct FSInput { float2 texCoords : TEXCOORD0; }
+struct FSInput {
+    float2 texCoords : TEXCOORD0;
+};
 
+// clang-format off
 [shader("fragment")]
-float4 downFragMain(FSInput input) : SV_Target
-{
+float4 downFragMain(FSInput input) : SV_Target {
+    // clang-format on
     return float4(kawaseDown(image, input.texCoords, offset).rg, 0.0, 1.0);
-}
+};
 
+// clang-format off
 [shader("fragment")]
-float4 upFragMain(FSInput input) : SV_Target
-{
+float4 upFragMain(FSInput input) : SV_Target {
+    // clang-format on
     return float4(kawaseUp(image, input.texCoords, offset).rg, 0.0, 1.0);
-}
+};

--- a/assets/shaders/slang/cluster_assign.slang
+++ b/assets/shaders/slang/cluster_assign.slang
@@ -1,30 +1,27 @@
-// cluster_assign.slang — volume tiled forward light culling (reference; see cluster_assign.comp.glsl)
+// cluster_assign.slang: volume tiled forward light culling (reference; see cluster_assign.comp.glsl)
 // Note: compiled as hand-written GLSL; slangc emits unsupported extensions on this driver.
 #include "include/clustered.slang"
 
-struct PointLightGPU
-{
+struct PointLightGPU {
     float3 color;
     float  pad0;
-    float3 position;       // world-space
+    float3 position;  // world-space
     int    attenuationIndex;
     float4 pad1;
-}
+};
 
 // std430-compatible: explicit padding so float3 → 16-byte slot.
 // Must match ClusterAABB in clusteredlights.hpp.
-struct ClusterAABB
-{
+struct ClusterAABB {
     float3 minBounds;
     float  padMin;
     float3 maxBounds;
     float  padMax;
-}
+};
 
 // Must match ComputeParams in clusteredlights.hpp. View passed as explicit
-// rows — SSBO matrix layout on nested structs is driver-inconsistent.
-struct ComputeParams
-{
+// rows; SSBO matrix layout on nested structs is driver-inconsistent.
+struct ComputeParams {
     float4 viewRow0;
     float4 viewRow1;
     float4 viewRow2;
@@ -32,19 +29,19 @@ struct ComputeParams
     float  far;
     int    numLights;
     int    numClusters;
-}
+};
 
-[[vk::binding(3)]] StructuredBuffer<PointLightGPU>  lightBuffer;    // read
-[[vk::binding(4)]] RWStructuredBuffer<uint2>         lightGrid;      // write
-[[vk::binding(5)]] RWStructuredBuffer<uint>          lightIndices;   // write
-[[vk::binding(6)]] StructuredBuffer<ClusterAABB>     clusterAABBs;   // read
-[[vk::binding(7)]] StructuredBuffer<ComputeParams>   computeParams;  // read
-[[vk::binding(8)]] StructuredBuffer<uint>            tileFlags;      // read
+[[vk::binding(3)]] StructuredBuffer<PointLightGPU> lightBuffer;    // read
+[[vk::binding(4)]] RWStructuredBuffer<uint2>       lightGrid;      // write
+[[vk::binding(5)]] RWStructuredBuffer<uint>        lightIndices;   // write
+[[vk::binding(6)]] StructuredBuffer<ClusterAABB>   clusterAABBs;   // read
+[[vk::binding(7)]] StructuredBuffer<ComputeParams> computeParams;  // read
+[[vk::binding(8)]] StructuredBuffer<uint>          tileFlags;      // read
 
-[shader("compute")]
-[numthreads(64, 1, 1)]
-void csMain(uint3 tid : SV_DispatchThreadID)
-{
+// clang-format off
+[shader("compute")] [numthreads(64, 1, 1)]
+void csMain(uint3 tid : SV_DispatchThreadID) {
+    // clang-format on
     int           ci = int(tid.x);
     ComputeParams p  = computeParams[0];
     if (ci >= p.numClusters) {
@@ -63,8 +60,7 @@ void csMain(uint3 tid : SV_DispatchThreadID)
     ClusterAABB aabb  = clusterAABBs[ci];
     int         count = 0;
 
-    for (int i = 0; i < p.numLights && count < MAX_LIGHTS_PER_CLUSTER; ++i)
-    {
+    for (int i = 0; i < p.numLights && count < MAX_LIGHTS_PER_CLUSTER; ++i) {
         float4 wp    = float4(lightBuffer[i].position, 1.0);
         float3 vsPos = float3(dot(p.viewRow0, wp), dot(p.viewRow1, wp),
                               dot(p.viewRow2, wp));
@@ -73,12 +69,11 @@ void csMain(uint3 tid : SV_DispatchThreadID)
         float r    = attenuationRadius[aidx];
 
         float3 closest = clamp(vsPos, aabb.minBounds, aabb.maxBounds);
-        if (length(vsPos - closest) <= r)
-        {
+        if (length(vsPos - closest) <= r) {
             lightIndices[base + uint(count)] = uint(i);
             count++;
         }
     }
 
     lightGrid[ci] = uint2(base, uint(count));
-}
+};

--- a/assets/shaders/slang/cube.slang
+++ b/assets/shaders/slang/cube.slang
@@ -1,25 +1,28 @@
-// cube.slang — debug light-position cube vertex + fragment shader
+// cube.slang: debug light-position cube vertex + fragment shader
 uniform float4x4 mvp;
 uniform float3   lightColor;
 
-struct VSInput  { float3 position : POSITION; }
-struct VSOutput
-{
-    float4 pos   : SV_Position;
+struct VSInput {
+    float3 position : POSITION;
+};
+struct VSOutput {
+    float4 pos : SV_Position;
     float3 color : TEXCOORD0;
-}
+};
 
+// clang-format off
 [shader("vertex")]
-VSOutput vertMain(VSInput input)
-{
+VSOutput vertMain(VSInput input) {
+    // clang-format on
     VSOutput output;
     output.pos   = mul(mvp, float4(input.position, 1.0));
     output.color = lightColor;
     return output;
-}
+};
 
+// clang-format off
 [shader("fragment")]
-float4 fragMain(VSOutput input) : SV_Target
-{
+float4 fragMain(VSOutput input) : SV_Target {
+    // clang-format on
     return float4(input.color, 1.0);
-}
+};

--- a/assets/shaders/slang/depthprepass.slang
+++ b/assets/shaders/slang/depthprepass.slang
@@ -1,4 +1,4 @@
-// depthprepass.slang — camera-space depth-only prepass + active-tile marking
+// depthprepass.slang: camera-space depth-only prepass + active-tile marking
 #include "include/clustered.slang"
 
 uniform float4x4 mvp;
@@ -6,8 +6,7 @@ uniform float4x4 modelView;
 
 // Fragment-stage params in a named ConstantBuffer so the vertex and fragment
 // loose-uniform blocks cannot disagree (see uniforms.slang).
-struct PrepassParams
-{
+struct PrepassParams {
     float2 screenSize;
     float  clusterNear;
     float  clusterFar;
@@ -15,31 +14,34 @@ struct PrepassParams
 };
 [[vk::binding(2)]] ConstantBuffer<PrepassParams> prepassParams;
 
-// Active volume-tile flags, one uint per cluster — consumed by
+// Active volume-tile flags, one uint per cluster, consumed by
 // cluster_assign.slang so light assignment skips clusters with no fragments.
 [[vk::binding(8)]] RWStructuredBuffer<uint> tileFlags;
 
-struct VSInput  { float3 position : POSITION; }
-struct VSOutput
-{
-    float4 pos   : SV_Position;
+struct VSInput {
+    float3 position : POSITION;
+};
+struct VSOutput {
+    float4 pos : SV_Position;
     float  viewZ : TEXCOORD0;  // positive view-space depth
-}
+};
 
+// clang-format off
 [shader("vertex")]
-VSOutput vertMain(VSInput input)
-{
+VSOutput vertMain(VSInput input) {
+    // clang-format on
     VSOutput o;
     o.pos   = mul(mvp, float4(input.position, 1.0));
     o.viewZ = -mul(modelView, float4(input.position, 1.0)).z;
     return o;
-}
+};
 
+// clang-format off
 [shader("fragment")]
-void fragMain(VSOutput input, float4 fragCoord : SV_Position)
-{
-    int ci = clusterIndex(fragCoord.xy, input.viewZ,
-                          prepassParams.screenSize, prepassParams.clusterNear,
-                          prepassParams.clusterFar, prepassParams.tilesZ);
+void fragMain(VSOutput input, float4 fragCoord : SV_Position) {
+    // clang-format on
+    int ci        = clusterIndex(fragCoord.xy, input.viewZ,
+                                 prepassParams.screenSize, prepassParams.clusterNear,
+                                 prepassParams.clusterFar, prepassParams.tilesZ);
     tileFlags[ci] = 1U;
-}
+};

--- a/assets/shaders/slang/fxaa.slang
+++ b/assets/shaders/slang/fxaa.slang
@@ -1,65 +1,62 @@
-// fxaa.slang — fullscreen quad vertex + FXAA 3.11 (quality preset 12) + bloom overlay
+// fxaa.slang: fullscreen quad vertex + FXAA 3.11 (quality preset 12) + bloom overlay
 // FXAA based on Timothy Lottes / NVIDIA, adapted to Slang.
 #include "include/dither.slang"
 
-struct VSInput
-{
+struct VSInput {
     float2 position : POSITION;
     float2 texCoord : TEXCOORD0;
 };
 
-struct VSOutput
-{
-    float4 pos       : SV_Position;
+struct VSOutput {
+    float4 pos : SV_Position;
     float2 texCoords : TEXCOORD0;
 };
 
+// clang-format off
 [shader("vertex")]
-VSOutput vertMain(VSInput input)
-{
+VSOutput vertMain(VSInput input) {
+    // clang-format on
     VSOutput output;
     output.pos       = float4(input.position, 0.0, 1.0);
     output.texCoords = input.texCoord;
     return output;
-}
+};
 
 [[vk::binding(0)]] Sampler2D<float4> screenTexture;
 [[vk::binding(1)]] Sampler2D<float4> bloomTex;
-uniform float2    rcpFrame;
-uniform float     bloomIntensity;
+uniform float2                       rcpFrame;
+uniform float                        bloomIntensity;
 
 // Quality preset 12: 5-step search (1.5, 2.0, 2.0, 2.0, 8.0)
 static const float FXAA_SUBPIX             = 0.75;
 static const float FXAA_EDGE_THRESHOLD     = 0.125;
 static const float FXAA_EDGE_THRESHOLD_MIN = 0.0625;
-static const float steps[5]               = { 1.5, 2.0, 2.0, 2.0, 8.0 };
+static const float steps[5]                = { 1.5, 2.0, 2.0, 2.0, 8.0 };
 
-// Green-channel-weighted luma (Lottes formula — blue excluded)
+// Green-channel-weighted luma (Lottes formula, blue excluded)
 float fxaaLuma(float3 rgb) { return rgb.y * (0.587 / 0.299) + rgb.x; }
 
-float4 fxaaPass(float2 uv)
-{
+float4 fxaaPass(float2 uv) {
     float4 rgbaM = screenTexture.Sample(uv);
     float  lumaM = fxaaLuma(rgbaM.rgb);
 
-    float lumaN  = fxaaLuma(screenTexture.Sample(uv + float2( 0,  rcpFrame.y)).rgb);
-    float lumaS  = fxaaLuma(screenTexture.Sample(uv + float2( 0, -rcpFrame.y)).rgb);
-    float lumaE  = fxaaLuma(screenTexture.Sample(uv + float2( rcpFrame.x,  0)).rgb);
-    float lumaW  = fxaaLuma(screenTexture.Sample(uv + float2(-rcpFrame.x,  0)).rgb);
+    float lumaN = fxaaLuma(screenTexture.Sample(uv + float2(0, rcpFrame.y)).rgb);
+    float lumaS = fxaaLuma(screenTexture.Sample(uv + float2(0, -rcpFrame.y)).rgb);
+    float lumaE = fxaaLuma(screenTexture.Sample(uv + float2(rcpFrame.x, 0)).rgb);
+    float lumaW = fxaaLuma(screenTexture.Sample(uv + float2(-rcpFrame.x, 0)).rgb);
 
     float rangeMax = max(lumaM, max(max(lumaN, lumaS), max(lumaE, lumaW)));
     float rangeMin = min(lumaM, min(min(lumaN, lumaS), min(lumaE, lumaW)));
     float range    = rangeMax - rangeMin;
 
-    if (range < max(FXAA_EDGE_THRESHOLD_MIN, rangeMax * FXAA_EDGE_THRESHOLD))
-    {
+    if (range < max(FXAA_EDGE_THRESHOLD_MIN, rangeMax * FXAA_EDGE_THRESHOLD)) {
         return rgbaM;
     }
 
-    float lumaNW = fxaaLuma(screenTexture.Sample(uv + float2(-rcpFrame.x,  rcpFrame.y)).rgb);
-    float lumaNE = fxaaLuma(screenTexture.Sample(uv + float2( rcpFrame.x,  rcpFrame.y)).rgb);
+    float lumaNW = fxaaLuma(screenTexture.Sample(uv + float2(-rcpFrame.x, rcpFrame.y)).rgb);
+    float lumaNE = fxaaLuma(screenTexture.Sample(uv + float2(rcpFrame.x, rcpFrame.y)).rgb);
     float lumaSW = fxaaLuma(screenTexture.Sample(uv + float2(-rcpFrame.x, -rcpFrame.y)).rgb);
-    float lumaSE = fxaaLuma(screenTexture.Sample(uv + float2( rcpFrame.x, -rcpFrame.y)).rgb);
+    float lumaSE = fxaaLuma(screenTexture.Sample(uv + float2(rcpFrame.x, -rcpFrame.y)).rgb);
 
     float subpixNSEW = lumaN + lumaS + lumaE + lumaW;
     float subpixA    = (2.0 * subpixNSEW + lumaNW + lumaNE + lumaSW + lumaSE) / 12.0;
@@ -69,11 +66,11 @@ float4 fxaaPass(float2 uv)
 
     float edgeHorz =
         abs(lumaNW + -2.0 * lumaN + lumaNE) +
-        abs(lumaW  + -2.0 * lumaM + lumaE ) * 2.0 +
+        abs(lumaW + -2.0 * lumaM + lumaE) * 2.0 +
         abs(lumaSW + -2.0 * lumaS + lumaSE);
     float edgeVert =
         abs(lumaNW + -2.0 * lumaW + lumaSW) +
-        abs(lumaN  + -2.0 * lumaM + lumaS ) * 2.0 +
+        abs(lumaN + -2.0 * lumaM + lumaS) * 2.0 +
         abs(lumaNE + -2.0 * lumaE + lumaSE);
     bool horzSpan = (edgeHorz >= edgeVert);
 
@@ -85,84 +82,76 @@ float4 fxaaPass(float2 uv)
 
     float gradientScaled = 0.25 * max(abs(grad1), abs(grad2));
     float stepLen        = horzSpan ? rcpFrame.y : rcpFrame.x;
-    if (pairN)
-    {
+    if (pairN) {
         stepLen = -stepLen;
     }
-    float localAvg       = 0.5 * (pairN ? luma1 : luma2) + 0.5 * lumaM;
+    float localAvg = 0.5 * (pairN ? luma1 : luma2) + 0.5 * lumaM;
 
-    float2 posP  = uv;
-    if (horzSpan)
-    {
+    float2 posP = uv;
+    if (horzSpan) {
         posP.y += stepLen * 0.5;
-    }
-    else
-    {
+    } else {
         posP.x += stepLen * 0.5;
     }
 
     float2 offNP = horzSpan ? float2(rcpFrame.x, 0.0) : float2(0.0, rcpFrame.y);
 
-    float2 posN      = posP - offNP * steps[0];
-    float2 posPos    = posP + offNP * steps[0];
-    float  lumaEndN  = fxaaLuma(screenTexture.Sample(posN  ).rgb) - localAvg;
-    float  lumaEndP  = fxaaLuma(screenTexture.Sample(posPos).rgb) - localAvg;
-    bool   doneN     = abs(lumaEndN) >= gradientScaled;
-    bool   doneP     = abs(lumaEndP) >= gradientScaled;
+    float2 posN     = posP - offNP * steps[0];
+    float2 posPos   = posP + offNP * steps[0];
+    float  lumaEndN = fxaaLuma(screenTexture.Sample(posN).rgb) - localAvg;
+    float  lumaEndP = fxaaLuma(screenTexture.Sample(posPos).rgb) - localAvg;
+    bool   doneN    = abs(lumaEndN) >= gradientScaled;
+    bool   doneP    = abs(lumaEndP) >= gradientScaled;
 
-    for (int i = 1; i < 5; i++)
-    {
+    for (int i = 1; i < 5; i++) {
         if (!doneN) {
-            posN    -= offNP * steps[i];
-            lumaEndN = fxaaLuma(screenTexture.Sample(posN  ).rgb) - localAvg;
+            posN -= offNP * steps[i];
+            lumaEndN = fxaaLuma(screenTexture.Sample(posN).rgb) - localAvg;
             doneN    = abs(lumaEndN) >= gradientScaled;
         }
         if (!doneP) {
-            posPos  += offNP * steps[i];
+            posPos += offNP * steps[i];
             lumaEndP = fxaaLuma(screenTexture.Sample(posPos).rgb) - localAvg;
             doneP    = abs(lumaEndP) >= gradientScaled;
         }
-        if (doneN && doneP)
-        {
+        if (doneN && doneP) {
             break;
         }
     }
 
-    float dstN      = horzSpan ? (uv.x - posN.x  ) : (uv.y - posN.y  );
-    float dstP      = horzSpan ? (posPos.x - uv.x ) : (posPos.y - uv.y);
+    float dstN      = horzSpan ? (uv.x - posN.x) : (uv.y - posN.y);
+    float dstP      = horzSpan ? (posPos.x - uv.x) : (posPos.y - uv.y);
     bool  goodSpanN = (lumaEndN < 0.0) != (lumaM < localAvg);
     bool  goodSpanP = (lumaEndP < 0.0) != (lumaM < localAvg);
     float spanLen   = dstN + dstP;
 
     float pixelOffset = max(
         goodSpanN ? (0.5 - dstN / spanLen) : 0.0,
-        goodSpanP ? (0.5 - dstP / spanLen) : 0.0
-    );
+        goodSpanP ? (0.5 - dstP / spanLen) : 0.0);
     pixelOffset = max(pixelOffset, subpixD);
 
     float2 finalUV = uv;
-    if (horzSpan)
-    {
+    if (horzSpan) {
         finalUV.y += pixelOffset * stepLen;
-    }
-    else
-    {
+    } else {
         finalUV.x += pixelOffset * stepLen;
     }
 
     return screenTexture.Sample(finalUV);
 }
 
-struct FSInput { float2 texCoords : TEXCOORD0; }
+struct FSInput {
+    float2 texCoords : TEXCOORD0;
+};
 
+// clang-format off
 [shader("fragment")]
-float4 fragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target
-{
+float4 fragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target {
+    // clang-format on
     float4 color = fxaaPass(input.texCoords);
-    if (bloomIntensity > 0.0)
-    {
+    if (bloomIntensity > 0.0) {
         color.rgb += bloomTex.Sample(input.texCoords).rgb * bloomIntensity;
     }
     color.rgb = dither8(color.rgb, fragCoord.xy);
     return color;
-}
+};

--- a/assets/shaders/slang/include/clustered.slang
+++ b/assets/shaders/slang/include/clustered.slang
@@ -2,30 +2,29 @@
 #pragma once
 #include "lighting.slang"
 
-// Screen tile grid — must match tilesX/Y in clusteredlights.hpp. The z-slice
+// Screen tile grid; must match tilesX/Y in clusteredlights.hpp. The z-slice
 // count is runtime (derived from the FOV, van Oosten eq. 8.2) and passed as
 // tilesZ.
 static const int TILES_X = 16;
 static const int TILES_Y = 9;
 
-// Max lights per cluster — must match maxLightsPerCluster in clusteredlights.hpp.
+// Max lights per cluster; must match maxLightsPerCluster in clusteredlights.hpp.
 // Sized >= the max scene light count so per-cluster truncation cannot occur.
 static const int MAX_LIGHTS_PER_CLUSTER = 512;
 
-// Culling radii live in lighting.slang (attenuationRadius) — shared with the
+// Culling radii live in lighting.slang (attenuationRadius), shared with the
 // radiance window so culled lights are exactly zero at the boundary.
 
 // Returns the 1-D cluster index for the given fragment.
-// viewZ: positive view-space depth — dot(worldPos - cameraPos, cameraForward).
-// Note: decoding gl_FragCoord.z instead was tried and fails — it disagrees
-// with the view-space slice AABBs on this pipeline (verified empirically).
+// viewZ: positive view-space depth = dot(worldPos - cameraPos, cameraForward).
+// Do not decode gl_FragCoord.z instead; it disagrees with the view-space
+// slice AABBs on this pipeline.
 // clusterNear: near bound of the cluster grid (not the camera near plane);
 // fragments closer than it clamp into slice 0, whose AABB extends to the
 // camera near plane.
 // Z subdivision formula must match buildClusterAABBs() in clusteredlights.cpp.
 int clusterIndex(float2 fragCoord, float viewZ, float2 screenSize,
-                 float clusterNear, float far, int tilesZ)
-{
+                 float clusterNear, float far, int tilesZ) {
     int   x = clamp(int(fragCoord.x / screenSize.x * TILES_X), 0, TILES_X - 1);
     int   y = clamp(int(fragCoord.y / screenSize.y * TILES_Y), 0, TILES_Y - 1);
     float d = max(viewZ, clusterNear);

--- a/assets/shaders/slang/include/dither.slang
+++ b/assets/shaders/slang/include/dither.slang
@@ -1,9 +1,8 @@
 #pragma once
 
-// Interleaved gradient noise (Jimenez 2014), ±0.5 LSB at 8-bit — breaks up
+// Interleaved gradient noise (Jimenez 2014), ±0.5 LSB at 8-bit; breaks up
 // banding in dim gradients. Apply at every pass that writes an 8-bit target.
-float3 dither8(float3 color, float2 fragCoord)
-{
+float3 dither8(float3 color, float2 fragCoord) {
     float ign = frac(52.9829189 *
                      frac(dot(fragCoord, float2(0.06711056, 0.00583715))));
     return color + (ign - 0.5) / 255.0;

--- a/assets/shaders/slang/include/kawase.slang
+++ b/assets/shaders/slang/include/kawase.slang
@@ -1,33 +1,31 @@
 #pragma once
 
-float4 kawaseDown(Sampler2D<float4> image, float2 uv, float offset)
-{
-    uint   w, h, levels;
+float4 kawaseDown(Sampler2D<float4> image, float2 uv, float offset) {
+    uint w, h, levels;
     image.GetDimensions(0, w, h, levels);
     float2 o = float2(0.5 / float(w), 0.5 / float(h)) * offset;
 
     float4 color = image.Sample(uv) * 4.0;
     color += image.Sample(uv + float2(-o.x, -o.y));
-    color += image.Sample(uv + float2( o.x, -o.y));
-    color += image.Sample(uv + float2(-o.x,  o.y));
-    color += image.Sample(uv + float2( o.x,  o.y));
+    color += image.Sample(uv + float2(o.x, -o.y));
+    color += image.Sample(uv + float2(-o.x, o.y));
+    color += image.Sample(uv + float2(o.x, o.y));
     return color / 8.0;
 }
 
-float4 kawaseUp(Sampler2D<float4> image, float2 uv, float offset)
-{
-    uint   w, h, levels;
+float4 kawaseUp(Sampler2D<float4> image, float2 uv, float offset) {
+    uint w, h, levels;
     image.GetDimensions(0, w, h, levels);
     float2 o = float2(0.5 / float(w), 0.5 / float(h)) * offset;
 
     float4 color = float4(0.0);
-    color += image.Sample(uv + float2(-o.x * 2.0,       0.0));
-    color += image.Sample(uv + float2( o.x * 2.0,       0.0));
-    color += image.Sample(uv + float2(0.0,        -o.y * 2.0));
-    color += image.Sample(uv + float2(0.0,         o.y * 2.0));
-    color += image.Sample(uv + float2(-o.x,  o.y)) * 2.0;
-    color += image.Sample(uv + float2( o.x,  o.y)) * 2.0;
+    color += image.Sample(uv + float2(-o.x * 2.0, 0.0));
+    color += image.Sample(uv + float2(o.x * 2.0, 0.0));
+    color += image.Sample(uv + float2(0.0, -o.y * 2.0));
+    color += image.Sample(uv + float2(0.0, o.y * 2.0));
+    color += image.Sample(uv + float2(-o.x, o.y)) * 2.0;
+    color += image.Sample(uv + float2(o.x, o.y)) * 2.0;
     color += image.Sample(uv + float2(-o.x, -o.y)) * 2.0;
-    color += image.Sample(uv + float2( o.x, -o.y)) * 2.0;
+    color += image.Sample(uv + float2(o.x, -o.y)) * 2.0;
     return color / 12.0;
 }

--- a/assets/shaders/slang/include/lighting.slang
+++ b/assets/shaders/slang/include/lighting.slang
@@ -5,9 +5,9 @@ static const float M_PI = 3.14159265359;
 // Attenuation coefficients [constant, linear, quadratic] per distance range.
 // See https://learnopengl.com/Lighting/Light-casters
 static const float3 lightAttenuation[11] = {
-    float3(1.0, 0.70,  1.800),  float3(1.0, 0.35,  0.440),
-    float3(1.0, 0.22,  0.200),  float3(1.0, 0.14,  0.070),
-    float3(1.0, 0.09,  0.032),  float3(1.0, 0.07,  0.017),
+    float3(1.0, 0.70, 1.800), float3(1.0, 0.35, 0.440),
+    float3(1.0, 0.22, 0.200), float3(1.0, 0.14, 0.070),
+    float3(1.0, 0.09, 0.032), float3(1.0, 0.07, 0.017),
     float3(1.0, 0.045, 0.0075), float3(1.0, 0.027, 0.0028),
     float3(1.0, 0.022, 0.0019), float3(1.0, 0.014, 0.0007),
     float3(1.0, 0.007, 0.0002)
@@ -16,16 +16,15 @@ static const float3 lightAttenuation[11] = {
 // Culling radii (world units) per attenuation index. Radiance is windowed to
 // zero at this radius so cluster culling produces no visible seams.
 static const float attenuationRadius[11] = {
-    7.0,  13.0,  20.0,  32.0,  50.0,  65.0,
+    7.0, 13.0, 20.0, 32.0, 50.0, 65.0,
     100.0, 160.0, 200.0, 325.0, 600.0
 };
 
 // ---------------------------------------------------------------------------
-// Light interface — all light types conform to this.
+// Light interface.
 // evaluatePBR<L:ILight>() is monomorphized per concrete type at compile time.
 // ---------------------------------------------------------------------------
-interface ILight
-{
+interface ILight {
     // World-space unit vector from worldPos toward the light.
     float3 getDirection(float3 worldPos);
 
@@ -37,41 +36,36 @@ interface ILight
 // Concrete light types
 // ---------------------------------------------------------------------------
 
-struct DirectionalLight
-{
+struct DirectionalLight {
     bool   enabled;
     bool   castShadow;
     float3 color;
     float3 direction;
-}
+};
 
-extension DirectionalLight : ILight
-{
+extension DirectionalLight : ILight {
     float3 getDirection(float3 worldPos) { return normalize(-direction); }
-    float3 getRadiance(float3 worldPos)  { return color; }
+    float3 getRadiance(float3 worldPos) { return color; }
 }
 
-struct PointLight
-{
+struct PointLight {
     float3 color;
     float3 position;
     int    attenuationIndex;
-}
+};
 
-extension PointLight : ILight
-{
+extension PointLight : ILight {
     float3 getDirection(float3 worldPos) { return normalize(position - worldPos); }
-    float3 getRadiance(float3 worldPos)
-    {
-        float  dist = length(position - worldPos);
-        int    idx  = clamp(attenuationIndex, 0, 10);
-        float3 att  = lightAttenuation[idx];
+    float3 getRadiance(float3 worldPos) {
+        float  dist  = length(position - worldPos);
+        int    idx   = clamp(attenuationIndex, 0, 10);
+        float3 att   = lightAttenuation[idx];
         float  atten = 1.0 / (att.x + att.y * dist + att.z * dist * dist);
         // Window to zero at the culling radius (Karis falloff) so lights
         // culled per-cluster never leave a hard seam at cluster boundaries.
-        float  dr     = dist / attenuationRadius[idx];
-        float  dr2    = dr * dr;
-        float  window = saturate(1.0 - dr2 * dr2);
+        float dr     = dist / attenuationRadius[idx];
+        float dr2    = dr * dr;
+        float window = saturate(1.0 - dr2 * dr2);
         return color * atten * window * window;
     }
 }
@@ -80,35 +74,31 @@ extension PointLight : ILight
 // PBR BRDF helpers
 // ---------------------------------------------------------------------------
 
-float3 fresnelSchlick(float cosTheta, float3 F0)
-{
-    // Optimized exponent — Karis 2013
+float3 fresnelSchlick(float cosTheta, float3 F0) {
+    // Optimized exponent (Karis 2013)
     return F0 + (1.0 - F0) * pow(2.0, (-5.55473 * cosTheta - 6.98316) * cosTheta);
 }
 
-float distributionGGX(float3 N, float3 H, float rough)
-{
-    float a      = rough * rough;
-    float a2     = a * a;
-    float NdotH  = max(dot(N, H), 0.0);
-    float denom  = (NdotH * NdotH * (a2 - 1.0) + 1.0);
+float distributionGGX(float3 N, float3 H, float rough) {
+    float a     = rough * rough;
+    float a2    = a * a;
+    float NdotH = max(dot(N, H), 0.0);
+    float denom = (NdotH * NdotH * (a2 - 1.0) + 1.0);
     return a2 / (M_PI * denom * denom);
 }
 
-float geometrySchlickGGX(float NdotV, float rough)
-{
+float geometrySchlickGGX(float NdotV, float rough) {
     float r = rough + 1.0;
     float k = (r * r) / 8.0;
     return NdotV / (NdotV * (1.0 - k) + k);
 }
 
-float geometrySmith(float NdotV, float NdotL, float rough)
-{
+float geometrySmith(float NdotV, float NdotL, float rough) {
     return geometrySchlickGGX(NdotV, rough) * geometrySchlickGGX(NdotL, rough);
 }
 
 // ---------------------------------------------------------------------------
-// Generic PBR evaluation — resolved at compile time per light type.
+// Generic PBR evaluation, resolved at compile time per light type.
 // ---------------------------------------------------------------------------
 float3 evaluatePBR<L : ILight>(
     L      light,
@@ -117,12 +107,11 @@ float3 evaluatePBR<L : ILight>(
     float3 N,
     float3 V,
     float  metallic,
-    float  roughness)
-{
+    float  roughness) {
     float3 Ldir     = light.getDirection(worldPos);
     float3 radiance = light.getRadiance(worldPos);
     float3 H        = normalize(V + Ldir);
-    float  NdotV    = max(dot(N, V),    1e-5);
+    float  NdotV    = max(dot(N, V), 1e-5);
     float  NdotL    = max(dot(N, Ldir), 1e-5);
     float3 F0       = lerp(float3(0.04), albedo, metallic);
     float  NDF      = distributionGGX(N, H, roughness);

--- a/assets/shaders/slang/include/shadows.slang
+++ b/assets/shaders/slang/include/shadows.slang
@@ -4,14 +4,12 @@
 float shadowEVSM(
     Sampler2D<float2> shadowMap,
     float4            fragPosLightSpace,
-    float             evsmBleedThreshold)
-{
+    float             evsmBleedThreshold) {
     float3 proj = fragPosLightSpace.xyz / fragPosLightSpace.w;
-    proj = proj * 0.5 + 0.5;
+    proj        = proj * 0.5 + 0.5;
     // Outside the shadow frustum (xy or z) there is no occlusion information;
     // sampling clamped edge texels would falsely shadow everything beyond it.
-    if (any(proj < 0.0) || any(proj > 1.0))
-    {
+    if (any(proj < 0.0) || any(proj > 1.0)) {
         return 0.0;
     }
 
@@ -22,6 +20,6 @@ float shadowEVSM(
     float variance = max(moments.y - moments.x * moments.x, 0.00002);
     float d        = currentDepth - moments.x;
     float pMax     = variance / (variance + d * d);
-    pMax = clamp((pMax - evsmBleedThreshold) / (1.0 - evsmBleedThreshold), 0.0, 1.0);
+    pMax           = clamp((pMax - evsmBleedThreshold) / (1.0 - evsmBleedThreshold), 0.0, 1.0);
     return 1.0 - max(p, pMax);
 }

--- a/assets/shaders/slang/include/ui_uniforms.slang
+++ b/assets/shaders/slang/include/ui_uniforms.slang
@@ -1,8 +1,7 @@
 #pragma once
 
-struct QuadParams
-{
-    float4x4 projection;   // vertex
+struct QuadParams {
+    float4x4 projection;  // vertex
     float4   corners;
     float    cornerRadius;
     float4   color;
@@ -11,10 +10,9 @@ struct QuadParams
 };
 [[vk::binding(3)]] ConstantBuffer<QuadParams> quadParams;
 
-struct SpriteParams
-{
-    float4x4 projection;   // vertex
+struct SpriteParams {
+    float4x4 projection;  // vertex
     float    alpha;
-    float3   textColor;    // text fragment only
+    float3   textColor;  // text fragment only
 };
 [[vk::binding(4)]] ConstantBuffer<SpriteParams> spriteParams;

--- a/assets/shaders/slang/include/uniforms.slang
+++ b/assets/shaders/slang/include/uniforms.slang
@@ -5,7 +5,7 @@
 //
 // Each stage is compiled by a separate slangc invocation, so loose `uniform`
 // globals get collected into a per-stage block containing only the fields that
-// stage references — which makes the vertex and fragment blocks disagree and
+// stage references, which makes the vertex and fragment blocks disagree and
 // fails program linking ("struct type mismatch ... block_GlobalParams").
 //
 // A named ConstantBuffer is emitted whole (no per-field stripping) and with an
@@ -18,11 +18,10 @@
 // calls use the original names. Unreferenced ConstantBuffers are stripped by
 // slangc, so a shader only emits the block it actually uses.
 
-struct PbrParams
-{
-    float4x4         mvp;                // vertex
-    float4x4         model;              // vertex
-    float4x4         normalMatrix;       // vertex; precomputed transpose(inverse(model)) on CPU
+struct PbrParams {
+    float4x4         mvp;               // vertex
+    float4x4         model;             // vertex
+    float4x4         normalMatrix;      // vertex; precomputed transpose(inverse(model)) on CPU
     float4x4         lightSpaceMatrix;  // vertex
     float            metallic;
     float            roughness;

--- a/assets/shaders/slang/pbr.slang
+++ b/assets/shaders/slang/pbr.slang
@@ -1,58 +1,56 @@
-// pbr.slang — PBR vertex + fragment shader
+// pbr.slang: PBR vertex + fragment shader
 #include "include/uniforms.slang"
 #include "include/shadows.slang"
 #include "include/clustered.slang"
 #include "include/dither.slang"
 
-struct PointLightGPU
-{
+struct PointLightGPU {
     float3 color;
     float  pad0;
     float3 position;
     int    attenuationIndex;
     float4 pad1;
-}
+};
 
 [[vk::binding(3)]] StructuredBuffer<PointLightGPU> lightBuffer;
 [[vk::binding(4)]] StructuredBuffer<uint2>         lightGrid;
 [[vk::binding(5)]] StructuredBuffer<uint>          lightIndices;
 
-
-struct VSInput
-{
+struct VSInput {
     float3 position : POSITION;
     float2 texCoord : TEXCOORD0;
-    float3 normal   : NORMAL;
-}
+    float3 normal : NORMAL;
+};
 
-struct VSOutput
-{
-    float4 pos              : SV_Position;
-    float3 worldPosition    : TEXCOORD0;
-    float3 worldNormal      : TEXCOORD1;
-    float2 texCoords        : TEXCOORD2;
-    float4 fragPosLightSpace: TEXCOORD3;
-}
+struct VSOutput {
+    float4 pos : SV_Position;
+    float3 worldPosition : TEXCOORD0;
+    float3 worldNormal : TEXCOORD1;
+    float2 texCoords : TEXCOORD2;
+    float4 fragPosLightSpace : TEXCOORD3;
+};
 
+// clang-format off
 [shader("vertex")]
-VSOutput vertMain(VSInput input)
-{
+VSOutput vertMain(VSInput input) {
+    // clang-format on
     VSOutput output;
-    float4 worldPos4        = mul(params.model, float4(input.position, 1.0));
-    output.pos              = mul(params.mvp,   float4(input.position, 1.0));
-    output.worldPosition    = worldPos4.xyz;
-    output.worldNormal      = mul((float3x3)params.normalMatrix, input.normal);
-    output.texCoords        = input.texCoord;
-    output.fragPosLightSpace= mul(params.lightSpaceMatrix, worldPos4);
+    float4   worldPos4       = mul(params.model, float4(input.position, 1.0));
+    output.pos               = mul(params.mvp, float4(input.position, 1.0));
+    output.worldPosition     = worldPos4.xyz;
+    output.worldNormal       = mul((float3x3)params.normalMatrix, input.normal);
+    output.texCoords         = input.texCoord;
+    output.fragPosLightSpace = mul(params.lightSpaceMatrix, worldPos4);
     return output;
-}
+};
 
 [[vk::binding(0)]] Sampler2D<float4> texture_diffuse1;
 [[vk::binding(1)]] Sampler2D<float2> shadowMap;
 
+// clang-format off
 [shader("fragment")]
-float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target
-{
+float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target {
+    // clang-format on
     float3 texColor = pow(texture_diffuse1.Sample(input.texCoords).rgb, float3(2.2));
     float3 albedo   = lerp(texColor, float3(1.0), float(params.hasNoTexture));
 
@@ -63,27 +61,24 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target
     // Directional light
     float3 dirContrib = evaluatePBR(params.directionalLight, input.worldPosition, albedo, N, V, params.metallic, params.roughness);
     float  shadow     = 0.0;
-    if (params.directionalLight.castShadow)
-    {
+    if (params.directionalLight.castShadow) {
         shadow = shadowEVSM(shadowMap, input.fragPosLightSpace, params.evsmBleedThreshold);
     }
     Lo += dirContrib * (1.0 - shadow) * float(params.directionalLight.enabled);
 
     // Clustered point lights
-    if (params.numLights > 0)
-    {
-        float viewZ    = dot(input.worldPosition - params.viewPos,
-                             params.viewForward);
-        int   ci       = clusterIndex(fragCoord.xy, viewZ,
-                                      params.screenSize,
-                                      params.clusterNear, params.farPlane,
-                                      params.tilesZ);
-        uint2 tile     = lightGrid[ci];
-        uint  tileEnd  = tile.x + tile.y;
-        for (uint j = tile.x; j < tileEnd; ++j)
-        {
-            uint          li    = lightIndices[j];
-            PointLightGPU gpu   = lightBuffer[li];
+    if (params.numLights > 0) {
+        float viewZ   = dot(input.worldPosition - params.viewPos,
+                            params.viewForward);
+        int   ci      = clusterIndex(fragCoord.xy, viewZ,
+                                     params.screenSize,
+                                     params.clusterNear, params.farPlane,
+                                     params.tilesZ);
+        uint2 tile    = lightGrid[ci];
+        uint  tileEnd = tile.x + tile.y;
+        for (uint j = tile.x; j < tileEnd; ++j) {
+            uint          li  = lightIndices[j];
+            PointLightGPU gpu = lightBuffer[li];
             PointLight    pl;
             pl.color            = gpu.color;
             pl.position         = gpu.position;
@@ -105,4 +100,4 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target
     color = dither8(color, fragCoord.xy);
 
     return float4(color + params.emissive, 1.0);
-}
+};

--- a/assets/shaders/slang/rectangle.slang
+++ b/assets/shaders/slang/rectangle.slang
@@ -1,46 +1,45 @@
-// rectangle.slang — UI rounded-rect vertex + SDF fragment shader
+// rectangle.slang: UI rounded-rect vertex + SDF fragment shader
 #include "include/ui_uniforms.slang"
 
-struct VSInput
-{
+struct VSInput {
     float2 position : POSITION;
-}
+};
 
-struct VSOutput
-{
-    float4 pos          : SV_Position;
-    float2 localPosition: TEXCOORD0;
-}
+struct VSOutput {
+    float4 pos : SV_Position;
+    float2 localPosition : TEXCOORD0;
+};
 
+// clang-format off
 [shader("vertex")]
-VSOutput vertMain(VSInput input)
-{
+VSOutput vertMain(VSInput input) {
+    // clang-format on
     VSOutput output;
     output.pos           = mul(quadParams.projection, float4(input.position, 0.0, 1.0));
     output.localPosition = input.position;
     return output;
-}
+};
 
+// clang-format off
 [shader("fragment")]
-float4 fragMain(VSOutput input) : SV_Target
-{
-    float2 localPos  = (input.localPosition - quadParams.corners.xy) / (quadParams.corners.zw - quadParams.corners.xy);
-    float2 quadSize  = quadParams.corners.zw - quadParams.corners.xy;
-    float2 pos       = localPos * quadSize;
-    float2 halfSize  = quadSize * 0.5;
+float4 fragMain(VSOutput input) : SV_Target {
+    // clang-format on
+    float2 localPos = (input.localPosition - quadParams.corners.xy) / (quadParams.corners.zw - quadParams.corners.xy);
+    float2 quadSize = quadParams.corners.zw - quadParams.corners.xy;
+    float2 pos      = localPos * quadSize;
+    float2 halfSize = quadSize * 0.5;
 
-    float2 d    = abs(pos - halfSize) - (halfSize - quadParams.cornerRadius);
-    float  dist = length(max(d, float2(0.0, 0.0))) - quadParams.cornerRadius;
+    float2 d     = abs(pos - halfSize) - (halfSize - quadParams.cornerRadius);
+    float  dist  = length(max(d, float2(0.0, 0.0))) - quadParams.cornerRadius;
     float  alpha = smoothstep(1.0, 0.0, dist);
 
-    if (quadParams.borderWidth > 0.0)
-    {
-        float2 innerD    = abs(pos - halfSize) - (halfSize - quadParams.cornerRadius - quadParams.borderWidth);
-        float  innerDist = length(max(innerD, float2(0.0, 0.0))) - quadParams.cornerRadius;
+    if (quadParams.borderWidth > 0.0) {
+        float2 innerD     = abs(pos - halfSize) - (halfSize - quadParams.cornerRadius - quadParams.borderWidth);
+        float  innerDist  = length(max(innerD, float2(0.0, 0.0))) - quadParams.cornerRadius;
         float  borderMask = smoothstep(1.0, 0.0, dist) - smoothstep(1.0, 0.0, innerDist);
         float  fillMask   = smoothstep(1.0, 0.0, innerDist);
         float4 finalColor = quadParams.borderColor * borderMask + quadParams.color * fillMask;
         return float4(finalColor.rgb, finalColor.a * alpha);
     }
     return float4(quadParams.color.rgb, quadParams.color.a * alpha);
-}
+};

--- a/assets/shaders/slang/shadowmap.slang
+++ b/assets/shaders/slang/shadowmap.slang
@@ -1,35 +1,36 @@
-// shadowmap.slang — shadow depth vertex + fragment entry points
+// shadowmap.slang: shadow depth vertex + fragment entry points
 uniform float4x4 lightSpaceMatrix;
 uniform float4x4 model;
 
-struct VSInput
-{
+struct VSInput {
     float3 position : POSITION;
-}
+};
 
-struct VSOutput
-{
+struct VSOutput {
     float4 pos : SV_Position;
-}
+};
 
+// clang-format off
 [shader("vertex")]
-VSOutput vertMain(VSInput input)
-{
+VSOutput vertMain(VSInput input) {
+    // clang-format on
     VSOutput output;
     output.pos = mul(lightSpaceMatrix, mul(model, float4(input.position, 1.0)));
     return output;
-}
+};
 
-// Plain depth: written implicitly via SV_Position.z — no explicit output needed.
+// Plain depth: written implicitly via SV_Position.z; no explicit output needed.
+// clang-format off
 [shader("fragment")]
-void fragMain()
-{
-}
+void fragMain() {
+    // clang-format on
+};
 
 // EVSM: store depth moments (depth, depth²) for variance shadow mapping.
+// clang-format off
 [shader("fragment")]
-float4 fragMainEVSM(VSOutput input) : SV_Target
-{
+float4 fragMainEVSM(VSOutput input) : SV_Target {
+    // clang-format on
     float depth = input.pos.z;
     return float4(depth, depth * depth, 0.0, 1.0);
-}
+};

--- a/assets/shaders/slang/sprite.slang
+++ b/assets/shaders/slang/sprite.slang
@@ -1,51 +1,50 @@
-// sprite.slang — sprite and text vertex + fragment shaders
+// sprite.slang: sprite and text vertex + fragment shaders
 #include "include/ui_uniforms.slang"
 
-struct VSInput
-{
-    float4 vertex : POSITION; // xy=pos, zw=texcoord
-}
+struct VSInput {
+    float4 vertex : POSITION;  // xy=pos, zw=texcoord
+};
 
-struct VSOutput
-{
-    float4 pos      : SV_Position;
+struct VSOutput {
+    float4 pos : SV_Position;
     float2 texCoord : TEXCOORD0;
-}
+};
 
+// clang-format off
 [shader("vertex")]
-VSOutput vertMain(VSInput input)
-{
+VSOutput vertMain(VSInput input) {
+    // clang-format on
     VSOutput output;
     output.texCoord = input.vertex.zw;
     output.pos      = mul(spriteParams.projection, float4(input.vertex.xy, 0.0, 1.0));
     return output;
-}
+};
 
 [[vk::binding(0)]] Sampler2D<float4> image;
 
+// clang-format off
 [shader("fragment")]
-float4 fragMain(VSOutput input) : SV_Target
-{
+float4 fragMain(VSOutput input) : SV_Target {
+    // clang-format on
     float4 color = image.Sample(input.texCoord);
-    if (color.a == 0.0)
-    {
+    if (color.a == 0.0) {
         discard;
     }
     color.a *= spriteParams.alpha;
     return color;
-}
+};
 
-struct TextFSOutput
-{
-    [[vk::location(0)]] [[vk::index(0)]] float4 fragColor    : SV_Target0;
+struct TextFSOutput {
+    [[vk::location(0)]] [[vk::index(0)]] float4 fragColor : SV_Target0;
     [[vk::location(0)]] [[vk::index(1)]] float4 fragCoverage : SV_Target1;
-}
+};
 
+// clang-format off
 [shader("fragment")]
-TextFSOutput textFragMain(VSOutput input)
-{
+TextFSOutput textFragMain(VSOutput input) {
+    // clang-format on
     TextFSOutput output;
     output.fragColor    = float4(spriteParams.textColor, 1.0);
     output.fragCoverage = float4(image.Sample(input.texCoord).rgb, 1.0);
     return output;
-}
+};


### PR DESCRIPTION
## Summary

- Add a scoped `assets/shaders/.clang-format` (attached braces, no include sorting, no line wrapping) and format all Slang shaders with it.
- clang-format cannot parse HLSL-style single-bracket attributes (`[shader(...)]`, `[numthreads]`); a misparsed entry point breaks indentation for the rest of the file. Entry points now follow a convention that keeps formatting stable:
  - `// clang-format off/on` guards around attributes and signature, with the opening brace on the signature line inside the guard
  - stacked attributes on one line
  - a trailing `;` after each entry-point body to restore the parser state (slangc accepts it)
  - trailing semicolons on structs
- Extend the pre-commit clang-format hook to `.slang` files. The mirror hook's `types_or` filter silently excluded anything not identified as C-family, so the existing `glsl` pattern never matched either; `types_or: [file]` makes the `files` regex authoritative.
- Bump typos to v1.48.0 and the clang-format mirror to v22.1.5 (pinned tags, both pass over the full repo with no changes).
- Remove em dashes and filler from shader comments.

All 24 shader targets compile clean via `compile_shaders` and formatting is idempotent under the hook's pinned clang-format version.