### PR TITLE
fix(shadows): stop directional shadow clipping on Sponza second floor

### DIFF
--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -247,7 +247,7 @@ void ImGuiLayer::showDirectionalLightControls() {
             ImGui::Text("Direction");
             ImGui::TableNextColumn();
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-            if (ImGui::SliderFloat3("##directionaldirection", vec.data(), -10.F,
+            if (ImGui::SliderFloat3("##directionaldirection", vec.data(), -50.F,
                                     10.F, "%2.2f",
                                     ImGuiSliderFlags_AlwaysClamp)) {
                 mazeLayer->setDirectionalLightDirection(

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -21,11 +21,11 @@
 #include <string>
 
 namespace {
-constexpr auto cameraPosition = glm::vec3(0.F, 3.F, 0.F);
+constexpr auto cameraPosition = glm::vec3(-5.F, 1.5F, 0.F);
 
 constexpr auto dirLightCastsShadow = true;
 constexpr auto dirLightColor       = glm::vec3(1.F, 1.F, 1.F);
-constexpr auto dirLightDirection   = glm::vec3(0.F, -10.F, 1.333F);
+constexpr auto dirLightDirection   = glm::vec3(0.F, -20.F, 1.333F);
 constexpr auto dirLightEnabled     = true;
 constexpr auto defaultShadowMapRes = 1024U;
 
@@ -58,24 +58,24 @@ std::array gameObjects = {
     //             .rotation    = { .angle = 0.F, .axis{ 0.F, 1.F, 0.F }, },
     //             .translation = glm::vec3(0.F, 0.F, .5F), },
 
-    GameObject{ .name        = "cube3",
-                .path        = "/models/gltf/cube/cube-tex.glb",
-                .scale       = glm::vec3(.25F),
-                .rotation    = { .angle = glm::radians(60.F),
-                                 .axis  = glm::vec3(1.F, 0.F, 1.F), },
-                .translation = glm::vec3(-1.F, 2.25F, 1.F),
-                .emissive    = glm::vec3(1.5F, 1.2F, 0.5F), },
+    // GameObject{ .name        = "cube3",
+    //             .path        = "/models/gltf/cube/cube-tex.glb",
+    //             .scale       = glm::vec3(.25F),
+    //             .rotation    = { .angle = glm::radians(60.F),
+    //                              .axis  = glm::vec3(1.F, 0.F, 1.F), },
+    //             .translation = glm::vec3(-1.F, 2.25F, 1.F),
+    //             .emissive    = glm::vec3(1.5F, 1.2F, 0.5F), },
 
     GameObject{ .name        = "helmet",
                 .path        = "/models/gltf/helmet/DamagedHelmet.glb",
                 .scale       = glm::vec3(.3F),
-                .rotation    = { .angle = glm::radians(45.F),
+                .rotation    = { .angle = glm::radians(-75.F),
                                  .axis  = glm::vec3(0.F, 1.F, 0.F), },
-                .translation = glm::vec3(2.F, 2.F, 0.F), },
+                .translation = glm::vec3(2.F, 0.5F, 0.F), },
 
     GameObject{ .name        = "sponza",
                 .path        = "/models/gltf/sponza/sponza.glb",
-                .translation = glm::vec3(0.5F, 1.F, 0.310F), },
+                .translation = glm::vec3(0.F, 0.F, 0.F), },
 };
 }  // namespace
 
@@ -572,7 +572,7 @@ void MazeLayer::setNumLights(const int32_t val) {
             light.color    = glm::vec3(1.F);
             light.position = glm::vec3(
                 rotate(glm::mat4(1.F), angle, glm::vec3(0.F, 1.F, 0.F)) *
-                glm::vec4(0.F, 2.75F, -radius, 1.F));
+                glm::vec4(0.F, 5.75F, -radius, 1.F));
         }
     }
 

--- a/game/src/scene/gamecamera.hpp
+++ b/game/src/scene/gamecamera.hpp
@@ -72,7 +72,7 @@ private:
     static constexpr float zNear = 0.1F;
     static constexpr float zFar  = 100.F;
 
-    float pitch = -24.F;
+    float pitch = 0.F;
     float yaw   = 0.F;
 
     float width  = 0.F;

--- a/sponge/src/platform/opengl/scene/shadowmap.cpp
+++ b/sponge/src/platform/opengl/scene/shadowmap.cpp
@@ -9,14 +9,16 @@
 
 #include <glm/glm.hpp>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <string>
 
 namespace {
-constexpr float nearPlane    = 1.F;
-constexpr float farPlane     = 75.F;
-constexpr float orthoBoxSize = 5.F;
+constexpr float nearPlane     = 1.F;
+constexpr float farPlane      = 75.F;
+constexpr float orthoBoxSize  = 20.F;
+constexpr float lightDistance = 30.F;
 }  // namespace
 
 namespace sponge::platform::opengl::scene {
@@ -213,16 +215,16 @@ const glm::mat4& ShadowMap::getLightSpaceMatrix() const {
 }
 
 void ShadowMap::updateLightSpaceMatrix(const glm::vec3& lightDirection) {
-    const float left   = -orthoBoxSize;
-    const float right  = orthoBoxSize;
-    const float bottom = -orthoBoxSize;
-    const float top    = orthoBoxSize;
-
     const auto lightProjection =
-        glm::ortho(left, right, bottom, top, nearPlane, farPlane);
+        glm::ortho(-orthoBoxSize, orthoBoxSize, -orthoBoxSize, orthoBoxSize,
+                   nearPlane, farPlane);
 
-    const auto lightView = glm::lookAt(10.F * -lightDirection, glm::vec3(0.0f),
-                                       glm::vec3(0.0f, 1.0f, 0.0f));
+    // avoid lookAt degenerating when light direction nears vertical
+    const auto up = std::abs(lightDirection.y) > 0.99F ?
+                        glm::vec3(0.F, 0.F, 1.F) :
+                        glm::vec3(0.F, 1.F, 0.F);
+    const auto lightView =
+        glm::lookAt(lightDistance * -lightDirection, glm::vec3(0.0f), up);
 
     lightSpaceMatrix = lightProjection * lightView;
 }


### PR DESCRIPTION
## Summary
- `updateLightSpaceMatrix` hardcoded a 10-unit light eye distance and a ±5 ortho box, both far smaller than the Sponza scene (~28 wide, ~17 tall), so the second-floor arches sat above/beyond the light's near plane and box and clipped out of shadow.
- Sizes bumped to a ±20 box at a 30-unit eye distance so the whole building sits between eye and near plane.
- Also fixes `lookAt` using a fixed world-up vector, which degenerates when the light direction is near-vertical (the default direction is ~4° off straight down) and was wobbling the shadow frustum independently of the sizing issue.

## Test plan
- [x] Incremental `cmake --build out/build/ci-windows-debug --target game` succeeds
- [x] Launched `maze.exe` locally to confirm no regressions in startup