### PR TITLE
Make option menu semi-transparent and hide underlying menus

### DIFF
--- a/game/src/layer/exitlayer.cpp
+++ b/game/src/layer/exitlayer.cpp
@@ -206,6 +206,10 @@ bool ExitLayer::onUpdate(const double elapsedTime) {
         wasActiveLastFrame = true;
     }
 
+    if (Maze::get().getOptionLayer()->isActive()) {
+        return isRunning;
+    }
+
     for (const auto& shader : { menuFont->getShader(), Quad::getShader() }) {
         shader->bind();
         shader->setMat4("projection", orthoCamera->getProjection());

--- a/game/src/layer/introlayer.cpp
+++ b/game/src/layer/introlayer.cpp
@@ -212,6 +212,10 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
         wasActiveLastFrame = true;
     }
 
+    if (Maze::get().getOptionLayer()->isActive()) {
+        return isRunning;
+    }
+
     for (const auto& shader : { menuFont->getShader(), Quad::getShader() }) {
         shader->bind();
         shader->setMat4("projection", orthoCamera->getProjection());

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -464,7 +464,8 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
 
     const auto width  = static_cast<float>(orthoCamera->getWidth());
     const auto height = static_cast<float>(orthoCamera->getHeight());
-    quad->render({ 0.F, 0.F }, { width, height }, backgroundColor);
+    quad->render({ 0.F, 0.F }, { width, height }, { 0.F, 0.F, 0.F, .5F });
+    UNUSED(backgroundColor);
 
     auto [rootNodeX, rootNodeY, rootNodeW, rootNodeH] =
         getNodeLayout(rootNode, 0.F, 0.F);


### PR DESCRIPTION
## Summary

- Render the option menu background at 50% opacity so the game shows through
- Skip rendering the intro and exit layers while the option menu is active, so only the maze layer is visible behind it