### PR TITLE
Improve UI text rendering with light hinting and subpixel positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ A game engine featuring a nice walk through a maze.
 * Physically based rendering (PBR)
 * Cook-Torrance microfacet specular BRDF
 * Point lights and directional light
+* Clustered (volume-tiled) light culling with a compute shader
 * Exponential variance shadow maps (EVSM) with Dual Kawase blur
 * Reinhard tone mapping
 * Fast approximate anti-aliasing (FXAA)
-* Multi-channel signed distance field (MSDF) text rendering
+* FreeType + HarfBuzz text rendering with LCD subpixel anti-aliasing and subpixel positioning
 * Performance profiling with Tracy
 * Gamepad support
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A game engine featuring a nice walk through a maze.
 * Physically based rendering (PBR)
 * Cook-Torrance microfacet specular BRDF
 * Point lights and directional light
-* Clustered (volume-tiled) light culling with a compute shader
+* Clustered (volume-tiled) light culling
 * Exponential variance shadow maps (EVSM) with Dual Kawase blur
 * Reinhard tone mapping
 * Fast approximate anti-aliasing (FXAA)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A game engine featuring a nice walk through a maze.
 * Reinhard tone mapping
 * Fast approximate anti-aliasing (FXAA)
 * FreeType + HarfBuzz text rendering with LCD subpixel anti-aliasing and subpixel positioning
+* Flexbox-based UI layout with Yoga
 * Performance profiling with Tracy
 * Gamepad support
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,6 +15,7 @@ A game engine featuring a nice walk through a maze.
 * Reinhard tone mapping
 * Fast approximate anti-aliasing (FXAA)
 * FreeType + HarfBuzz text rendering with LCD subpixel anti-aliasing and subpixel positioning
+* Flexbox-based UI layout with Yoga
 * Performance profiling with Tracy
 
 ## Project Organization

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,10 +10,11 @@ A game engine featuring a nice walk through a maze.
 * Physically based rendering (PBR)
 * Cook-Torrance microfacet specular BRDF
 * Point lights and directional light
+* Clustered (volume-tiled) light culling with a compute shader
 * Exponential variance shadow maps (EVSM) with Dual Kawase blur
 * Reinhard tone mapping
 * Fast approximate anti-aliasing (FXAA)
-* Multi-channel signed distance field (MSDF) text rendering
+* FreeType + HarfBuzz text rendering with LCD subpixel anti-aliasing and subpixel positioning
 * Performance profiling with Tracy
 
 ## Project Organization

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,7 +10,7 @@ A game engine featuring a nice walk through a maze.
 * Physically based rendering (PBR)
 * Cook-Torrance microfacet specular BRDF
 * Point lights and directional light
-* Clustered (volume-tiled) light culling with a compute shader
+* Clustered (volume-tiled) light culling
 * Exponential variance shadow maps (EVSM) with Dual Kawase blur
 * Reinhard tone mapping
 * Fast approximate anti-aliasing (FXAA)

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -464,8 +464,7 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
 
     const auto width  = static_cast<float>(orthoCamera->getWidth());
     const auto height = static_cast<float>(orthoCamera->getHeight());
-    quad->render({ 0.F, 0.F }, { width, height }, { 0.F, 0.F, 0.F, .5F });
-    UNUSED(backgroundColor);
+    quad->render({ 0.F, 0.F }, { width, height }, backgroundColor);
 
     auto [rootNodeX, rootNodeY, rootNodeW, rootNodeH] =
         getNodeLayout(rootNode, 0.F, 0.F);

--- a/sponge/src/platform/opengl/scene/bitmapfont.cpp
+++ b/sponge/src/platform/opengl/scene/bitmapfont.cpp
@@ -14,8 +14,22 @@ constexpr size_t maxLength   = 256;
 constexpr size_t indexCount  = 6;
 constexpr size_t vertexCount = 8;
 
-std::array<uint32_t, maxLength * indexCount>   batchIndices;
 std::array<glm::vec2, maxLength * vertexCount> batchVertices;
