### PR TITLE
Consolidate menu UI helpers; fix cross-thread GLFW calls

### DIFF
--- a/game/src/layer/exitlayer.cpp
+++ b/game/src/layer/exitlayer.cpp
@@ -6,6 +6,7 @@
 #include "sponge.hpp"
 #include "ui/button.hpp"
 #include "ui/menufontsize.hpp"
+#include "ui/menulayout.hpp"
 
 #include <yoga/Yoga.h>
 
@@ -23,7 +24,6 @@ constexpr std::string_view fontName   = "inter";
 constexpr std::string_view fontPath   = "/fonts/inter.ttf";
 
 constexpr glm::vec4 buttonColor    = { 0.05F, 0.05F, 0.05F, 1.F };
-constexpr glm::vec4 hoverColor     = { 0.84F, 0.84F, 0.84F, 0.14F };
 constexpr glm::vec3 textColor      = { 1.F, 1.F, 1.F };
 constexpr glm::vec4 textHoverColor = { 0.84F, 0.04F, 0.04F, 0.07F };
 
@@ -41,7 +41,6 @@ YGNodeRef menuNode           = nullptr;
 YGNodeRef optionsNode        = nullptr;
 YGNodeRef returnToMenuNode   = nullptr;
 YGNodeRef rootNode           = nullptr;
-YGNodeRef titleNode          = nullptr;
 
 std::shared_ptr<game::scene::OrthoCamera> orthoCamera;
 
