### PR TITLE
fix: harden Worker against kick misuse and task exceptions

### DIFF
--- a/sponge/src/thread/worker.cpp
+++ b/sponge/src/thread/worker.cpp
@@ -1,5 +1,10 @@
 #include "worker.hpp"
 
+#include "logging/log.hpp"
+
+#include <cassert>
+#include <exception>
+
 namespace sponge::thread {
 
 Worker::~Worker() {
@@ -27,7 +32,16 @@ void Worker::start() {
                 hasWork     = false;
             }
 
-            const bool taskResult = currentTask();
+            bool taskResult = false;
+            try {
+                taskResult = currentTask();
+            } catch (const std::exception& e) {
+                // Uncaught here would std::terminate the whole process;
+                // report failure so the main loop shuts down cleanly.
+                SPONGE_CORE_ERROR("Worker task threw: {}", e.what());
+            } catch (...) {
+                SPONGE_CORE_ERROR("Worker task threw a non-std exception");
+            }
 
             {
                 std::scoped_lock lock(mutex);
@@ -44,6 +58,9 @@ void Worker::start() {
 void Worker::kick(std::function<bool()> newTask) {
     {
         std::scoped_lock lock(mutex);
+        // Kicking over an in-flight task would silently drop it; callers must
+        // waitForComplete() first.
+        assert(done && "Worker::kick() called while a task is in flight");
         task    = std::move(newTask);
         done    = false;
         hasWork = true;


### PR DESCRIPTION
## Summary
- `Worker::kick()` now asserts no task is in flight — breaking the wait-before-kick discipline trips in debug builds instead of silently dropping the running task (compiled out in release)
- Exceptions escaping a worker task previously hit the thread boundary and called `std::terminate` with no context; they are now logged via `SPONGE_CORE_ERROR` and reported as task failure, which the main loop already treats as a quit signal — clean shutdown instead of an abort

## Testing
- Built `game` target with `windows-msvc-release`; pre-commit hooks pass