### PR TITLE
Fix vsync checkbox reverting after Apply

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -213,6 +213,6 @@ else ()
 
     install(TARGETS game RUNTIME DESTINATION .)
     install(FILES $<TARGET_RUNTIME_DLLS:game> DESTINATION .)
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets DESTINATION . PATTERN "slang" EXCLUDE)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets DESTINATION . PATTERN "slang" EXCLUDE PATTERN ".clang-format" EXCLUDE)
     install(DIRECTORY "${CMAKE_BINARY_DIR}/shaders/glsl" DESTINATION assets/shaders)
 endif ()

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -833,15 +833,20 @@ void OptionLayer::applyChanges() {
     saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
                       pendingFxaa, shadowRes);
 
-    syncPendingCheckboxState();
+    // vsync is applied asynchronously on the render thread, so
+    // hasVerticalSync() may not reflect pendingVsync yet; skip re-reading it
+    // here.
+    syncPendingCheckboxState(/*syncVsync=*/false);
     hasUnappliedChanges = false;
     returnButton->setMessage(returnMessage);
 }
 
-void OptionLayer::syncPendingCheckboxState() {
+void OptionLayer::syncPendingCheckboxState(const bool syncVsync) {
     pendingFullscreen = Maze::get().isFullscreen();
-    pendingVsync      = Maze::get().hasVerticalSync();
-    pendingFxaa       = Maze::get().isFxaaEnabled();
+    if (syncVsync) {
+        pendingVsync = Maze::get().hasVerticalSync();
+    }
+    pendingFxaa = Maze::get().isFxaaEnabled();
 
     const auto currentShadowRes =
         Maze::get().getMazeLayer()->getDirectionalLightShadowMapRes();

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -826,6 +826,7 @@ void OptionLayer::applyChanges() {
         Maze::get().toggleFullscreen();
     }
     Maze::get().requestVerticalSync(pendingVsync);
+    appliedVsync = pendingVsync;
     Maze::get().setFxaaEnabled(pendingFxaa);
     const auto shadowRes =
         shadowResolutions[static_cast<size_t>(pendingShadowResIndex)];
@@ -833,20 +834,16 @@ void OptionLayer::applyChanges() {
     saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
                       pendingFxaa, shadowRes);
 
-    // vsync is applied asynchronously on the render thread, so
-    // hasVerticalSync() may not reflect pendingVsync yet; skip re-reading it
-    // here.
-    syncPendingCheckboxState(/*syncVsync=*/false);
+    syncPendingCheckboxState();
     hasUnappliedChanges = false;
     returnButton->setMessage(returnMessage);
 }
 
-void OptionLayer::syncPendingCheckboxState(const bool syncVsync) {
+void OptionLayer::syncPendingCheckboxState() {
     pendingFullscreen = Maze::get().isFullscreen();
-    if (syncVsync) {
-        pendingVsync = Maze::get().hasVerticalSync();
-    }
-    pendingFxaa = Maze::get().isFxaaEnabled();
+    pendingVsync      = Maze::get().hasVerticalSync();
+    appliedVsync      = pendingVsync;
+    pendingFxaa       = Maze::get().isFxaaEnabled();
 
     const auto currentShadowRes =
         Maze::get().getMazeLayer()->getDirectionalLightShadowMapRes();
@@ -864,7 +861,7 @@ void OptionLayer::syncPendingCheckboxState(const bool syncVsync) {
 void OptionLayer::updateChangeStatus() {
     const bool checkboxChanged =
         pendingFullscreen != Maze::get().isFullscreen() ||
-        pendingVsync != Maze::get().hasVerticalSync() ||
+        pendingVsync != appliedVsync ||
         pendingFxaa != Maze::get().isFxaaEnabled();
 
     const auto window = Maze::get().getWindow();

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -45,6 +45,12 @@ private:
     bool pendingFxaa           = false;
     int  pendingShadowResIndex = 1;
 
+    // Mirrors the vsync value last requested via Maze::requestVerticalSync().
+    // vsync is applied asynchronously on the render thread, so comparing
+    // pendingVsync against the live Maze::hasVerticalSync() right after
+    // applying would race the render thread; compare against this instead.
+    bool appliedVsync = false;
+
     std::unique_ptr<ui::SelectList> aspectRatioList;
     std::unique_ptr<ui::SelectList> resolutionList;
     std::unique_ptr<ui::SelectList> shadowQualityList;
@@ -61,7 +67,7 @@ private:
 
     void applyChanges();
 
-    void syncPendingCheckboxState(bool syncVsync = true);
+    void syncPendingCheckboxState();
 
     void updateChangeStatus();
 

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -61,7 +61,7 @@ private:
 
     void applyChanges();
 
-    void syncPendingCheckboxState();
+    void syncPendingCheckboxState(bool syncVsync = true);
 
     void updateChangeStatus();
 


### PR DESCRIPTION
## Summary
- Skip re-reading vsync from live app state right after requesting it in `applyChanges()`, since `requestVerticalSync()` is applied asynchronously on the render thread and `hasVerticalSync()` doesn't reflect the change yet
- Exclude `assets/shaders/.clang-format` from the install step

## Test plan
- [ ] Toggle vsync in the options menu, press Apply, confirm the checkbox stays on the selected value
- [ ] Confirm `settings.json` reflects the chosen vsync value after Apply