@@ -72,17 +71,9 @@ void ExitLayer::onAttach() {
     orthoCamera = ResourceManager::createOrthoCamera(orthoCameraCreateInfo);
 
     auto makeMenuButton = [](std::string_view message) {
-        return std::make_unique<ui::Button>(ui::ButtonCreateInfo{
-            .topLeft      = glm::vec2{ 0.F },
-            .bottomRight  = glm::vec2{ 0.F },
-            .message      = std::string(message),
-            .fontSize     = ui::menuFontSizeForWidth(orthoCamera->getWidth()),
-            .font         = menuFont,
-            .buttonColor  = buttonColor,
-            .textColor    = textColor,
-            .marginLeft   = 26,
-            .cornerRadius = 12.F,
-            .alignType    = ui::ButtonAlignType::LeftAligned });
+        return ui::makeMenuButton(
+            message, ui::menuFontSizeForWidth(orthoCamera->getWidth()),
+            menuFont, buttonColor, textColor);
     };
 
     continueButton     = makeMenuButton(continueMessage);
@@ -96,34 +87,15 @@ void ExitLayer::onAttach() {
         shader->unbind();
     }
 
-    rootNode = YGNodeNew();
+    const auto skeleton = ui::buildMenuSkeleton(45.F);
+    rootNode            = skeleton.root;
+    menuNode            = skeleton.menu;
+    menuBackgroundNode  = skeleton.menuBackground;
 
-    titleNode = YGNodeNew();
-    YGNodeStyleSetFlexGrow(titleNode, 0.9F);
-    YGNodeInsertChild(rootNode, titleNode, 0);
-
-    menuNode = YGNodeNew();
-    YGNodeStyleSetFlex(menuNode, 1.F);
-    YGNodeStyleSetFlexDirection(menuNode, YGFlexDirectionRow);
-    YGNodeInsertChild(rootNode, menuNode, 1);
-
-    menuBackgroundNode = YGNodeNew();
-    YGNodeStyleSetMargin(menuBackgroundNode, YGEdgeAll, 10.F);
-    YGNodeStyleSetWidthPercent(menuBackgroundNode, 45.F);
-    YGNodeInsertChild(menuNode, menuBackgroundNode, 0);
-
-    auto makeMenuNode = [](const YGNodeRef parent, const int index) {
-        auto* const child = YGNodeNew();
-        YGNodeStyleSetFlex(child, 1.F);
-        YGNodeStyleSetMaxHeight(child, 110);
-        YGNodeInsertChild(parent, child, index);
-        return child;
-    };
-
-    continueNode     = makeMenuNode(menuBackgroundNode, 0);
-    optionsNode      = makeMenuNode(menuBackgroundNode, 1);
-    returnToMenuNode = makeMenuNode(menuBackgroundNode, 2);
-    exitNode         = makeMenuNode(menuBackgroundNode, 3);
+    continueNode     = ui::makeMenuRow(menuBackgroundNode, 0);
+    optionsNode      = ui::makeMenuRow(menuBackgroundNode, 1);
+    returnToMenuNode = ui::makeMenuRow(menuBackgroundNode, 2);
+    exitNode         = ui::makeMenuRow(menuBackgroundNode, 3);
 
     const auto width  = static_cast<float>(orthoCamera->getWidth());
     const auto height = static_cast<float>(orthoCamera->getHeight());
@@ -216,31 +188,23 @@ bool ExitLayer::onUpdate(const double elapsedTime) {
         shader->unbind();
     }
 
-    auto getNodeLayout = [](const YGNodeRef node, const float offsetX,
-                            const float offsetY) {
-        return std::tuple{ offsetX + YGNodeLayoutGetLeft(node),
-                           offsetY + YGNodeLayoutGetTop(node),
-                           YGNodeLayoutGetWidth(node),
-                           YGNodeLayoutGetHeight(node) };
-    };
-
     auto [rootNodeX, rootNodeY, rootNodeW, rootNodeH] =
-        getNodeLayout(rootNode, 0.F, 0.F);
+        ui::getNodeLayout(rootNode, 0.F, 0.F);
     auto [menuNodeX, menuNodeY, menuNodeW, menuNodeH] =
-        getNodeLayout(menuNode, rootNodeX, rootNodeY);
+        ui::getNodeLayout(menuNode, rootNodeX, rootNodeY);
     auto [menuBackgroundNodeX, menuBackgroundNodeY, menuBackgroundNodeW,
           menuBackgroundNodeH] =
-        getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
+        ui::getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
 
-    const auto [continueX, continueY, continueW, continueH] =
-        getNodeLayout(continueNode, menuBackgroundNodeX, menuBackgroundNodeY);
-    const auto [optionsX, optionsY, optionsW, optionsH] =
-        getNodeLayout(optionsNode, menuBackgroundNodeX, menuBackgroundNodeY);
+    const auto [continueX, continueY, continueW, continueH] = ui::getNodeLayout(
+        continueNode, menuBackgroundNodeX, menuBackgroundNodeY);
+    const auto [optionsX, optionsY, optionsW, optionsH] = ui::getNodeLayout(
+        optionsNode, menuBackgroundNodeX, menuBackgroundNodeY);
     const auto [returnToMenuX, returnToMenuY, returnToMenuW, returnToMenuH] =
-        getNodeLayout(returnToMenuNode, menuBackgroundNodeX,
-                      menuBackgroundNodeY);
+        ui::getNodeLayout(returnToMenuNode, menuBackgroundNodeX,
+                          menuBackgroundNodeY);
     const auto [quitX, quitY, quitW, quitH] =
-        getNodeLayout(exitNode, menuBackgroundNodeX, menuBackgroundNodeY);
+        ui::getNodeLayout(exitNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     continueButton->setPosition(
         { continueX, continueY },
@@ -252,24 +216,17 @@ bool ExitLayer::onUpdate(const double elapsedTime) {
         { returnToMenuX + returnToMenuW, returnToMenuY + returnToMenuH });
     exitButton->setPosition({ quitX, quitY }, { quitX + quitW, quitY + quitH });
 
-    auto updateButtonVisuals = [this](ui::Button* button, ExitMenuItem item) {
-        if (selectedItem == item) {
-            button->setBorderWidth(3.F);
-            button->setBorderColor(glm::vec4{ 1.F });
-            button->setButtonColor(textHoverColor);
-        } else if (!button->hasHover()) {
-            button->setBorderWidth(0.F);
-            button->setButtonColor(glm::vec4{ 0.F });
-        } else {
-            button->setBorderWidth(0.F);
-            button->setButtonColor(hoverColor);
-        }
-    };
-
-    updateButtonVisuals(continueButton.get(), ExitMenuItem::Continue);
-    updateButtonVisuals(optionsButton.get(), ExitMenuItem::Options);
-    updateButtonVisuals(returnToMenuButton.get(), ExitMenuItem::ReturnToMenu);
-    updateButtonVisuals(exitButton.get(), ExitMenuItem::Exit);
+    ui::updateMenuButtonVisuals(continueButton.get(),
+                                selectedItem == ExitMenuItem::Continue,
+                                textHoverColor);
+    ui::updateMenuButtonVisuals(optionsButton.get(),
+                                selectedItem == ExitMenuItem::Options,
+                                textHoverColor);
+    ui::updateMenuButtonVisuals(returnToMenuButton.get(),
+                                selectedItem == ExitMenuItem::ReturnToMenu,
+                                textHoverColor);
+    ui::updateMenuButtonVisuals(
+        exitButton.get(), selectedItem == ExitMenuItem::Exit, textHoverColor);
 
     UNUSED(continueButton->onUpdate(elapsedTime));
     UNUSED(optionsButton->onUpdate(elapsedTime));
@@ -342,18 +299,10 @@ bool ExitLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
 bool ExitLayer::onMouseMoved(const MouseMovedEvent& event) {
     const auto pos = glm::vec2{ event.getX(), event.getY() };
 
-    auto updateHover = [&pos](ui::Button* button) {
-        if (!button->hasHover() && button->isInside(pos)) {
-            button->setHover(true);
-        } else if (button->hasHover() && !button->isInside(pos)) {
-            button->setHover(false);
-        }
-    };
-
-    updateHover(continueButton.get());
-    updateHover(optionsButton.get());
-    updateHover(returnToMenuButton.get());
-    updateHover(exitButton.get());
+    ui::updateButtonHover(continueButton.get(), pos);
+    ui::updateButtonHover(optionsButton.get(), pos);
+    ui::updateButtonHover(returnToMenuButton.get(), pos);
+    ui::updateButtonHover(exitButton.get(), pos);
 
     return true;
 }

--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -421,7 +421,7 @@ void ImGuiLayer::showMenu() {
 
             if (ImGui::MenuItem("Vertical Sync", nullptr, hasVsync)) {
                 hasVsync = !hasVsync;
-                Maze::get().setVerticalSync(hasVsync);
+                Maze::get().requestVerticalSync(hasVsync);
             }
 
             if (ImGui::MenuItem("Anti-Aliasing", nullptr, hasFxaa)) {

--- a/game/src/layer/introlayer.cpp
+++ b/game/src/layer/introlayer.cpp
@@ -6,6 +6,7 @@
 #include "sponge.hpp"
 #include "ui/button.hpp"
 #include "ui/menufontsize.hpp"
+#include "ui/menulayout.hpp"
 
 #include <yoga/Yoga.h>
 
@@ -23,7 +24,6 @@ constexpr std::string_view fontPath   = "/fonts/inter.ttf";
 
 constexpr glm::vec4 backgroundColor = { 0.12F, 0.19F, 0.29F, 1.F };
 constexpr glm::vec4 buttonColor     = { 0.F, 0.F, 0.F, 0.F };
-constexpr glm::vec4 hoverColor      = { 0.84F, 0.84F, 0.84F, 0.14F };
 constexpr glm::vec3 textColor       = { 1.F, 1.F, 1.F };
 constexpr glm::vec4 textHoverColor  = { 0.84F, 0.04F, 0.04F, 0.07F };
 
@@ -39,7 +39,6 @@ YGNodeRef newGameNode        = nullptr;
 YGNodeRef optionsNode        = nullptr;
 YGNodeRef quitNode           = nullptr;
 YGNodeRef rootNode           = nullptr;
-YGNodeRef titleNode          = nullptr;
 
 std::unique_ptr<sponge::platform::opengl::scene::Quad> quad;
 
@@ -81,17 +80,9 @@ void IntroLayer::onAttach() {
     quad = std::make_unique<Quad>();
 
     auto makeMenuButton = [](std::string_view message) {
-        return std::make_unique<ui::Button>(ui::ButtonCreateInfo{
-            .topLeft      = glm::vec2{ 0.F },
-            .bottomRight  = glm::vec2{ 0.F },
-            .message      = std::string(message),
-            .fontSize     = ui::menuFontSizeForWidth(orthoCamera->getWidth()),
-            .font         = menuFont,
-            .buttonColor  = buttonColor,
-            .textColor    = textColor,
-            .marginLeft   = 26,
-            .cornerRadius = 12.F,
-            .alignType    = ui::ButtonAlignType::LeftAligned });
+        return ui::makeMenuButton(
+            message, ui::menuFontSizeForWidth(orthoCamera->getWidth()),
+            menuFont, buttonColor, textColor);
     };
 
     newGameButton = makeMenuButton(newGameMessage);
@@ -104,33 +95,14 @@ void IntroLayer::onAttach() {
         shader->unbind();
     }
 
-    rootNode = YGNodeNew();
+    const auto skeleton = ui::buildMenuSkeleton(30.F);
+    rootNode            = skeleton.root;
+    menuNode            = skeleton.menu;
+    menuBackgroundNode  = skeleton.menuBackground;
 
-    titleNode = YGNodeNew();
-    YGNodeStyleSetFlexGrow(titleNode, 0.9F);
-    YGNodeInsertChild(rootNode, titleNode, 0);
-
-    menuNode = YGNodeNew();
-    YGNodeStyleSetFlex(menuNode, 1.F);
-    YGNodeStyleSetFlexDirection(menuNode, YGFlexDirectionRow);
-    YGNodeInsertChild(rootNode, menuNode, 1);
-
-    menuBackgroundNode = YGNodeNew();
-    YGNodeStyleSetMargin(menuBackgroundNode, YGEdgeAll, 10.F);
-    YGNodeStyleSetWidthPercent(menuBackgroundNode, 30.F);
-    YGNodeInsertChild(menuNode, menuBackgroundNode, 0);
-
-    auto makeMenuNode = [](const YGNodeRef parent, const int index) {
-        auto* const child = YGNodeNew();
-        YGNodeStyleSetFlex(child, 1.F);
-        YGNodeStyleSetMaxHeight(child, 110);
-        YGNodeInsertChild(parent, child, index);
-        return child;
-    };
-
-    newGameNode = makeMenuNode(menuBackgroundNode, 0);
-    optionsNode = makeMenuNode(menuBackgroundNode, 1);
-    quitNode    = makeMenuNode(menuBackgroundNode, 2);
+    newGameNode = ui::makeMenuRow(menuBackgroundNode, 0);
+    optionsNode = ui::makeMenuRow(menuBackgroundNode, 1);
+    quitNode    = ui::makeMenuRow(menuBackgroundNode, 2);
 
     const auto width  = static_cast<float>(orthoCamera->getWidth());
     const auto height = static_cast<float>(orthoCamera->getHeight());
@@ -228,28 +200,20 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
 
     quad->render({ 0.F, 0.F }, { width, height }, backgroundColor);
 
-    auto getNodeLayout = [](const YGNodeRef node, const float offsetX,
-                            const float offsetY) {
-        return std::tuple{ offsetX + YGNodeLayoutGetLeft(node),
-                           offsetY + YGNodeLayoutGetTop(node),
-                           YGNodeLayoutGetWidth(node),
-                           YGNodeLayoutGetHeight(node) };
-    };
-
     auto [rootNodeX, rootNodeY, rootNodeW, rootNodeH] =
-        getNodeLayout(rootNode, 0.F, 0.F);
+        ui::getNodeLayout(rootNode, 0.F, 0.F);
     auto [menuNodeX, menuNodeY, menuNodeW, menuNodeH] =
-        getNodeLayout(menuNode, rootNodeX, rootNodeY);
+        ui::getNodeLayout(menuNode, rootNodeX, rootNodeY);
     auto [menuBackgroundNodeX, menuBackgroundNodeY, menuBackgroundNodeW,
           menuBackgroundNodeH] =
-        getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
+        ui::getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
 
-    const auto [newGameX, newGameY, newGameW, newGameH] =
-        getNodeLayout(newGameNode, menuBackgroundNodeX, menuBackgroundNodeY);
-    const auto [optionsX, optionsY, optionsW, optionsH] =
-        getNodeLayout(optionsNode, menuBackgroundNodeX, menuBackgroundNodeY);
+    const auto [newGameX, newGameY, newGameW, newGameH] = ui::getNodeLayout(
+        newGameNode, menuBackgroundNodeX, menuBackgroundNodeY);
+    const auto [optionsX, optionsY, optionsW, optionsH] = ui::getNodeLayout(
+        optionsNode, menuBackgroundNodeX, menuBackgroundNodeY);
     const auto [quitX, quitY, quitW, quitH] =
-        getNodeLayout(quitNode, menuBackgroundNodeX, menuBackgroundNodeY);
+        ui::getNodeLayout(quitNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     newGameButton->setPosition({ newGameX, newGameY },
                                { newGameX + newGameW, newGameY + newGameH });
@@ -257,23 +221,14 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
                                { optionsX + optionsW, optionsY + optionsH });
     quitButton->setPosition({ quitX, quitY }, { quitX + quitW, quitY + quitH });
 
-    auto updateButtonVisuals = [this](ui::Button* button, IntroMenuItem item) {
-        if (selectedItem == item) {
-            button->setBorderWidth(3.F);
-            button->setBorderColor(glm::vec4{ 1.F });
-            button->setButtonColor(textHoverColor);
-        } else if (!button->hasHover()) {
-            button->setBorderWidth(0.F);
-            button->setButtonColor(glm::vec4{ 0.F });
-        } else {
-            button->setBorderWidth(0.F);
-            button->setButtonColor(hoverColor);
-        }
-    };
-
-    updateButtonVisuals(newGameButton.get(), IntroMenuItem::NewGame);
-    updateButtonVisuals(optionsButton.get(), IntroMenuItem::Options);
-    updateButtonVisuals(quitButton.get(), IntroMenuItem::Quit);
+    ui::updateMenuButtonVisuals(newGameButton.get(),
+                                selectedItem == IntroMenuItem::NewGame,
+                                textHoverColor);
+    ui::updateMenuButtonVisuals(optionsButton.get(),
+                                selectedItem == IntroMenuItem::Options,
+                                textHoverColor);
+    ui::updateMenuButtonVisuals(
+        quitButton.get(), selectedItem == IntroMenuItem::Quit, textHoverColor);
 
     UNUSED(newGameButton->onUpdate(elapsedTime));
     UNUSED(optionsButton->onUpdate(elapsedTime));
@@ -382,17 +337,9 @@ bool IntroLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
 bool IntroLayer::onMouseMoved(const MouseMovedEvent& event) {
     const auto pos = glm::vec2{ event.getX(), event.getY() };
 
-    auto updateHover = [&pos](ui::Button* button) {
-        if (!button->hasHover() && button->isInside(pos)) {
-            button->setHover(true);
-        } else if (button->hasHover() && !button->isInside(pos)) {
-            button->setHover(false);
-        }
-    };
-
-    updateHover(newGameButton.get());
-    updateHover(optionsButton.get());
-    updateHover(quitButton.get());
+    ui::updateButtonHover(newGameButton.get(), pos);
+    ui::updateButtonHover(optionsButton.get(), pos);
+    ui::updateButtonHover(quitButton.get(), pos);
 
     return false;
 }

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -234,7 +234,7 @@ bool MazeLayer::onUpdate(const double elapsedTime) {
     } else {
         if (!overlayActive && snap.isActive(GameAction::Pause)) {
             Maze::get().getExitLayer()->setActive(true);
-            Application::get().setMouseVisible(true);
+            Application::get().requestMouseVisible(true);
             inputManager.setMouseLookActive(false);
             mouseButtonPressed = false;
             inputManager.setActiveContext(sponge::input::InputContext::Menu);

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -24,6 +24,7 @@
 #include "ui/button.hpp"
 #include "ui/checkbox.hpp"
 #include "ui/menufontsize.hpp"
+#include "ui/menulayout.hpp"
 #include "ui/selectlist.hpp"
 
 namespace {
@@ -129,14 +130,6 @@ size_t findAspectRatioIndex(const uint32_t width, const uint32_t height) {
                0;
 }
 
-std::tuple<float, float, float, float> getNodeLayout(const YGNodeRef node,
-                                                     const float     offsetX,
-                                                     const float     offsetY) {
-    return { offsetX + YGNodeLayoutGetLeft(node),
-             offsetY + YGNodeLayoutGetTop(node), YGNodeLayoutGetWidth(node),
-             YGNodeLayoutGetHeight(node) };
-}
-
 std::shared_ptr<sponge::platform::opengl::scene::BitmapFont> menuFont;
 
 // max display width across all aspect-ratio labels and resolution strings
@@ -182,7 +175,6 @@ YGNodeRef verticalSyncNode   = nullptr;
 YGNodeRef fullScreenNode     = nullptr;
 YGNodeRef returnNode         = nullptr;
 YGNodeRef rootNode           = nullptr;
-YGNodeRef titleNode          = nullptr;
 
 std::optional<size_t> currentShadowResIndex;
 
@@ -217,17 +209,8 @@ void OptionLayer::onAttach() {
     fontSize = ui::menuFontSizeForWidth(
         static_cast<uint32_t>(orthoCamera->getWidth()));
 
-    returnButton = std::make_unique<ui::Button>(
-        ui::ButtonCreateInfo{ .topLeft      = glm::vec2{ 0.F },
-                              .bottomRight  = glm::vec2{ 0.F },
-                              .message      = std::string(returnMessage),
-                              .fontSize     = fontSize,
-                              .font         = menuFont,
-                              .buttonColor  = buttonColor,
-                              .textColor    = textColor,
-                              .marginLeft   = 26,
-                              .cornerRadius = 12.F,
-                              .alignType = ui::ButtonAlignType::LeftAligned });
+    returnButton = ui::makeMenuButton(returnMessage, fontSize, menuFont,
+                                      buttonColor, textColor);
 
     for (const auto& shader : { menuFont->getShader(), Quad::getShader() }) {
         shader->bind();
@@ -235,37 +218,18 @@ void OptionLayer::onAttach() {
         shader->unbind();
     }
 
-    rootNode = YGNodeNew();
+    const auto skeleton = ui::buildMenuSkeleton(45.F);
+    rootNode            = skeleton.root;
+    menuNode            = skeleton.menu;
+    menuBackgroundNode  = skeleton.menuBackground;
 
-    titleNode = YGNodeNew();
-    YGNodeStyleSetFlexGrow(titleNode, 0.9F);
-    YGNodeInsertChild(rootNode, titleNode, 0);
-
-    menuNode = YGNodeNew();
-    YGNodeStyleSetFlex(menuNode, 1.F);
-    YGNodeStyleSetFlexDirection(menuNode, YGFlexDirectionRow);
-    YGNodeInsertChild(rootNode, menuNode, 1);
-
-    menuBackgroundNode = YGNodeNew();
-    YGNodeStyleSetMargin(menuBackgroundNode, YGEdgeAll, 10.F);
-    YGNodeStyleSetWidthPercent(menuBackgroundNode, 45.F);
-    YGNodeInsertChild(menuNode, menuBackgroundNode, 0);
-
-    auto makeMenuNode = [](const YGNodeRef parent, const int index) {
-        auto* const child = YGNodeNew();
-        YGNodeStyleSetFlex(child, 1.F);
-        YGNodeStyleSetMaxHeight(child, 110);
-        YGNodeInsertChild(parent, child, index);
-        return child;
-    };
-
-    aspectRatioNode   = makeMenuNode(menuBackgroundNode, 0);
-    resolutionNode    = makeMenuNode(menuBackgroundNode, 1);
-    fullScreenNode    = makeMenuNode(menuBackgroundNode, 2);
-    verticalSyncNode  = makeMenuNode(menuBackgroundNode, 3);
-    antiAliasingNode  = makeMenuNode(menuBackgroundNode, 4);
-    shadowQualityNode = makeMenuNode(menuBackgroundNode, 5);
-    returnNode        = makeMenuNode(menuBackgroundNode, 6);
+    aspectRatioNode   = ui::makeMenuRow(menuBackgroundNode, 0);
+    resolutionNode    = ui::makeMenuRow(menuBackgroundNode, 1);
+    fullScreenNode    = ui::makeMenuRow(menuBackgroundNode, 2);
+    verticalSyncNode  = ui::makeMenuRow(menuBackgroundNode, 3);
+    antiAliasingNode  = ui::makeMenuRow(menuBackgroundNode, 4);
+    shadowQualityNode = ui::makeMenuRow(menuBackgroundNode, 5);
+    returnNode        = ui::makeMenuRow(menuBackgroundNode, 6);
 
     availableResolutions = Maze::get().getAvailableResolutions();
 
@@ -467,26 +431,26 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
     quad->render({ 0.F, 0.F }, { width, height }, backgroundColor);
 
     auto [rootNodeX, rootNodeY, rootNodeW, rootNodeH] =
-        getNodeLayout(rootNode, 0.F, 0.F);
+        ui::getNodeLayout(rootNode, 0.F, 0.F);
     auto [menuNodeX, menuNodeY, menuNodeW, menuNodeH] =
-        getNodeLayout(menuNode, rootNodeX, rootNodeY);
+        ui::getNodeLayout(menuNode, rootNodeX, rootNodeY);
     auto [menuBgX, menuBgY, menuBgW, menuBgH] =
-        getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
+        ui::getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
 
     const auto [arX, arY, arW, arH] =
-        getNodeLayout(aspectRatioNode, menuBgX, menuBgY);
+        ui::getNodeLayout(aspectRatioNode, menuBgX, menuBgY);
     const auto [resX, resY, resW, resH] =
-        getNodeLayout(resolutionNode, menuBgX, menuBgY);
+        ui::getNodeLayout(resolutionNode, menuBgX, menuBgY);
     const auto [fsX, fsY, fsW, fsH] =
-        getNodeLayout(fullScreenNode, menuBgX, menuBgY);
+        ui::getNodeLayout(fullScreenNode, menuBgX, menuBgY);
     const auto [vsX, vsY, vsW, vsH] =
-        getNodeLayout(verticalSyncNode, menuBgX, menuBgY);
+        ui::getNodeLayout(verticalSyncNode, menuBgX, menuBgY);
     const auto [aaX, aaY, aaW, aaH] =
-        getNodeLayout(antiAliasingNode, menuBgX, menuBgY);
+        ui::getNodeLayout(antiAliasingNode, menuBgX, menuBgY);
     const auto [sqX, sqY, sqW, sqH] =
-        getNodeLayout(shadowQualityNode, menuBgX, menuBgY);
+        ui::getNodeLayout(shadowQualityNode, menuBgX, menuBgY);
     const auto [retX, retY, retW, retH] =
-        getNodeLayout(returnNode, menuBgX, menuBgY);
+        ui::getNodeLayout(returnNode, menuBgX, menuBgY);
 
     auto renderDots = [&](const size_t count, const float valueCenterX,
                           const float rowY, const float rowH,
@@ -555,17 +519,9 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
                shadowQualityList->getSelectedIndex(), currentShadowResIndex);
 
     returnButton->setPosition({ retX, retY }, { retX + retW, retY + retH });
-    if (selectedItem == OptionMenuItem::Return) {
-        returnButton->setBorderWidth(selectedBorderWidth);
-        returnButton->setBorderColor(glm::vec4{ 1.F });
-        returnButton->setButtonColor(textHoverColor);
-    } else if (!returnButton->hasHover()) {
-        returnButton->setBorderWidth(0.F);
-        returnButton->setButtonColor(glm::vec4{ 0.F });
-    } else {
-        returnButton->setBorderWidth(0.F);
-        returnButton->setButtonColor(hoverColor);
-    }
+    ui::updateMenuButtonVisuals(returnButton.get(),
+                                selectedItem == OptionMenuItem::Return,
+                                textHoverColor);
 
     UNUSED(returnButton->onUpdate(elapsedTime));
 
@@ -616,14 +572,14 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
     }
 
     auto [rootNodeX, rootNodeY, rootNodeW, rootNodeH] =
-        getNodeLayout(rootNode, 0.F, 0.F);
+        ui::getNodeLayout(rootNode, 0.F, 0.F);
     auto [menuNodeX, menuNodeY, menuNodeW, menuNodeH] =
-        getNodeLayout(menuNode, rootNodeX, rootNodeY);
+        ui::getNodeLayout(menuNode, rootNodeX, rootNodeY);
     auto [menuBackgroundNodeX, menuBackgroundNodeY, menuBackgroundNodeW,
           menuBackgroundNodeH] =
-        getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
+        ui::getNodeLayout(menuBackgroundNode, menuNodeX, menuNodeY);
 
-    const auto [arX, arY, arW, arH] = getNodeLayout(
+    const auto [arX, arY, arW, arH] = ui::getNodeLayout(
         aspectRatioNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     if (mouseX >= arX && mouseX <= arX + arW && mouseY >= arY &&
@@ -641,8 +597,8 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         return true;
     }
 
-    const auto [resX, resY, resW, resH] =
-        getNodeLayout(resolutionNode, menuBackgroundNodeX, menuBackgroundNodeY);
+    const auto [resX, resY, resW, resH] = ui::getNodeLayout(
+        resolutionNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     if (mouseX >= resX && mouseX <= resX + resW && mouseY >= resY &&
         mouseY <= resY + resH) {
@@ -661,8 +617,8 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         return true;
     }
 
-    const auto [fullX, fullY, fullW, fullH] =
-        getNodeLayout(fullScreenNode, menuBackgroundNodeX, menuBackgroundNodeY);
+    const auto [fullX, fullY, fullW, fullH] = ui::getNodeLayout(
+        fullScreenNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     if (mouseX >= fullX && mouseX <= fullX + fullW && mouseY >= fullY &&
         mouseY <= fullY + fullH) {
@@ -675,7 +631,7 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         return true;
     }
 
-    const auto [vsyncX, vsyncY, vsyncW, vsyncH] = getNodeLayout(
+    const auto [vsyncX, vsyncY, vsyncW, vsyncH] = ui::getNodeLayout(
         verticalSyncNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     if (mouseX >= vsyncX && mouseX <= vsyncX + vsyncW && mouseY >= vsyncY &&
@@ -689,7 +645,7 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         return true;
     }
 
-    const auto [aaX, aaY, aaW, aaH] = getNodeLayout(
+    const auto [aaX, aaY, aaW, aaH] = ui::getNodeLayout(
         antiAliasingNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     if (mouseX >= aaX && mouseX <= aaX + aaW && mouseY >= aaY &&
@@ -703,7 +659,7 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
         return true;
     }
 
-    const auto [sqX, sqY, sqW, sqH] = getNodeLayout(
+    const auto [sqX, sqY, sqW, sqH] = ui::getNodeLayout(
         shadowQualityNode, menuBackgroundNodeX, menuBackgroundNodeY);
 
     if (mouseX >= sqX && mouseX <= sqX + sqW && mouseY >= sqY &&
@@ -729,29 +685,21 @@ bool OptionLayer::onMouseButtonPressed(const MouseButtonPressedEvent& event) {
 bool OptionLayer::onMouseMoved(const MouseMovedEvent& event) {
     const auto pos = glm::vec2{ event.getX(), event.getY() };
 
-    auto updateHover = [&pos](ui::Button* button) {
-        if (!button->hasHover() && button->isInside(pos)) {
-            button->setHover(true);
-        } else if (button->hasHover() && !button->isInside(pos)) {
-            button->setHover(false);
-        }
-    };
+    ui::updateButtonHover(returnButton.get(), pos);
 
-    updateHover(returnButton.get());
-
-    const auto rootNodeLayout = getNodeLayout(rootNode, 0.F, 0.F);
-    const auto menuNodeLayout = getNodeLayout(
+    const auto rootNodeLayout = ui::getNodeLayout(rootNode, 0.F, 0.F);
+    const auto menuNodeLayout = ui::getNodeLayout(
         menuNode, std::get<0>(rootNodeLayout), std::get<1>(rootNodeLayout));
     const auto menuBackgroundNodeLayout =
-        getNodeLayout(menuBackgroundNode, std::get<0>(menuNodeLayout),
-                      std::get<1>(menuNodeLayout));
+        ui::getNodeLayout(menuBackgroundNode, std::get<0>(menuNodeLayout),
+                          std::get<1>(menuNodeLayout));
 
     const float menuBackgroundNodeX = std::get<0>(menuBackgroundNodeLayout);
     const float menuBackgroundNodeY = std::get<1>(menuBackgroundNodeLayout);
 
     auto isOver = [&](auto* node) {
         const auto nodeLayout =
-            getNodeLayout(node, menuBackgroundNodeX, menuBackgroundNodeY);
+            ui::getNodeLayout(node, menuBackgroundNodeX, menuBackgroundNodeY);
         const float x = std::get<0>(nodeLayout);
         const float y = std::get<1>(nodeLayout);
         const float w = std::get<2>(nodeLayout);

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -877,7 +877,7 @@ void OptionLayer::applyChanges() {
     if (pendingFullscreen != Maze::get().isFullscreen()) {
         Maze::get().toggleFullscreen();
     }
-    Maze::get().setVerticalSync(pendingVsync);
+    Maze::get().requestVerticalSync(pendingVsync);
     Maze::get().setFxaaEnabled(pendingFxaa);
     const auto shadowRes =
         shadowResolutions[static_cast<size_t>(pendingShadowResIndex)];

--- a/game/src/ui/button.cpp
+++ b/game/src/ui/button.cpp
@@ -101,4 +101,44 @@ void Button::setPosition(const glm::vec2& topLeft,
                              ((height - static_cast<float>(textSize)) / 2.F) };
     }
 }
+
+std::unique_ptr<Button> makeMenuButton(
+    std::string_view message, const uint32_t fontSize,
+    std::shared_ptr<sponge::platform::opengl::scene::BitmapFont> font,
+    const glm::vec4& buttonColor, const glm::vec3& textColor) {
+    return std::make_unique<Button>(
+        ButtonCreateInfo{ .message      = std::string(message),
+                          .fontSize     = fontSize,
+                          .font         = std::move(font),
+                          .buttonColor  = buttonColor,
+                          .textColor    = textColor,
+                          .marginLeft   = 26,
+                          .cornerRadius = 12.F,
+                          .alignType    = ButtonAlignType::LeftAligned });
+}
+
+void updateMenuButtonVisuals(Button* button, const bool selected,
+                             const glm::vec4& selectedColor) {
+    constexpr glm::vec4 hoverColor = { 0.84F, 0.84F, 0.84F, 0.14F };
+
+    if (selected) {
+        button->setBorderWidth(3.F);
+        button->setBorderColor(glm::vec4{ 1.F });
+        button->setButtonColor(selectedColor);
+    } else if (!button->hasHover()) {
+        button->setBorderWidth(0.F);
+        button->setButtonColor(glm::vec4{ 0.F });
+    } else {
+        button->setBorderWidth(0.F);
+        button->setButtonColor(hoverColor);
+    }
+}
+
+void updateButtonHover(Button* button, const glm::vec2& pos) {
+    if (!button->hasHover() && button->isInside(pos)) {
+        button->setHover(true);
+    } else if (button->hasHover() && !button->isInside(pos)) {
+        button->setHover(false);
+    }
+}
 }  // namespace game::ui

--- a/game/src/ui/button.hpp
+++ b/game/src/ui/button.hpp
@@ -11,10 +11,10 @@ namespace game::ui {
 enum class ButtonAlignType : uint8_t { CenterAligned = 0, LeftAligned };
 
 struct ButtonCreateInfo {
-    glm::vec2                                                    topLeft;
-    glm::vec2                                                    bottomRight;
-    std::string                                                  message;
-    uint32_t                                                     fontSize;
+    glm::vec2   topLeft     = {};
+    glm::vec2   bottomRight = {};
+    std::string message;
+    uint32_t    fontSize;
     std::shared_ptr<sponge::platform::opengl::scene::BitmapFont> font;
     glm::vec4                                                    buttonColor;
     glm::vec3                                                    textColor;
@@ -81,4 +81,14 @@ private:
     std::shared_ptr<sponge::platform::opengl::scene::BitmapFont> font;
     std::unique_ptr<sponge::platform::opengl::scene::Quad>       quad;
 };
+
+std::unique_ptr<Button> makeMenuButton(
+    std::string_view message, uint32_t fontSize,
+    std::shared_ptr<sponge::platform::opengl::scene::BitmapFont> font,
+    const glm::vec4& buttonColor, const glm::vec3& textColor);
+
+void updateMenuButtonVisuals(Button* button, bool selected,
+                             const glm::vec4& selectedColor);
+
+void updateButtonHover(Button* button, const glm::vec2& pos);
 }  // namespace game::ui

--- a/game/src/ui/menulayout.hpp
+++ b/game/src/ui/menulayout.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <yoga/Yoga.h>
+
+#include <tuple>
+
+namespace game::ui {
+
+struct MenuSkeleton {
+    YGNodeRef root;
+    YGNodeRef menu;
+    YGNodeRef menuBackground;
+};
+
+inline MenuSkeleton buildMenuSkeleton(const float menuBackgroundWidthPercent) {
+    auto* const root = YGNodeNew();
+
+    auto* const title = YGNodeNew();
+    YGNodeStyleSetFlexGrow(title, 0.9F);
+    YGNodeInsertChild(root, title, 0);
+
+    auto* const menu = YGNodeNew();
+    YGNodeStyleSetFlex(menu, 1.F);
+    YGNodeStyleSetFlexDirection(menu, YGFlexDirectionRow);
+    YGNodeInsertChild(root, menu, 1);
+
+    auto* const menuBackground = YGNodeNew();
+    YGNodeStyleSetMargin(menuBackground, YGEdgeAll, 10.F);
+    YGNodeStyleSetWidthPercent(menuBackground, menuBackgroundWidthPercent);
+    YGNodeInsertChild(menu, menuBackground, 0);
+
+    return { root, menu, menuBackground };
+}
+
+inline YGNodeRef makeMenuRow(const YGNodeRef parent, const int index) {
+    auto* const child = YGNodeNew();
+    YGNodeStyleSetFlex(child, 1.F);
+    YGNodeStyleSetMaxHeight(child, 110);
+    YGNodeInsertChild(parent, child, index);
+    return child;
+}
+
+inline std::tuple<float, float, float, float>
+    getNodeLayout(const YGNodeRef node, const float offsetX,
+                  const float offsetY) {
+    return { offsetX + YGNodeLayoutGetLeft(node),
+             offsetY + YGNodeLayoutGetTop(node), YGNodeLayoutGetWidth(node),
+             YGNodeLayoutGetHeight(node) };
+}
+
+}  // namespace game::ui

--- a/sponge/src/platform/glfw/core/application.cpp
+++ b/sponge/src/platform/glfw/core/application.cpp
@@ -197,6 +197,11 @@ void Application::setMouseVisible(const bool value) const {
     }
 }
 
+void Application::requestMouseVisible(const bool value) {
+    pendingMouseVisibleValue.store(value, std::memory_order_relaxed);
+    pendingMouseVisible.store(true, std::memory_order_release);
+}
+
 void Application::centerMouse() {
     const auto cx = static_cast<double>(window->getWidth()) / 2.0;
     const auto cy = static_cast<double>(window->getHeight()) / 2.0;
@@ -216,6 +221,11 @@ std::pair<float, float> Application::getMousePosition() const {
 void Application::setVerticalSync(const bool val) {
     vsync = val;
     glfwSwapInterval(vsync ? 1 : 0);
+}
+
+void Application::requestVerticalSync(const bool val) {
+    pendingVerticalSyncValue.store(val, std::memory_order_relaxed);
+    pendingVerticalSync.store(true, std::memory_order_release);
 }
 
 void Application::setResolution(const uint32_t width, const uint32_t height) {
@@ -386,6 +396,18 @@ void Application::run() {
                 }
             }
             pendingResolution.store(false, std::memory_order_relaxed);
+        }
+
+        if (pendingMouseVisible.load(std::memory_order_acquire)) {
+            setMouseVisible(
+                pendingMouseVisibleValue.load(std::memory_order_relaxed));
+            pendingMouseVisible.store(false, std::memory_order_relaxed);
+        }
+
+        if (pendingVerticalSync.load(std::memory_order_acquire)) {
+            setVerticalSync(
+                pendingVerticalSyncValue.load(std::memory_order_relaxed));
+            pendingVerticalSync.store(false, std::memory_order_relaxed);
         }
 
         // Wait for update thread before writing new snapshot data.

--- a/sponge/src/platform/glfw/core/application.hpp
+++ b/sponge/src/platform/glfw/core/application.hpp
@@ -76,6 +76,11 @@ public:
 
     void setVerticalSync(bool val);
 
+    // Thread-safe request to change vsync from a non-main thread (e.g. an
+    // update-thread or render-thread layer). Applied on the main thread,
+    // which owns the GLFW window/context.
+    void requestVerticalSync(bool val);
+
     std::vector<LogItem>& getMessages() const {
         return *messages;
     }
@@ -89,6 +94,11 @@ public:
     }
 
     void setMouseVisible(bool value) const;
+
+    // Thread-safe request to change mouse visibility from a non-main thread
+    // (e.g. an update-thread layer). Applied on the main thread, which owns
+    // the GLFW window.
+    void requestMouseVisible(bool value);
 
     void centerMouse();
 
@@ -169,6 +179,18 @@ private:
     // fullscreen flips immediately in toggleFullscreen(); the GLFW window call
     // runs here to avoid deadlocking the Win32 message pump.
     std::atomic<bool> pendingFullscreenToggle{ false };
+
+    // Deferred mouse-visibility change requested from update-thread layers
+    // (e.g. MazeLayer's pause handling). glfwSetInputMode must run on the
+    // thread that owns the window.
+    std::atomic<bool> pendingMouseVisible{ false };
+    std::atomic<bool> pendingMouseVisibleValue{ false };
+
+    // Deferred vsync change requested from update-thread or render-thread
+    // layers (e.g. OptionLayer, ImGuiLayer). glfwSwapInterval must run on
+    // the thread that owns the window/context.
+    std::atomic<bool> pendingVerticalSync{ false };
+    std::atomic<bool> pendingVerticalSyncValue{ false };
 
     static Application* instance;
 

--- a/sponge/src/platform/glfw/core/inputmanager.cpp
+++ b/sponge/src/platform/glfw/core/inputmanager.cpp
@@ -74,7 +74,7 @@ void InputManager::onMouseWarped() {
 }
 
 void InputManager::recenterCursor() {
-    if (!mouseLookActive) {
+    if (!mouseLookActive.load(std::memory_order_acquire)) {
         return;
     }
     int width  = 0;
@@ -127,7 +127,7 @@ void InputManager::update() {
     cursorDeltaY = cursorY - prevCursorY;
 
     recenterCursor();
-    if (!mouseLookActive) {
+    if (!mouseLookActive.load(std::memory_order_acquire)) {
         prevCursorX = cursorX;
         prevCursorY = cursorY;
     }

--- a/sponge/src/platform/glfw/core/inputmanager.hpp
+++ b/sponge/src/platform/glfw/core/inputmanager.hpp
@@ -37,13 +37,15 @@ public:
     // Prevents the cursor from drifting outside the window and sending
     // negative coordinates to ImGui.
     void setMouseLookActive(const bool active) {
-        mouseLookActive = active;
+        mouseLookActive.store(active, std::memory_order_release);
     }
 
 private:
     GLFWwindow* window = nullptr;
 
-    bool mouseLookActive = false;
+    // Written from the update thread (MazeLayer), read from the main thread
+    // (recenterCursor/update).
+    std::atomic<bool> mouseLookActive{ false };
 
     input::InputSnapshot snapshot;
 


### PR DESCRIPTION
## Summary
- Extract the duplicated Yoga menu-tree construction and button visual/hover logic from ExitLayer, IntroLayer, and OptionLayer into `game/src/ui/` (`menulayout.hpp`, extended `button.hpp/.cpp`). No behavior change; per-file style constants that genuinely differ stay in each layer.
- Fix `setMouseVisible`/`setVerticalSync` calling GLFW functions directly from the update/render threads instead of the main thread (the thread that owns the GLFW window/context). Added `requestMouseVisible`/`requestVerticalSync`, deferred and applied on the main thread each loop iteration, matching the existing `pendingFullscreenToggle`/`pendingResolution` pattern. Also made `InputManager::mouseLookActive` atomic to close a related data race.

## Test plan
- [x] `cmake --build build --target game --config Release` builds clean
- [x] Manual: open main menu, pause menu, and settings menu; confirm layout/visuals unchanged
- [x] Manual: hold mouse-look, press Escape to open the pause menu, confirm the cursor no longer sticks to the center of the screen
- [x] Manual: toggle vsync from the settings menu via keyboard/gamepad confirm, and from the ImGui debug menu