### PR TITLE
fix: guard ImGui-editable settings against update-thread races

### DIFF
--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <string>
 
@@ -276,28 +277,33 @@ void MazeLayer::captureRenderFrame(const uint32_t slotIndex) {
     frame.screenWidth      = screenWidth;
     frame.screenHeight     = screenHeight;
 
-    frame.shadowEnabled    = directionalLight.enabled;
-    frame.shadowCastShadow = directionalLight.castShadow;
-    frame.lightDirection   = directionalLight.direction;
-    if (directionalLight.enabled && directionalLight.castShadow) {
-        // Update on update thread to avoid racing render thread
-        // bind()/unbind().
-        shadowMap->updateLightSpaceMatrix(
-            glm::normalize(directionalLight.direction));
-        frame.lightSpaceMatrix = shadowMap->getLightSpaceMatrix();
-    }
+    {
+        // ImGui setters mutate these from the render thread.
+        std::scoped_lock lock(settingsMutex);
 
-    frame.numLights             = numLights;
-    frame.lightAttenuationIndex = attenuationIndex;
-    for (int32_t i = 0; i < numLights; i++) {
-        frame.lightPositions[i] = pointLights.at(i).position;
-        frame.lightColors[i]    = pointLights.at(i).color;
-    }
+        frame.shadowEnabled    = directionalLight.enabled;
+        frame.shadowCastShadow = directionalLight.castShadow;
+        frame.lightDirection   = directionalLight.direction;
+        if (directionalLight.enabled && directionalLight.castShadow) {
+            // Update on update thread to avoid racing render thread
+            // bind()/unbind().
+            shadowMap->updateLightSpaceMatrix(
+                glm::normalize(directionalLight.direction));
+            frame.lightSpaceMatrix = shadowMap->getLightSpaceMatrix();
+        }
 
-    frame.fxaaEnabled    = fxaaEnabled;
-    frame.bloomEnabled   = bloomEnabled;
-    frame.bloomThreshold = bloomThreshold;
-    frame.bloomIntensity = bloomIntensity;
+        frame.numLights             = numLights;
+        frame.lightAttenuationIndex = attenuationIndex;
+        for (int32_t i = 0; i < numLights; i++) {
+            frame.lightPositions[i] = pointLights.at(i).position;
+            frame.lightColors[i]    = pointLights.at(i).color;
+        }
+
+        frame.fxaaEnabled    = fxaaEnabled;
+        frame.bloomEnabled   = bloomEnabled;
+        frame.bloomThreshold = bloomThreshold;
+        frame.bloomIntensity = bloomIntensity;
+    }
 
     // Static after onAttach(); safe to copy.
     frame.objectModelMatrices = objectModelMatrices;
@@ -443,7 +449,10 @@ int32_t MazeLayer::getAttenuationIndex() const {
 }
 
 void MazeLayer::setAttenuationIndex(const int32_t val) {
-    attenuationIndex = val;
+    {
+        std::scoped_lock lock(settingsMutex);
+        attenuationIndex = val;
+    }
     setNumLights(numLights);
 }
 
@@ -456,7 +465,10 @@ bool MazeLayer::getDirectionalLightCastsShadow() const {
 }
 
 void MazeLayer::setDirectionalLightCastsShadow(const bool value) {
-    directionalLight.castShadow = value;
+    {
+        std::scoped_lock lock(settingsMutex);
+        directionalLight.castShadow = value;
+    }
 
     const auto shader = Mesh::getShader();
     shader->bind();
@@ -483,7 +495,10 @@ glm::vec3 MazeLayer::getDirectionalLightDirection() const {
 }
 
 void MazeLayer::setDirectionalLightDirection(const glm::vec3& direction) {
-    directionalLight.direction = direction;
+    {
+        std::scoped_lock lock(settingsMutex);
+        directionalLight.direction = direction;
+    }
 
     const auto shader = Mesh::getShader();
     shader->bind();
@@ -496,7 +511,10 @@ bool MazeLayer::getDirectionalLightEnabled() const {
 }
 
 void MazeLayer::setDirectionalLightEnabled(const bool value) {
-    directionalLight.enabled = value;
+    {
+        std::scoped_lock lock(settingsMutex);
+        directionalLight.enabled = value;
+    }
 
     const auto shader = Mesh::getShader();
     shader->bind();
@@ -519,23 +537,26 @@ int32_t MazeLayer::getNumLights() const {
 }
 
 void MazeLayer::setNumLights(const int32_t val) {
-    numLights = std::clamp(val, 0, maxPointLights);
+    {
+        std::scoped_lock lock(settingsMutex);
+        numLights = std::clamp(val, 0, maxPointLights);
 
-    std::mt19937                          rng(42U);
-    std::uniform_real_distribution<float> jitterAngle(-0.4F, 0.4F);
-    std::uniform_real_distribution<float> jitterRadius(-0.5F, 0.5F);
+        std::mt19937                          rng(42U);
+        std::uniform_real_distribution<float> jitterAngle(-0.4F, 0.4F);
+        std::uniform_real_distribution<float> jitterRadius(-0.5F, 0.5F);
 
-    for (int32_t i = 0; i < numLights; i++) {
-        const float t =
-            numLights > 1 ? static_cast<float>(i) / (numLights - 1) : 0.F;
-        const float radius = 1.5F + t * 13.5F + jitterRadius(rng);
-        const float angle =
-            glm::two_pi<float>() * i / numLights + jitterAngle(rng);
-        auto& light = pointLights.at(i);
-        light.color = glm::vec3(1.F);
-        light.position =
-            glm::vec3(rotate(glm::mat4(1.F), angle, glm::vec3(0.F, 1.F, 0.F)) *
-                      glm::vec4(0.F, 2.75F, -radius, 1.F));
+        for (int32_t i = 0; i < numLights; i++) {
+            const float t =
+                numLights > 1 ? static_cast<float>(i) / (numLights - 1) : 0.F;
+            const float radius = 1.5F + t * 13.5F + jitterRadius(rng);
+            const float angle =
+                glm::two_pi<float>() * i / numLights + jitterAngle(rng);
+            auto& light    = pointLights.at(i);
+            light.color    = glm::vec3(1.F);
+            light.position = glm::vec3(
+                rotate(glm::mat4(1.F), angle, glm::vec3(0.F, 1.F, 0.F)) *
+                glm::vec4(0.F, 2.75F, -radius, 1.F));
+        }
     }
 
     const auto shader = Mesh::getShader();
@@ -755,7 +776,10 @@ bool MazeLayer::isFxaaEnabled() const {
 }
 
 void MazeLayer::setFxaaEnabled(const bool val) {
-    fxaaEnabled = val;
+    {
+        std::scoped_lock lock(settingsMutex);
+        fxaaEnabled = val;
+    }
     if (fxaa) {
         fxaa->setEnabled(val);
     }
@@ -766,6 +790,7 @@ bool MazeLayer::isBloomEnabled() const {
 }
 
 void MazeLayer::setBloomEnabled(const bool val) {
+    std::scoped_lock lock(settingsMutex);
     bloomEnabled = val;
 }
 
@@ -774,6 +799,7 @@ float MazeLayer::getBloomThreshold() const {
 }
 
 void MazeLayer::setBloomThreshold(const float val) {
+    std::scoped_lock lock(settingsMutex);
     bloomThreshold = val;
 }
 
@@ -782,6 +808,7 @@ float MazeLayer::getBloomIntensity() const {
 }
 
 void MazeLayer::setBloomIntensity(const float val) {
+    std::scoped_lock lock(settingsMutex);
     bloomIntensity = val;
 }
 

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string_view>
 #include <vector>
 
@@ -135,6 +136,11 @@ private:
 
     void captureRenderFrame(uint32_t slotIndex);
     void queueResize(uint32_t w, uint32_t h) const;
+
+    // Guards settings written by ImGui (render thread) and read by
+    // captureRenderFrame() (update thread): lights, directional light,
+    // fxaa/bloom params. Uncontended except while a debug slider is dragged.
+    mutable std::mutex settingsMutex;
 
     std::atomic<int32_t> screenWidth{ 0 };
     std::atomic<int32_t> screenHeight{ 0 };

--- a/sponge/src/scene/mesh.cpp
+++ b/sponge/src/scene/mesh.cpp
@@ -30,13 +30,13 @@ void Mesh::optimize() {
                              numIndices, &optimalVertices[0].position.x,
                              optimalVertexCount, sizeof(Vertex), 1.05F);
 
-    meshopt_optimizeVertexFetch(optimalVertices.data(), optimalIndices.data(),
-                                numIndices, optimalVertices.data(),
-                                optimalVertexCount, sizeof(Vertex));
+    const auto fetchVertexCount = meshopt_optimizeVertexFetch(
+        optimalVertices.data(), optimalIndices.data(), numIndices,
+        optimalVertices.data(), optimalVertexCount, sizeof(Vertex));
 
     indices.swap(optimalIndices);
     vertices.swap(optimalVertices);
-    numVertices = optimalVertexCount;
+    numVertices = fetchVertexCount;
 }
 
 }  // namespace sponge::scene

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "maze",
   "version-string": "latest",
-  "builtin-baseline": "82b6bc886d7b0f8342e34babc2e0b8943f79b0e1",
+  "builtin-baseline": "2475cc332a47b3a63bb3de58293bdab7726613ca",
   "dependencies": [
     {
       "name": "fmt",
@@ -33,7 +33,7 @@
     },
     {
       "name": "meshoptimizer",
-      "version>=": "1.1.1"
+      "version>=": "1.2"
     },
     {
       "name": "mimalloc",


### PR DESCRIPTION
## Summary
- Add `settingsMutex` guarding settings written by ImGui on the render thread (directional light, point lights, attenuation, fxaa/bloom params) and read by `captureRenderFrame()` on the update thread — removes a data race and makes each frame snapshot internally consistent
- Capture `meshopt_optimizeVertexFetch`'s returned vertex count and use it as `numVertices` instead of discarding it
- Bump vcpkg builtin-baseline and require meshoptimizer >= 1.2

## Testing
- Built `game` target with `windows-msvc-release`; pre-commit hooks (clang-format, cpplint, typos) pass