+
+// quad index pattern is fixed, so the index buffer is filled once at startup
+std::array<uint32_t, maxLength * indexCount> makeQuadIndices() {
+    std::array<uint32_t, maxLength * indexCount> indices;
+    for (uint32_t quad = 0; quad < maxLength; quad++) {
+        const uint32_t base            = quad * 4;
+        indices[quad * indexCount]     = base;
+        indices[quad * indexCount + 1] = base + 2;
+        indices[quad * indexCount + 2] = base + 1;
+        indices[quad * indexCount + 3] = base;
+        indices[quad * indexCount + 4] = base + 3;
+        indices[quad * indexCount + 5] = base + 2;
+    }
+    return indices;
+}
 }  // namespace
 
 namespace sponge::platform::opengl::scene {
@@ -39,8 +53,9 @@ BitmapFont::BitmapFont(const FontCreateInfo& createInfo) {
         nullptr, maxLength * vertexCount * sizeof(glm::vec2));
     vbo->bind();
 
-    ebo = std::make_unique<renderer::IndexBuffer>(
-        nullptr, maxLength * indexCount * sizeof(uint32_t));
+    const auto quadIndices = makeQuadIndices();
+    ebo                    = std::make_unique<renderer::IndexBuffer>(
+        quadIndices.data(), quadIndices.size() * sizeof(uint32_t));
     ebo->bind();
 
     constexpr uint32_t pos = 0;
@@ -53,7 +68,7 @@ BitmapFont::BitmapFont(const FontCreateInfo& createInfo) {
     shader->unbind();
 
     const std::string ttfPath = createInfo.assetsFolder + createInfo.path;
-    atlas.build({ { ttfPath } }, { 16, 24, 32, 48 });
+    atlas.build(ttfPath, { 16, 24, 32, 48 });
 
     glGenTextures(1, &textureId);
     glBindTexture(GL_TEXTURE_2D, textureId);
@@ -126,7 +141,7 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
                 static_cast<float>(sponge::scene::FontAtlas::subpixelPhases)));
 
         const sponge::scene::GlyphInfo* glyphInfo =
-            atlas.getGlyph(shapedGlyph.codepoint, passTargetSize, phase);
+            atlas.getGlyph(shapedGlyph.glyphIndex, passTargetSize, phase);
         if (glyphInfo && glyphInfo->width > 0 && glyphInfo->height > 0) {
             const float xpos = xfloor + static_cast<float>(glyphInfo->bearingX);
             const float ypos =
@@ -154,15 +169,6 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
             std::copy(vertices.begin(), vertices.end(),
                       batchVertices.begin() +
                           static_cast<ptrdiff_t>(glyphCount * vertexCount));
-
-            const std::array<uint32_t, indexCount> indices = {
-                glyphCount * 4, (glyphCount * 4) + 2, (glyphCount * 4) + 1,
-                glyphCount * 4, (glyphCount * 4) + 3, (glyphCount * 4) + 2
-            };
-
-            std::copy(indices.begin(), indices.end(),
-                      batchIndices.begin() +
-                          static_cast<ptrdiff_t>(glyphCount * indexCount));
             glyphCount++;
         }
 
@@ -177,7 +183,6 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
 
     vbo->update(batchVertices.data(),
                 glyphCount * vertexCount * sizeof(glm::vec2));
-    ebo->update(batchIndices.data(), glyphCount * indexCount);
 
     glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(glyphCount * indexCount),
                    GL_UNSIGNED_INT, nullptr);

--- a/sponge/src/platform/opengl/scene/bitmapfont.cpp
+++ b/sponge/src/platform/opengl/scene/bitmapfont.cpp
@@ -3,8 +3,10 @@
 #include "platform/opengl/renderer/assetmanager.hpp"
 #include "platform/opengl/renderer/gl.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
