### PR TITLE
Apply deferred vsync on render thread

### DIFF
--- a/sponge/src/platform/glfw/core/application.cpp
+++ b/sponge/src/platform/glfw/core/application.cpp
@@ -276,6 +276,14 @@ void Application::run() {
             pendingViewport.store(false, std::memory_order_relaxed);
         }
 
+        // glfwSwapInterval acts on the current context, which lives on this
+        // render thread (released from main above) — not the main thread.
+        if (pendingVerticalSync.load(std::memory_order_acquire)) {
+            setVerticalSync(
+                pendingVerticalSyncValue.load(std::memory_order_relaxed));
+            pendingVerticalSync.store(false, std::memory_order_relaxed);
+        }
+
         renderer->clear();
         imguiManager.begin();
 #ifdef ENABLE_IMGUI
@@ -402,12 +410,6 @@ void Application::run() {
             setMouseVisible(
                 pendingMouseVisibleValue.load(std::memory_order_relaxed));
             pendingMouseVisible.store(false, std::memory_order_relaxed);
-        }
-
-        if (pendingVerticalSync.load(std::memory_order_acquire)) {
-            setVerticalSync(
-                pendingVerticalSyncValue.load(std::memory_order_relaxed));
-            pendingVerticalSync.store(false, std::memory_order_relaxed);
         }
 
         // Wait for update thread before writing new snapshot data.


### PR DESCRIPTION
## Problem
Vertical sync changes made in the options menu never took effect.

## Root cause
`glfwSwapInterval` acts on the calling thread's *current* GL context. At startup the context is released from the main thread and made current on the render thread. But pending vsync changes were consumed on the main thread (which has no current context), so GLFW silently ignored every deferred toggle. Startup vsync worked only because `setVerticalSync` runs before the context is released.

## Fix
Move `pendingVerticalSync` handling from the main loop into `renderTask`, where the context is current — matching the existing `pendingViewport` pattern.