### PR TITLE
fix(ci): sync mono cert store on Linux to fix NuGet SSL failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,10 @@ jobs:
               if: runner.os == 'macOS'
               run: brew install mono
 
+            - name: Sync mono certificate store
+              if: runner.os == 'Linux'
+              run: cert-sync /etc/ssl/certs/ca-certificates.crt
+
             - name: Setup MSVC toolchain
               if: runner.os == 'Windows'
               uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
 
             - name: Sync mono certificate store
               if: runner.os == 'Linux'
-              run: cert-sync /etc/ssl/certs/ca-certificates.crt
+              run: sudo cert-sync /etc/ssl/certs/ca-certificates.crt
 
             - name: Setup MSVC toolchain
               if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
 
             - name: Sync mono certificate store
               if: runner.os == 'Linux'
-              run: sudo cert-sync /etc/ssl/certs/ca-certificates.crt
+              run: cert-sync --user /etc/ssl/certs/ca-certificates.crt
 
             - name: Setup MSVC toolchain
               if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
- Linux CI builds were failing at the "Create build tree" step with `CERTIFICATE_VERIFY_FAILED` when vcpkg's NuGet binary cache tried to restore packages from `nuget.pkg.github.com`.
- Root cause: on Linux, `nuget` runs under `mono`, whose TLS provider (BoringSSL-based `Mono.Btls`) keeps its own certificate store separate from the OS trust store. A fresh `mono-complete` install has an empty store, so every HTTPS request mono makes fails cert verification.
- Fix: run `cert-sync /etc/ssl/certs/ca-certificates.crt` (bundled with `mono-complete`) right after installing mono packages on Linux, before the NuGet credential setup step.

Ref: https://github.com/tomconder/maze/actions/runs/30910498667/job/91995795712

## Test plan
- [ ] CI passes on the `linux` build matrix leg (NuGet restore succeeds, no SSL errors)