### PR TITLE
fix: publish render snapshot at main-thread sync point

### DIFF
--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -310,8 +310,15 @@ void MazeLayer::captureRenderFrame(const uint32_t slotIndex) {
     frame.objectEmissives     = objectEmissives;
     frame.objectModels        = objectModels;
 
-    // Publish slot; release/acquire pair with onRender()'s load.
-    renderReadIndex.store(slotIndex, std::memory_order_release);
+    // Publication happens in onFrameSync() on the main thread, while both
+    // workers are idle — publishing here would race the in-flight render and
+    // make the frame pairing nondeterministic.
+    writtenSlot = slotIndex;
+}
+
+void MazeLayer::onFrameSync() {
+    // Release pairs with onRender()'s acquire load.
+    renderReadIndex.store(writtenSlot, std::memory_order_release);
 }
 
 void MazeLayer::onRender() {

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -48,6 +48,10 @@ public:
     // Render thread: all GL commands, reads from latest update snapshot.
     void onRender() override;
 
+    // Main thread, both workers idle: publish the slot written by the last
+    // completed onUpdate() so render[N] always reads update[N-1]'s frame.
+    void onFrameSync() override;
+
     float getAmbientOcclusion() const;
 
     void setAmbientOcclusion(float val);
@@ -121,6 +125,11 @@ private:
     // Double-buffered snapshots: update writes, render reads, no overlap.
     std::array<thread::MazeRenderFrame, 2> renderFrames;
     std::atomic<uint32_t>                  renderReadIndex{ 0 };
+
+    // Slot filled by the last completed captureRenderFrame(). Written on the
+    // update thread, read in onFrameSync() on the main thread — ordered by
+    // the Worker wait/kick handshake, so no atomic needed.
+    uint32_t writtenSlot{ 0 };
 
     // Deferred viewport/FXAA resize: set by onWindowResize(), applied in
     // onRender(). Dimensions are packed into one uint64_t (width << 32 |

--- a/sponge/src/layer/layer.hpp
+++ b/sponge/src/layer/layer.hpp
@@ -28,6 +28,11 @@ public:
     // GPU commands using state from onUpdate(). No-op for render-thread layers.
     virtual void onRender() {}
 
+    // Called on the main thread while both worker threads are idle, before
+    // update[N] and render[N] are kicked. Publish state produced by
+    // update[N-1] here so render[N] sees a deterministic, completed frame.
+    virtual void onFrameSync() {}
+
     // True if onUpdate() runs on the update thread (GL-free; onRender() does
     // GPU work).
     virtual bool runsOnUpdateThread() const {

--- a/sponge/src/platform/glfw/core/application.cpp
+++ b/sponge/src/platform/glfw/core/application.cpp
@@ -321,6 +321,18 @@ void Application::run() {
         renderElapsedTime = primeElapsed;
     }
 
+    // Both workers idle: publish update-thread layer state for the next
+    // render so the frame pairing is deterministic.
+    const auto frameSync = [this] {
+        for (const auto& layer : *layerStack) {
+            if (layer->isActive() && layer->runsOnUpdateThread()) {
+                layer->onFrameSync();
+            }
+        }
+    };
+
+    frameSync();
+
     // Warm up render thread (acquires GL context) before pipelined loop.
     renderThread.kick(renderTask);
     renderThread.waitForComplete();
@@ -430,6 +442,8 @@ void Application::run() {
 
         // Update elapsed time for render-thread layers.
         renderElapsedTime = elapsed;
+
+        frameSync();
 
         // Game logic for frame N into the free snapshot slot.
         updateThread.kick([this, elapsed] { return onUserUpdate(elapsed); });


### PR DESCRIPTION
## Summary
- The update thread published `renderReadIndex` mid-frame while render[N] was in flight, so whether render[N] saw frame N-1 or frame N depended on a race — visible as frame-pairing latency jitter
- Add `Layer::onFrameSync()`, called on the main thread while both worker threads are idle (after `updateThread.waitForComplete()`, before the next kicks, plus once before the warm-up render)
- `captureRenderFrame()` now records the written slot; `onFrameSync()` publishes it — render[N] always reads update[N-1]'s completed frame, and `renderReadIndex` never changes while a render frame is in flight

## Testing
- Built `game` target with `windows-msvc-release`; pre-commit hooks pass