### PR TITLE
refactor: silence clang-tidy warnings in layers

### DIFF
--- a/game/src/layer/exitlayer.cpp
+++ b/game/src/layer/exitlayer.cpp
@@ -120,12 +120,10 @@ void ExitLayer::onEvent(Event& event) {
             return isActive() ? this->onMouseButtonPressed(event) : false;
         });
     dispatcher.dispatch<MouseMovedEvent>([this](const MouseMovedEvent& event) {
-        return isActive() ? this->onMouseMoved(event) : false;
+        return isActive() ? onMouseMoved(event) : false;
     });
     dispatcher.dispatch<WindowResizeEvent>(
-        [this](const WindowResizeEvent& event) {
-            return this->onWindowResize(event);
-        });
+        [](const WindowResizeEvent& event) { return onWindowResize(event); });
 }
 
 bool ExitLayer::onUpdate(const double elapsedTime) {

--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -305,7 +305,7 @@ void ImGuiLayer::showPointLightControls() {
     int32_t    attenuationIndex = mazeLayer->getAttenuationIndex();
     if (ImGui::SliderInt(
             "Lights ", &numLights, 0,
-            static_cast<int>(game::thread::MazeRenderFrame::maxLights))) {
+            static_cast<int>(thread::MazeRenderFrame::maxLights))) {
         mazeLayer->setNumLights(numLights);
     }
 

--- a/game/src/layer/introlayer.cpp
+++ b/game/src/layer/introlayer.cpp
@@ -130,12 +130,10 @@ void IntroLayer::onEvent(Event& event) {
             return isActive() ? this->onMouseButtonPressed(event) : false;
         });
     dispatcher.dispatch<MouseMovedEvent>([this](const MouseMovedEvent& event) {
-        return isActive() ? this->onMouseMoved(event) : false;
+        return isActive() ? onMouseMoved(event) : false;
     });
     dispatcher.dispatch<WindowResizeEvent>(
-        [this](const WindowResizeEvent& event) {
-            return this->onWindowResize(event);
-        });
+        [](const WindowResizeEvent& event) { return onWindowResize(event); });
 }
 
 bool IntroLayer::onUpdate(const double elapsedTime) {
@@ -219,7 +217,7 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
                 .getInputManager()
                 .getSnapshot()
                 .gamepadConnected;
-        const auto gamepadStatus =
+        const auto* const gamepadStatus =
             gamepadConnected ? "Gamepad connected" : "No gamepad";
         constexpr auto statusFontSize = 16;
         constexpr auto margin         = 10.F;

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -172,9 +172,7 @@ void MazeLayer::onAttach() {
     createDepthPrepassFbo(w, h);
 
     shader->bind();
-    shader->setFloat(
-        "clusterNear",
-        sponge::platform::opengl::scene::ClusteredLights::clusterNear);
+    shader->setFloat("clusterNear", ClusteredLights::clusterNear);
     shader->setFloat("farPlane", camera->getFar());
     shader->setFloat2("screenSize",
                       glm::vec2(static_cast<float>(w), static_cast<float>(h)));

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -110,32 +110,27 @@ bool matchesAspectRatio(const AspectRatioFilter& filter, const uint32_t width,
 bool hasMatchingResolution(
     const AspectRatioFilter&                     filter,
     const std::vector<sponge::core::Resolution>& resolutions) {
-    for (const auto& res : resolutions) {
-        if (matchesAspectRatio(filter, res.width, res.height)) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(resolutions, [&](const auto& res) {
+        return matchesAspectRatio(filter, res.width, res.height);
+    });
 }
 
 size_t findAspectRatioIndex(const uint32_t width, const uint32_t height) {
     const auto g  = std::gcd(width, height);
     const auto rw = width / g;
     const auto rh = height / g;
-    auto       it =
-        std::find_if(validAspectRatioFilters.begin(),
-                     validAspectRatioFilters.end(), [&](const auto& f) {
-                         const auto fg = std::gcd(f.numerator, f.denominator);
-                         return !f.approximate && rw == f.numerator / fg &&
-                                rh == f.denominator / fg;
-                     });
+    auto it = std::ranges::find_if(validAspectRatioFilters, [&](const auto& f) {
+        const auto fg = std::gcd(f.numerator, f.denominator);
+        return !f.approximate && rw == f.numerator / fg &&
+               rh == f.denominator / fg;
+    });
     if (it != validAspectRatioFilters.end()) {
         return static_cast<size_t>(
             std::distance(validAspectRatioFilters.begin(), it));
     }
-    it = std::find_if(
-        validAspectRatioFilters.begin(), validAspectRatioFilters.end(),
-        [&](const auto& f) { return matchesAspectRatio(f, width, height); });
+    it = std::ranges::find_if(validAspectRatioFilters, [&](const auto& f) {
+        return matchesAspectRatio(f, width, height);
+    });
     return it != validAspectRatioFilters.end() ?
                static_cast<size_t>(
                    std::distance(validAspectRatioFilters.begin(), it)) :
@@ -286,7 +281,8 @@ void OptionLayer::onAttach() {
         rowNodes[i] = ui::makeMenuRow(menuBackgroundNode, static_cast<int>(i));
     }
 
-    availableResolutions = Maze::get().getAvailableResolutions();
+    availableResolutions =
+        sponge::platform::glfw::core::Application::getAvailableResolutions();
 
     validAspectRatioFilters.clear();
     for (const auto& f : aspectRatioFilters) {
@@ -741,9 +737,8 @@ void OptionLayer::filterResolutions() {
     resolutionList->setItems(std::move(resItems));
 
     if (!filteredResolutions.empty()) {
-        const auto it = std::find_if(
-            filteredResolutions.begin(), filteredResolutions.end(),
-            [&](const auto& r) {
+        const auto it =
+            std::ranges::find_if(filteredResolutions, [&](const auto& r) {
                 return r.width == currentWidth && r.height == currentHeight;
             });
         const auto idx = it != filteredResolutions.end() ?
@@ -831,9 +826,10 @@ void OptionLayer::updateChangeStatus() {
             filteredResolutions[resolutionList->getSelectedIndex()];
         resolutionChanged = res.width != curW || res.height != curH;
 
-        const auto it = std::find_if(
-            filteredResolutions.begin(), filteredResolutions.end(),
-            [&](const auto& r) { return r.width == curW && r.height == curH; });
+        const auto it =
+            std::ranges::find_if(filteredResolutions, [&](const auto& r) {
+                return r.width == curW && r.height == curH;
+            });
         currentResolutionIndex =
             it != filteredResolutions.end() ?
                 std::optional{ static_cast<size_t>(

--- a/sponge/src/platform/glfw/core/application.hpp
+++ b/sponge/src/platform/glfw/core/application.hpp
@@ -144,8 +144,8 @@ private:
     ApplicationSpecification appSpec;
 
     // 1 update thread (game logic, no GL) + 1 render thread (owns GL context).
-    sponge::thread::Worker renderThread;
-    sponge::thread::Worker updateThread;
+    thread::Worker renderThread;
+    thread::Worker updateThread;
 
     InputManager inputManager;
 

--- a/sponge/src/platform/opengl/scene/mesh.cpp
+++ b/sponge/src/platform/opengl/scene/mesh.cpp
@@ -32,7 +32,7 @@ using sponge::scene::Vertex;
 
 uint32_t Mesh::meshProgramId = 0;
 
-std::shared_ptr<renderer::Shader> Mesh::shader;
+std::shared_ptr<Shader> Mesh::shader;
 
 Mesh::Mesh(std::vector<Vertex>&& vertices, const std::size_t numVertices,
            std::vector<uint32_t>&& indices, const std::size_t numIndices,


### PR DESCRIPTION
Qualify static member access instead of going through an instance, switch iterator-pair algorithms to their ranges equivalents, and drop redundant namespace qualifiers.

- `optionlayer.cpp`: `getAvailableResolutions()` is static on `Application` — no longer called through `Maze::get()`; one raw loop → `std::ranges::any_of`, four `std::find_if(b, e, …)` → `std::ranges::find_if`
- `exitlayer.cpp` / `introlayer.cpp`: `onMouseMoved` / `onWindowResize` are static — dropped `this->`, resize lambdas no longer capture `this`
- `introlayer.cpp`: `const auto` → `const auto* const` for a `const char*`
- `imguilayer.cpp`, `mazelayer.cpp`, `application.hpp`, `mesh.cpp`: redundant namespace qualifiers removed

Verified with `cmake --build build --target game --config Release` — builds clean.