+#include <cmath>
 #include <string_view>
 
 namespace {
@@ -87,7 +89,7 @@ uint32_t BitmapFont::getLength(const std::string_view text,
         penX += shapedGlyph.xAdvance;
     }
 
-    return static_cast<uint32_t>(penX);
+    return static_cast<uint32_t>(std::lround(penX));
 }
 
 void BitmapFont::beginPass(const uint32_t size) {
@@ -113,12 +115,23 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
     const auto  shaped     = atlas.shape(str, passTargetSize);
 
     for (const auto& shapedGlyph : shaped) {
-        const sponge::scene::GlyphInfo* glyphInfo = shapedGlyph.glyphInfo;
+        // quad sits on the whole pixel; the fractional remainder picks the
+        // subpixel-shifted bitmap baked for that phase
+        const float glyphX = penX + shapedGlyph.xOffset;
+        const float xfloor = std::floor(glyphX);
+        const auto  phase  = std::min(
+            sponge::scene::FontAtlas::subpixelPhases - 1,
+            static_cast<uint32_t>(
+                (glyphX - xfloor) *
+                static_cast<float>(sponge::scene::FontAtlas::subpixelPhases)));
+
+        const sponge::scene::GlyphInfo* glyphInfo =
+            atlas.getGlyph(shapedGlyph.codepoint, passTargetSize, phase);
         if (glyphInfo && glyphInfo->width > 0 && glyphInfo->height > 0) {
-            const float xpos = penX + shapedGlyph.xOffset +
-                               static_cast<float>(glyphInfo->bearingX);
-            const float ypos = position.y - shapedGlyph.yOffset + ascender -
-                               static_cast<float>(glyphInfo->bearingY);
+            const float xpos = xfloor + static_cast<float>(glyphInfo->bearingX);
+            const float ypos =
+                std::round(position.y - shapedGlyph.yOffset + ascender) -
+                static_cast<float>(glyphInfo->bearingY);
             const float glyphWidth  = static_cast<float>(glyphInfo->width);
             const float glyphHeight = static_cast<float>(glyphInfo->height);
 

--- a/sponge/src/scene/fontatlas.cpp
+++ b/sponge/src/scene/fontatlas.cpp
@@ -23,7 +23,7 @@ constexpr std::array<char32_t, 1> supplementalGlyphs = {
 }  // namespace
 
 FontAtlas::~FontAtlas() {
-    for (auto& [size, hbFont] : hbFonts) {
+    if (hbFont != nullptr) {
         hb_font_destroy(hbFont);
     }
     if (ftFace != nullptr) {
@@ -34,8 +34,8 @@ FontAtlas::~FontAtlas() {
     }
 }
 
-void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
-                      const std::vector<uint32_t>&     sizes) {
+void FontAtlas::build(const std::string&           path,
+                      const std::vector<uint32_t>& sizes) {
     assert(textureWidth == 0 && "FontAtlas::build() called more than once");
 
     if (FT_Init_FreeType(&ftLibrary) != 0) {
@@ -50,17 +50,18 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
     FT_Property_Set(ftLibrary, "autofitter", "no-stem-darkening",
                     &noStemDarkening);
 
-    if (faces.empty()) {
+    if (FT_New_Face(ftLibrary, path.c_str(), 0, &ftFace) != 0) {
+        SPONGE_CORE_ERROR("Failed to load font: {}", path);
         return;
     }
 
-    if (FT_New_Face(ftLibrary, faces[0].path.c_str(), 0, &ftFace) != 0) {
-        SPONGE_CORE_ERROR("Failed to load font: {}", faces[0].path);
-        return;
-    }
+    hbFont = hb_ft_font_create_referenced(ftFace);
+    // unhinted metrics keep advances fractional; light hinting would
+    // round them to whole pixels and defeat subpixel positioning
+    hb_ft_font_set_load_flags(hbFont, FT_LOAD_NO_HINTING);
 
     struct PendingGlyph {
-        char32_t             codepoint;
+        uint32_t             glyphIndex;
         uint32_t             size;
         uint32_t             phase;
         GlyphInfo            glyphInfo;
@@ -83,8 +84,10 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
 
         auto rasterizeGlyph = [&](const char32_t codepoint,
                                   const uint32_t phase) {
-            if (FT_Load_Char(ftFace, codepoint,
-                             FT_LOAD_TARGET_LIGHT | FT_LOAD_NO_BITMAP) != 0) {
+            const FT_UInt glyphIndex = FT_Get_Char_Index(ftFace, codepoint);
+            if (glyphIndex == 0 ||
+                FT_Load_Glyph(ftFace, glyphIndex,
+                              FT_LOAD_TARGET_LIGHT | FT_LOAD_NO_BITMAP) != 0) {
                 return;
             }
 
@@ -108,12 +111,12 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
             glyphInfo.height   = bitmapHeight;
 
             if (bitmapWidth == 0 || bitmapHeight == 0) {
-                glyphs[glyphKey(codepoint, size, phase)] = glyphInfo;
+                glyphs[glyphKey(glyphIndex, size, phase)] = glyphInfo;
                 return;
             }
 
             PendingGlyph pendingGlyph;
-            pendingGlyph.codepoint    = codepoint;
+            pendingGlyph.glyphIndex   = glyphIndex;
             pendingGlyph.size         = size;
             pendingGlyph.phase        = phase;
             pendingGlyph.glyphInfo    = glyphInfo;
@@ -146,12 +149,6 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
                 rasterizeGlyph(codepoint, phase);
             }
         }
-
-        hb_font_t* hbFont = hb_ft_font_create_referenced(ftFace);
-        // unhinted metrics keep advances fractional; light hinting would
-        // round them to whole pixels and defeat subpixel positioning
-        hb_ft_font_set_load_flags(hbFont, FT_LOAD_NO_HINTING);
-        hbFonts[size] = hbFont;
     }
 
     textureWidth  = atlasSize;
@@ -170,9 +167,8 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
         GlyphInfo   glyphInfo = pendingGlyph.glyphInfo;
 
         if (!rect.was_packed) {
-            SPONGE_CORE_WARN("Glyph 0x{:x} size {} did not fit in atlas",
-                             static_cast<uint32_t>(pendingGlyph.codepoint),
-                             pendingGlyph.size);
+            SPONGE_CORE_WARN("Glyph {} size {} did not fit in atlas",
+                             pendingGlyph.glyphIndex, pendingGlyph.size);
             continue;
         }
 
@@ -197,7 +193,7 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
         glyphInfo.uvHeight = static_cast<float>(pendingGlyph.bitmapHeight) /
                              static_cast<float>(textureHeight);
 
-        glyphs[glyphKey(pendingGlyph.codepoint, pendingGlyph.size,
+        glyphs[glyphKey(pendingGlyph.glyphIndex, pendingGlyph.size,
                         pendingGlyph.phase)] = glyphInfo;
     }
 }
@@ -206,12 +202,10 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
                                           const uint32_t         size) {
     std::vector<ShapedGlyph> result;
 
-    const auto fontIter = hbFonts.find(size);
-    if (fontIter == hbFonts.end()) {
+    if (hbFont == nullptr) {
         return result;
     }
 
-    hb_font_t* hbFont = fontIter->second;
     FT_Set_Pixel_Sizes(ftFace, 0, size);
     hb_ft_font_changed(hbFont);
 
@@ -221,11 +215,10 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
     hb_buffer_guess_segment_properties(buffer);
 
     const hb_feature_t features[] = {
-        { HB_TAG('k', 'e', 'r', 'n'), 1, 0, UINT_MAX },
         { HB_TAG('l', 'i', 'g', 'a'), 0, 0, UINT_MAX },
         { HB_TAG('c', 'l', 'i', 'g'), 0, 0, UINT_MAX },
     };
-    hb_shape(hbFont, buffer, features, 3);
+    hb_shape(hbFont, buffer, features, 2);
 
     unsigned int     glyphCount = 0;
     hb_glyph_info_t* glyphInfos =
@@ -235,20 +228,9 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
 
     result.reserve(glyphCount);
     for (unsigned int index = 0; index < glyphCount; index++) {
-        const uint32_t      cluster = glyphInfos[index].cluster;
-        const unsigned char byte0   = static_cast<unsigned char>(text[cluster]);
-        char32_t            codepoint;
-        if (byte0 < 0x80) {
-            codepoint = byte0;
-        } else if (byte0 < 0xE0) {
-            codepoint = static_cast<char32_t>((byte0 & 0x1Fu) << 6u) |
-                        (static_cast<unsigned char>(text[cluster + 1]) & 0x3Fu);
-        } else {
-            codepoint = byte0;
-        }
-
         ShapedGlyph shapedGlyph{};
-        shapedGlyph.codepoint = codepoint;
+        // after shaping, hb_glyph_info_t.codepoint holds the glyph index
+        shapedGlyph.glyphIndex = glyphInfos[index].codepoint;
         shapedGlyph.xAdvance =
             static_cast<float>(positions[index].x_advance) / 64.0F;
         shapedGlyph.xOffset =
@@ -262,10 +244,10 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
     return result;
 }
 
-const GlyphInfo* FontAtlas::getGlyph(const char32_t codepoint,
+const GlyphInfo* FontAtlas::getGlyph(const uint32_t glyphIndex,
                                      const uint32_t size,
                                      const uint32_t phase) const {
-    const auto iter = glyphs.find(glyphKey(codepoint, size, phase));
+    const auto iter = glyphs.find(glyphKey(glyphIndex, size, phase));
     return iter != glyphs.end() ? &iter->second : nullptr;
 }
 

--- a/sponge/src/scene/fontatlas.cpp
+++ b/sponge/src/scene/fontatlas.cpp
@@ -45,6 +45,11 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
 
     FT_Library_SetLcdFilter(ftLibrary, FT_LCD_FILTER_DEFAULT);
 
+    // thicken stems to compensate for coverage loss in gamma-unaware blending
+    FT_Bool noStemDarkening = 0;
+    FT_Property_Set(ftLibrary, "autofitter", "no-stem-darkening",
+                    &noStemDarkening);
+
     if (faces.empty()) {
         return;
     }
@@ -57,6 +62,7 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
     struct PendingGlyph {
         char32_t             codepoint;
         uint32_t             size;
+        uint32_t             phase;
         GlyphInfo            glyphInfo;
         std::vector<uint8_t> bitmap;
         int                  bitmapWidth;
@@ -75,13 +81,21 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
         ascenders[size] =
             static_cast<float>(ftFace->size->metrics.ascender >> 6);
 
-        auto rasterizeGlyph = [&](const char32_t codepoint) {
+        auto rasterizeGlyph = [&](const char32_t codepoint,
+                                  const uint32_t phase) {
             if (FT_Load_Char(ftFace, codepoint,
-                             FT_LOAD_RENDER | FT_LOAD_TARGET_LCD) != 0) {
+                             FT_LOAD_TARGET_LIGHT | FT_LOAD_NO_BITMAP) != 0) {
                 return;
             }
 
             const FT_GlyphSlot glyphSlot = ftFace->glyph;
+            // shift outline by phase/4 pixel (26.6 fixed point) before
+            // rasterizing so each phase bakes a distinct subpixel position
+            FT_Outline_Translate(&glyphSlot->outline,
+                                 static_cast<FT_Pos>(phase * 16), 0);
+            if (FT_Render_Glyph(glyphSlot, FT_RENDER_MODE_LCD) != 0) {
+                return;
+            }
             const int lcdWidth     = static_cast<int>(glyphSlot->bitmap.width);
             const int bitmapPitch  = std::abs(glyphSlot->bitmap.pitch);
             const int bitmapWidth  = lcdWidth / 3;
@@ -92,16 +106,16 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
             glyphInfo.bearingY = glyphSlot->bitmap_top;
             glyphInfo.width    = bitmapWidth;
             glyphInfo.height   = bitmapHeight;
-            glyphInfo.advanceX = static_cast<float>(glyphSlot->advance.x >> 6);
 
             if (bitmapWidth == 0 || bitmapHeight == 0) {
-                glyphs[glyphKey(codepoint, size)] = glyphInfo;
+                glyphs[glyphKey(codepoint, size, phase)] = glyphInfo;
                 return;
             }
 
             PendingGlyph pendingGlyph;
             pendingGlyph.codepoint    = codepoint;
             pendingGlyph.size         = size;
+            pendingGlyph.phase        = phase;
             pendingGlyph.glyphInfo    = glyphInfo;
             pendingGlyph.bitmapWidth  = bitmapWidth;
             pendingGlyph.bitmapHeight = bitmapHeight;
@@ -123,16 +137,21 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
             rects.push_back(rect);
         };
 
-        for (char32_t codepoint = firstGlyph; codepoint <= lastGlyph;
-             codepoint++) {
-            rasterizeGlyph(codepoint);
-        }
-        for (const char32_t codepoint : supplementalGlyphs) {
-            rasterizeGlyph(codepoint);
+        for (uint32_t phase = 0; phase < subpixelPhases; phase++) {
+            for (char32_t codepoint = firstGlyph; codepoint <= lastGlyph;
+                 codepoint++) {
+                rasterizeGlyph(codepoint, phase);
+            }
+            for (const char32_t codepoint : supplementalGlyphs) {
+                rasterizeGlyph(codepoint, phase);
+            }
         }
 
         hb_font_t* hbFont = hb_ft_font_create_referenced(ftFace);
-        hbFonts[size]     = hbFont;
+        // unhinted metrics keep advances fractional; light hinting would
+        // round them to whole pixels and defeat subpixel positioning
+        hb_ft_font_set_load_flags(hbFont, FT_LOAD_NO_HINTING);
+        hbFonts[size] = hbFont;
     }
 
     textureWidth  = atlasSize;
@@ -178,7 +197,8 @@ void FontAtlas::build(const std::vector<FontFaceSpec>& faces,
         glyphInfo.uvHeight = static_cast<float>(pendingGlyph.bitmapHeight) /
                              static_cast<float>(textureHeight);
 
-        glyphs[glyphKey(pendingGlyph.codepoint, pendingGlyph.size)] = glyphInfo;
+        glyphs[glyphKey(pendingGlyph.codepoint, pendingGlyph.size,
+                        pendingGlyph.phase)] = glyphInfo;
     }
 }
 
@@ -228,7 +248,7 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
         }
 
         ShapedGlyph shapedGlyph{};
-        shapedGlyph.glyphInfo = getGlyph(codepoint, size);
+        shapedGlyph.codepoint = codepoint;
         shapedGlyph.xAdvance =
             static_cast<float>(positions[index].x_advance) / 64.0F;
         shapedGlyph.xOffset =
@@ -243,8 +263,9 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
 }
 
 const GlyphInfo* FontAtlas::getGlyph(const char32_t codepoint,
-                                     const uint32_t size) const {
-    const auto iter = glyphs.find(glyphKey(codepoint, size));
+                                     const uint32_t size,
+                                     const uint32_t phase) const {
+    const auto iter = glyphs.find(glyphKey(codepoint, size, phase));
     return iter != glyphs.end() ? &iter->second : nullptr;
 }
 

--- a/sponge/src/scene/fontatlas.hpp
+++ b/sponge/src/scene/fontatlas.hpp
@@ -28,15 +28,11 @@ struct GlyphInfo {
     int   height;             // bitmap height in pixels
 };
 
-struct FontFaceSpec {
-    std::string path;  // absolute path to .ttf file
-};
-
 struct ShapedGlyph {
-    char32_t codepoint;  // atlas lookup key; phase resolved at render time
-    float    xAdvance;   // horizontal advance (pixels)
-    float    xOffset;    // horizontal offset (pixels)
-    float    yOffset;    // vertical offset (pixels)
+    uint32_t glyphIndex;  // atlas lookup key; phase resolved at render time
+    float    xAdvance;    // horizontal advance (pixels)
+    float    xOffset;     // horizontal offset (pixels)
+    float    yOffset;     // vertical offset (pixels)
 };
 
 class FontAtlas {
@@ -46,12 +42,11 @@ public:
 
     ~FontAtlas();
 
-    void build(const std::vector<FontFaceSpec>& faces,
-               const std::vector<uint32_t>&     sizes);
+    void build(const std::string& path, const std::vector<uint32_t>& sizes);
 
     std::vector<ShapedGlyph> shape(std::string_view text, uint32_t size);
 
-    const GlyphInfo* getGlyph(char32_t codepoint, uint32_t size,
+    const GlyphInfo* getGlyph(uint32_t glyphIndex, uint32_t size,
                               uint32_t phase) const;
     float            getLineHeight(uint32_t size) const;
     float            getAscender(uint32_t size) const;
@@ -67,15 +62,14 @@ public:
     }
 
 private:
-    static uint64_t glyphKey(const char32_t codepoint, const uint32_t size,
+    static uint64_t glyphKey(const uint32_t glyphIndex, const uint32_t size,
                              const uint32_t phase) {
-        return (static_cast<uint64_t>(codepoint) << 32) | (size << 2) | phase;
+        return (static_cast<uint64_t>(glyphIndex) << 32) | (size << 2) | phase;
     }
 
-    std::unordered_map<uint64_t, GlyphInfo>  glyphs;
-    std::unordered_map<uint32_t, float>      lineHeights;
-    std::unordered_map<uint32_t, float>      ascenders;
-    std::unordered_map<uint32_t, hb_font_t*> hbFonts;
+    std::unordered_map<uint64_t, GlyphInfo> glyphs;
+    std::unordered_map<uint32_t, float>     lineHeights;
+    std::unordered_map<uint32_t, float>     ascenders;
 
     std::vector<uint8_t> atlasBuffer;
     uint32_t             textureWidth  = 0;
@@ -83,6 +77,9 @@ private:
 
     FT_Library ftLibrary = nullptr;
     FT_Face    ftFace    = nullptr;
+    // one font for all sizes; shape() resyncs its scale via
+    // hb_ft_font_changed after FT_Set_Pixel_Sizes
+    hb_font_t* hbFont = nullptr;
 };
 
 }  // namespace sponge::scene

--- a/sponge/src/scene/fontatlas.hpp
+++ b/sponge/src/scene/fontatlas.hpp
@@ -11,6 +11,8 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_LCD_FILTER_H
+#include FT_MODULE_H
+#include FT_OUTLINE_H
 #include <harfbuzz/hb.h>
 #include <harfbuzz/hb-ft.h>
 // clang-format on
@@ -24,7 +26,6 @@ struct GlyphInfo {
     int   bearingY;           // vertical bearing in pixels
     int   width;              // bitmap width in pixels
     int   height;             // bitmap height in pixels
-    float advanceX;           // horizontal advance in pixels
 };
 
 struct FontFaceSpec {
@@ -32,14 +33,17 @@ struct FontFaceSpec {
 };
 
 struct ShapedGlyph {
-    const GlyphInfo* glyphInfo;  // nullptr if not in atlas
-    float            xAdvance;   // horizontal advance (pixels)
-    float            xOffset;    // horizontal offset (pixels)
-    float            yOffset;    // vertical offset (pixels)
+    char32_t codepoint;  // atlas lookup key; phase resolved at render time
+    float    xAdvance;   // horizontal advance (pixels)
+    float    xOffset;    // horizontal offset (pixels)
+    float    yOffset;    // vertical offset (pixels)
 };
 
 class FontAtlas {
 public:
+    // horizontal subpixel positions baked per glyph (1/4 pixel steps)
+    static constexpr uint32_t subpixelPhases = 4;
+
     ~FontAtlas();
 
     void build(const std::vector<FontFaceSpec>& faces,
@@ -47,7 +51,8 @@ public:
 
     std::vector<ShapedGlyph> shape(std::string_view text, uint32_t size);
 
-    const GlyphInfo* getGlyph(char32_t codepoint, uint32_t size) const;
+    const GlyphInfo* getGlyph(char32_t codepoint, uint32_t size,
+                              uint32_t phase) const;
     float            getLineHeight(uint32_t size) const;
     float            getAscender(uint32_t size) const;
 
@@ -62,8 +67,9 @@ public:
     }
 
 private:
-    static uint64_t glyphKey(const char32_t codepoint, const uint32_t size) {
-        return (static_cast<uint64_t>(codepoint) << 32) | size;
+    static uint64_t glyphKey(const char32_t codepoint, const uint32_t size,
+                             const uint32_t phase) {
+        return (static_cast<uint64_t>(codepoint) << 32) | (size << 2) | phase;
     }
 
     std::unordered_map<uint64_t, GlyphInfo>  glyphs;


### PR DESCRIPTION
## Summary

Improves UI text clarity and spacing by reworking the FreeType + HarfBuzz pipeline in `FontAtlas`/`BitmapFont`:

- Rasterize glyphs with `FT_LOAD_TARGET_LIGHT` (vertical-only grid fit) and LCD subpixel anti-aliasing
- Bake 4 quarter-pixel phase variants per glyph; at render time the fractional pen position selects the phase, giving true subpixel positioning with `GL_NEAREST` sampling
- Shape with unhinted HarfBuzz metrics (`FT_LOAD_NO_HINTING`) so advances stay fractional instead of rounding to whole pixels
- Enable FreeType autofitter stem darkening to compensate for gamma-unaware blending
- Remove unused `GlyphInfo.advanceX`
- Docs: replace the stale MSDF feature bullet with the actual FreeType + HarfBuzz pipeline and add a clustered lighting bullet