### PR TITLE
perf: copy static object data into snapshots once at attach

### DIFF
--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -175,6 +175,14 @@ void MazeLayer::onAttach() {
     shader->unbind();
 
     setNumLights(numLights);
+
+    // Static after onAttach(); copy into both snapshot slots once instead of
+    // per frame in captureRenderFrame().
+    for (auto& frame : renderFrames) {
+        frame.objectModelMatrices = objectModelMatrices;
+        frame.objectEmissives     = objectEmissives;
+        frame.objectModels        = objectModels;
+    }
 }
 
 void MazeLayer::onDetach() {
@@ -304,11 +312,6 @@ void MazeLayer::captureRenderFrame(const uint32_t slotIndex) {
         frame.bloomThreshold = bloomThreshold;
         frame.bloomIntensity = bloomIntensity;
     }
-
-    // Static after onAttach(); safe to copy.
-    frame.objectModelMatrices = objectModelMatrices;
-    frame.objectEmissives     = objectEmissives;
-    frame.objectModels        = objectModels;
 
     // Publication happens in onFrameSync() on the main thread, while both
     // workers are idle — publishing here would race the in-flight render and


### PR DESCRIPTION
## Summary
- `objectModelMatrices`, `objectEmissives`, and `objectModels` never change after `onAttach()` but were copied into the render snapshot every update frame, including per-model `shared_ptr` refcount churn
- Copy them into both snapshot slots once at the end of `onAttach()` (runs before worker threads start, so no synchronization needed) and drop the per-frame copy from `captureRenderFrame()`
- If objects ever become dynamic (spawning), the copy must move back into the capture path

## Testing
- Built `game` target with `windows-msvc-release`; pre-commit hooks pass