### PR TITLE
Fix multiplication sign not rendering in resolution list

### DIFF
--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -830,8 +830,7 @@ void OptionLayer::filterResolutions() {
     };
 
     auto filtered = availableResolutions | std::views::filter(matchesFilter);
-    filteredResolutions =
-        std::vector<sponge::core::Resolution>(filtered.begin(), filtered.end());
+    filteredResolutions = std::vector(filtered.begin(), filtered.end());
 
     const auto window        = Maze::get().getWindow();
     const auto currentWidth  = window->getWidth();
@@ -850,11 +849,10 @@ void OptionLayer::filterResolutions() {
             [&](const auto& r) {
                 return r.width == currentWidth && r.height == currentHeight;
             });
-        const auto idx =
-            it != filteredResolutions.end() ?
-                std::optional<size_t>{ static_cast<size_t>(
-                    std::distance(filteredResolutions.begin(), it)) } :
-                std::nullopt;
+        const auto idx = it != filteredResolutions.end() ?
+                             std::optional{ static_cast<size_t>(std::distance(
+                                 filteredResolutions.begin(), it)) } :
+                             std::nullopt;
         resolutionList->setSelectedIndex(idx.value_or(0));
         currentResolutionIndex = idx;
     } else {
@@ -924,7 +922,7 @@ void OptionLayer::updateChangeStatus() {
         const auto idx = findAspectRatioIndex(curW, curH);
         currentAspectRatioIndex =
             matchesAspectRatio(validAspectRatioFilters[idx], curW, curH) ?
-                std::optional<size_t>{ idx } :
+                std::optional{ idx } :
                 std::nullopt;
     } else {
         currentAspectRatioIndex = std::nullopt;
@@ -941,7 +939,7 @@ void OptionLayer::updateChangeStatus() {
             [&](const auto& r) { return r.width == curW && r.height == curH; });
         currentResolutionIndex =
             it != filteredResolutions.end() ?
-                std::optional<size_t>{ static_cast<size_t>(
+                std::optional{ static_cast<size_t>(
                     std::distance(filteredResolutions.begin(), it)) } :
                 std::nullopt;
     }
@@ -950,7 +948,7 @@ void OptionLayer::updateChangeStatus() {
         Maze::get().getMazeLayer()->getDirectionalLightShadowMapRes();
     const auto sqIt = std::ranges::find(shadowResolutions, currentShadowRes);
     currentShadowResIndex = sqIt != shadowResolutions.end() ?
-                                std::optional<size_t>{ static_cast<size_t>(
+                                std::optional{ static_cast<size_t>(
                                     sqIt - shadowResolutions.begin()) } :
                                 std::nullopt;
     const bool shadowChanged =

--- a/sponge/src/scene/fontatlas.cpp
+++ b/sponge/src/scene/fontatlas.cpp
@@ -214,11 +214,15 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
                        static_cast<int>(text.size()));
     hb_buffer_guess_segment_properties(buffer);
 
+    // liga/clig/calt off so shaping never substitutes glyph indices the
+    // atlas did not bake (e.g. Inter calt swaps multiply for multiply.case
+    // between digits, which would render as nothing)
     const hb_feature_t features[] = {
         { HB_TAG('l', 'i', 'g', 'a'), 0, 0, UINT_MAX },
         { HB_TAG('c', 'l', 'i', 'g'), 0, 0, UINT_MAX },
+        { HB_TAG('c', 'a', 'l', 't'), 0, 0, UINT_MAX },
     };
-    hb_shape(hbFont, buffer, features, 2);
+    hb_shape(hbFont, buffer, features, 3);
 
     unsigned int     glyphCount = 0;
     hb_glyph_info_t* glyphInfos =


### PR DESCRIPTION
## Summary

The multiplication sign in resolution strings like "1920 x 1080" rendered as nothing after #421 switched font atlas lookups from codepoints to shaped glyph indices.

Inter's `calt` (contextual alternates) feature substitutes `multiply` (the cmap glyph the atlas bakes) with `multiply.case` when the sign sits between digits. The substituted glyph index was never baked, so `getGlyph` missed and the quad was skipped.

Fix: disable `calt` during shaping alongside the already-disabled `liga`/`clig`, so shaping can never emit a glyph index the atlas did not bake.

Also includes a small CTAD cleanup in optionlayer.

## Testing

- Verified with HarfBuzz against the shipped inter.ttf: with `calt` on, "1920 x 1080" shapes to `multiply.case` (unbaked); with `calt` off it shapes to `multiply` (baked).
- Built windows-msvc-release cleanly. Not yet visually verified in the options screen.