### PR TITLE
fix: address CLion/clang-tidy inspection findings

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: Maze
 site_description: 'A nice walk through a maze'
 site_author: 'Tom Conder <tom@itstom.co>'
-site_url: 'http://github.com/tomconder/maze'
+site_url: 'https://github.com/tomconder/maze'
 
 repo_name: 'maze'
-repo_url: 'http://github.com/tomconder/maze'
+repo_url: 'https://github.com/tomconder/maze'
 edit_uri: 'tree/main/docs/'
 remote_branch: gh-pages
 

--- a/game/src/layer/exitlayer.cpp
+++ b/game/src/layer/exitlayer.cpp
@@ -34,7 +34,10 @@ constexpr size_t menuItemCount = static_cast<size_t>(ExitMenuItem::Count);
 // Rows are laid out top-to-bottom in ExitMenuItem order, so the enum doubles
 // as the button and row index.
 constexpr std::array<std::string_view, menuItemCount> menuLabels = {
-    "Continue", "Options", "Return to Menu", "Exit the Game"
+    "Continue",
+    "Options",
+    "Return to Menu",
+    "Exit the Game",
 };
 
 constexpr std::string_view cameraName = "exit";
@@ -74,9 +77,11 @@ using sponge::platform::opengl::scene::Quad;
 ExitLayer::ExitLayer() : Layer("exit") {}
 
 void ExitLayer::onAttach() {
-    const auto fontCreateInfo = FontCreateInfo{ .name = std::string(fontName),
-                                                .path = std::string(fontPath) };
-    menuFont                  = AssetManager::createFont(fontCreateInfo);
+    const auto fontCreateInfo = FontCreateInfo{
+        .name = std::string(fontName),
+        .path = std::string(fontPath),
+    };
+    menuFont = AssetManager::createFont(fontCreateInfo);
 
     const auto orthoCameraCreateInfo =
         scene::OrthoCameraCreateInfo{ .name = std::string(cameraName) };
@@ -116,14 +121,17 @@ void ExitLayer::onEvent(Event& event) {
     EventDispatcher dispatcher(event);
 
     dispatcher.dispatch<MouseButtonPressedEvent>(
-        [this](const MouseButtonPressedEvent& event) {
-            return isActive() ? this->onMouseButtonPressed(event) : false;
+        [this](const MouseButtonPressedEvent& mbEvent) {
+            return isActive() ? this->onMouseButtonPressed(mbEvent) : false;
         });
-    dispatcher.dispatch<MouseMovedEvent>([this](const MouseMovedEvent& event) {
-        return isActive() ? onMouseMoved(event) : false;
-    });
+    dispatcher.dispatch<MouseMovedEvent>(
+        [this](const MouseMovedEvent& mmEvent) {
+            return isActive() ? onMouseMoved(mmEvent) : false;
+        });
     dispatcher.dispatch<WindowResizeEvent>(
-        [](const WindowResizeEvent& event) { return onWindowResize(event); });
+        [](const WindowResizeEvent& wrEvent) {
+            return onWindowResize(wrEvent);
+        });
 }
 
 bool ExitLayer::onUpdate(const double elapsedTime) {

--- a/game/src/layer/exitlayer.hpp
+++ b/game/src/layer/exitlayer.hpp
@@ -14,7 +14,7 @@ enum class ExitMenuItem : uint8_t {
     Options,
     ReturnToMenu,
     Exit,
-    Count
+    Count,
 };
 
 class ExitLayer final : public sponge::layer::Layer {

--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -25,13 +25,17 @@ namespace {
 constexpr ImColor                         darkDebugColor{ .3F, .8F, .8F, 1.F };
 constexpr ImColor                         darkErrorColor{ .7F, .3F, 0.3F, 1.F };
 constexpr ImColor                         darkWarnColor{ .8F, .8F, 0.3F, 1.F };
-constexpr std::array<std::string_view, 4> categories = { "categories", "app",
-                                                         "sponge", "opengl" };
-constexpr std::array<std::string_view, 7> logLevels  = {
+constexpr std::array<std::string_view, 4> categories = {
+    "categories",
+    "app",
+    "sponge",
+    "opengl",
+};
+constexpr std::array<std::string_view, 7> logLevels = {
     SPDLOG_LEVEL_NAME_TRACE.data(), SPDLOG_LEVEL_NAME_DEBUG.data(),
     SPDLOG_LEVEL_NAME_INFO.data(),  SPDLOG_LEVEL_NAME_WARNING.data(),
     SPDLOG_LEVEL_NAME_ERROR.data(), SPDLOG_LEVEL_NAME_CRITICAL.data(),
-    SPDLOG_LEVEL_NAME_OFF.data()
+    SPDLOG_LEVEL_NAME_OFF.data(),
 };
 
 constexpr ImGuiWindowFlags windowFlags =
@@ -269,10 +273,16 @@ void ImGuiLayer::showDirectionalLightControls() {
             ImGui::TableNextColumn();
 
             static constexpr std::array<uint32_t, 4> shadowResolutions = {
-                512, 1024, 2048, 4096
+                512,
+                1024,
+                2048,
+                4096,
             };
             static constexpr std::array<const char*, 4> shadowResLabels = {
-                "Low", "Normal", "High", "Ultra"
+                "Low",
+                "Normal",
+                "High",
+                "Ultra",
             };
 
             const auto currentRes =

--- a/game/src/layer/introlayer.cpp
+++ b/game/src/layer/introlayer.cpp
@@ -33,9 +33,11 @@ constexpr size_t menuItemCount = static_cast<size_t>(IntroMenuItem::Count);
 
 // Rows are laid out top-to-bottom in IntroMenuItem order, so the enum doubles
 // as the button and row index.
-constexpr std::array<std::string_view, menuItemCount> menuLabels = { "New Game",
-                                                                     "Options",
-                                                                     "Quit" };
+constexpr std::array<std::string_view, menuItemCount> menuLabels = {
+    "New Game",
+    "Options",
+    "Quit",
+};
 
 constexpr std::string_view cameraName = "intro";
 constexpr std::string_view fontName   = "inter";
@@ -82,9 +84,11 @@ void IntroLayer::beginFadeIn(const double duration) {
 }
 
 void IntroLayer::onAttach() {
-    const auto fontCreateInfo = FontCreateInfo{ .name = std::string(fontName),
-                                                .path = std::string(fontPath) };
-    menuFont                  = AssetManager::createFont(fontCreateInfo);
+    const auto fontCreateInfo = FontCreateInfo{
+        .name = std::string(fontName),
+        .path = std::string(fontPath),
+    };
+    menuFont = AssetManager::createFont(fontCreateInfo);
 
     const auto orthoCameraCreateInfo =
         scene::OrthoCameraCreateInfo{ .name = std::string(cameraName) };
@@ -126,14 +130,17 @@ void IntroLayer::onEvent(Event& event) {
     EventDispatcher dispatcher(event);
 
     dispatcher.dispatch<MouseButtonPressedEvent>(
-        [this](const MouseButtonPressedEvent& event) {
-            return isActive() ? this->onMouseButtonPressed(event) : false;
+        [this](const MouseButtonPressedEvent& mbEvent) {
+            return isActive() ? this->onMouseButtonPressed(mbEvent) : false;
         });
-    dispatcher.dispatch<MouseMovedEvent>([this](const MouseMovedEvent& event) {
-        return isActive() ? onMouseMoved(event) : false;
-    });
+    dispatcher.dispatch<MouseMovedEvent>(
+        [this](const MouseMovedEvent& mmEvent) {
+            return isActive() ? onMouseMoved(mmEvent) : false;
+        });
     dispatcher.dispatch<WindowResizeEvent>(
-        [](const WindowResizeEvent& event) { return onWindowResize(event); });
+        [](const WindowResizeEvent& wrEvent) {
+            return onWindowResize(wrEvent);
+        });
 }
 
 bool IntroLayer::onUpdate(const double elapsedTime) {

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -558,9 +558,9 @@ void MazeLayer::setNumLights(const int32_t val) {
         std::scoped_lock lock(settingsMutex);
         numLights = std::clamp(val, 0, maxPointLights);
 
-        std::mt19937                          rng(42U);
-        std::uniform_real_distribution<float> jitterAngle(-0.4F, 0.4F);
-        std::uniform_real_distribution<float> jitterRadius(-0.5F, 0.5F);
+        std::mt19937                   rng(42U);
+        std::uniform_real_distribution jitterAngle(-0.4F, 0.4F);
+        std::uniform_real_distribution jitterRadius(-0.5F, 0.5F);
 
         for (int32_t i = 0; i < numLights; i++) {
             const float t =

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -52,10 +52,12 @@ constexpr auto aspectRatioFilters = std::to_array<AspectRatioFilter>({
     { .label = "5:3", .numerator = 5, .denominator = 3 },
     { .label = "5:4", .numerator = 5, .denominator = 4 },
     { .label = "16:9", .numerator = 16, .denominator = 9 },
-    { .label       = "~16:9",
-      .numerator   = 16,
-      .denominator = 9,
-      .approximate = true },
+    {
+        .label       = "~16:9",
+        .numerator   = 16,
+        .denominator = 9,
+        .approximate = true,
+    },
     { .label = "16:10", .numerator = 16, .denominator = 10 },
     { .label = "25:16", .numerator = 25, .denominator = 16 },
 });
@@ -250,9 +252,11 @@ using sponge::platform::opengl::scene::Quad;
 OptionLayer::OptionLayer() : Layer("options") {}
 
 void OptionLayer::onAttach() {
-    const auto fontCreateInfo = FontCreateInfo{ .name = std::string(fontName),
-                                                .path = std::string(fontPath) };
-    menuFont                  = AssetManager::createFont(fontCreateInfo);
+    const auto fontCreateInfo = FontCreateInfo{
+        .name = std::string(fontName),
+        .path = std::string(fontPath),
+    };
+    menuFont = AssetManager::createFont(fontCreateInfo);
 
     const auto orthoCameraCreateInfo =
         scene::OrthoCameraCreateInfo{ .name = std::string(cameraName) };
@@ -260,8 +264,7 @@ void OptionLayer::onAttach() {
 
     quad = std::make_unique<Quad>();
 
-    fontSize = ui::menuFontSizeForWidth(
-        static_cast<uint32_t>(orthoCamera->getWidth()));
+    fontSize = ui::menuFontSizeForWidth(orthoCamera->getWidth());
 
     returnButton = ui::makeMenuButton(returnMessage, fontSize, menuFont,
                                       buttonColor, textColor);
@@ -306,7 +309,8 @@ void OptionLayer::onAttach() {
     shadowQualityList = std::make_unique<ui::SelectList>(selectCreateInfo);
 
     const ui::CheckboxCreateInfo checkboxCreateInfo{
-        .margin = textMarginLeft, .size = static_cast<float>(fontSize)
+        .margin = textMarginLeft,
+        .size   = static_cast<float>(fontSize),
     };
     antiAliasingCheckbox = std::make_unique<ui::Checkbox>(checkboxCreateInfo);
     fullScreenCheckbox   = std::make_unique<ui::Checkbox>(checkboxCreateInfo);

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -22,7 +22,7 @@ enum class OptionMenuItem : uint8_t {
     AntiAliasing,
     ShadowQuality,
     Return,
-    Count
+    Count,
 };
 
 class OptionLayer final : public sponge::layer::Layer {

--- a/game/src/maze.cpp
+++ b/game/src/maze.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<sponge::platform::glfw::core::Application>
         .width      = Settings::getUInt32("video.width", 0),
         .height     = Settings::getUInt32("video.height", 0),
         .fullscreen = Settings::getBool("video.fullscreen", true),
-        .vsync      = Settings::getBool("video.vsync", true)
+        .vsync      = Settings::getBool("video.vsync", true),
     };
 
     return std::make_unique<game::Maze>(spec);

--- a/game/src/mimallocoverride.cpp
+++ b/game/src/mimallocoverride.cpp
@@ -5,7 +5,7 @@
 #include <cstddef>
 #include <new>
 
-#if defined(__APPLE__)
+#ifdef __APPLE__
 // Apple's libc++ std::basic_string::__grow_by_and_replace calls system realloc
 // directly rather than going through operator new/delete. With operator new
 // overridden to use mimalloc, string buffers are mimalloc memory, but system

--- a/game/src/scene/gamecamera.cpp
+++ b/game/src/scene/gamecamera.cpp
@@ -18,9 +18,8 @@ GameCamera::GameCamera(const GameCameraCreateInfo& createInfo) {
 
     const auto radYaw   = glm::radians(yaw);
     const auto radPitch = glm::radians(pitch);
-    cameraFront         = { glm::cos(radYaw) * glm::cos(radPitch),  //
-                            glm::sin(radPitch),                     //
-                            glm::sin(radYaw) * glm::cos(radPitch) };
+    cameraFront = { glm::cos(radYaw) * glm::cos(radPitch), glm::sin(radPitch),
+                    glm::sin(radYaw) * glm::cos(radPitch) };
 }
 
 void GameCamera::updateProjection() {
@@ -82,10 +81,9 @@ void GameCamera::mouseMove(const glm::vec2& offset) {
 
     const auto radYaw   = glm::radians(yaw);
     const auto radPitch = glm::radians(pitch);
-    cameraFront =
-        normalize(glm::vec3{ glm::cos(radYaw) * glm::cos(radPitch),  //
-                             glm::sin(radPitch),                     //
-                             glm::sin(radYaw) * glm::cos(radPitch) });
+    cameraFront = normalize(glm::vec3{ glm::cos(radYaw) * glm::cos(radPitch),
+                                       glm::sin(radPitch),
+                                       glm::sin(radYaw) * glm::cos(radPitch) });
 
     updateView();
 }

--- a/game/src/scene/light.cpp
+++ b/game/src/scene/light.cpp
@@ -1,12 +1,14 @@
 #include "scene/light.hpp"
 
 #include <algorithm>
+#include <array>
 
 namespace game::scene {
 
 // Must match attenuationRadius in lighting.slang.
-constexpr float distance[11] = { 3.F,  6.F,  9.F,  16.F,  23.F, 31.F,
-                                 47.F, 78.F, 94.F, 155.F, 290.F };
+constexpr std::array<float, 11> distance = {
+    3.F, 6.F, 9.F, 16.F, 23.F, 31.F, 47.F, 78.F, 94.F, 155.F, 290.F,
+};
 
 float Light::getAttenuationDistance(const int32_t index) {
     const uint32_t value = std::clamp(index, 0, 10);

--- a/game/src/ui/button.cpp
+++ b/game/src/ui/button.cpp
@@ -97,13 +97,13 @@ void Button::setPosition(const glm::vec2& topLeft,
     const auto height = std::abs(topLeft.y - bottomRight.y);
 
     if (alignType == ButtonAlignType::CenterAligned) {
-        textPosition = { top.x + ((width - static_cast<float>(length)) / 2.F),
+        textPosition = { top.x + (width - static_cast<float>(length)) / 2.F,
                          top.y +
-                             ((height - static_cast<float>(textSize)) / 2.F) };
+                             (height - static_cast<float>(textSize)) / 2.F };
     } else {
         textPosition = { top.x + marginLeft,
                          top.y +
-                             ((height - static_cast<float>(textSize)) / 2.F) };
+                             (height - static_cast<float>(textSize)) / 2.F };
     }
 }
 
@@ -111,15 +111,16 @@ std::unique_ptr<Button> makeMenuButton(
     std::string_view message, const uint32_t fontSize,
     std::shared_ptr<sponge::platform::opengl::scene::BitmapFont> font,
     const glm::vec4& buttonColor, const glm::vec3& textColor) {
-    return std::make_unique<Button>(
-        ButtonCreateInfo{ .message      = std::string(message),
-                          .fontSize     = fontSize,
-                          .font         = std::move(font),
-                          .buttonColor  = buttonColor,
-                          .textColor    = textColor,
-                          .marginLeft   = 26,
-                          .cornerRadius = 12.F,
-                          .alignType    = ButtonAlignType::LeftAligned });
+    return std::make_unique<Button>(ButtonCreateInfo{
+        .message      = std::string(message),
+        .fontSize     = fontSize,
+        .font         = std::move(font),
+        .buttonColor  = buttonColor,
+        .textColor    = textColor,
+        .marginLeft   = 26,
+        .cornerRadius = 12.F,
+        .alignType    = ButtonAlignType::LeftAligned,
+    });
 }
 
 void updateMenuButtonVisuals(Button* button, const bool selected,

--- a/sponge/src/core/timer.hpp
+++ b/sponge/src/core/timer.hpp
@@ -4,7 +4,7 @@
 
 namespace sponge::core {
 
-constexpr double MICROSECONDS_TO_SECONDS = 1e-6F;
+constexpr double microsecondsToSeconds = 1e-6F;
 
 using std::chrono::high_resolution_clock;
 
@@ -17,7 +17,7 @@ public:
         const auto duration =
             std::chrono::duration_cast<std::chrono::microseconds>(
                 currentTicks - previousTicks);
-        elapsedSeconds = duration.count() * MICROSECONDS_TO_SECONDS;
+        elapsedSeconds = duration.count() * microsecondsToSeconds;
         previousTicks  = currentTicks;
     }
 
@@ -28,7 +28,7 @@ public:
 private:
     double                            elapsedSeconds{ 0.0 };
     high_resolution_clock::time_point previousTicks{
-        high_resolution_clock::now()
+        high_resolution_clock::now(),
     };
 };
 

--- a/sponge/src/event/event.hpp
+++ b/sponge/src/event/event.hpp
@@ -12,7 +12,7 @@ enum class EventType : uint8_t {
     MouseScrolled,
     WindowClose,
     WindowFocus,
-    WindowResize
+    WindowResize,
 };
 
 #define EVENT_CLASS_TYPE(type)                \
@@ -40,7 +40,7 @@ public:
     explicit EventDispatcher(Event& event) : event(event) {}
 
     template <typename T>
-    bool dispatch(EventFn<T> func) {
+    bool dispatch(const EventFn<T>& func) {
         if (event.getEventType() == T::getStaticType() && !event.handled) {
             event.handled |= func(static_cast<T&>(event));
             return true;

--- a/sponge/src/input/gameaction.hpp
+++ b/sponge/src/input/gameaction.hpp
@@ -20,7 +20,7 @@ enum class GameAction : uint8_t {
     ExitGame,
     ToggleFullscreen,
     ToggleDebugUI,
-    Count
+    Count,
 };
 
 constexpr int operator+(const GameAction a) noexcept {

--- a/sponge/src/input/inputbinding.hpp
+++ b/sponge/src/input/inputbinding.hpp
@@ -13,7 +13,7 @@ enum class BindingType : uint8_t {
     MouseAxisX,
     MouseAxisY,
     GamepadButton,
-    GamepadAxis
+    GamepadAxis,
 };
 
 struct InputBinding {

--- a/sponge/src/input/keycode.hpp
+++ b/sponge/src/input/keycode.hpp
@@ -138,7 +138,7 @@ enum class KeyCode : uint16_t {
     SpongeKey_RightControl = 345,
     SpongeKey_RightAlt     = 346,
     SpongeKey_RightSuper   = 347,
-    SpongeKey_Menu         = 348
+    SpongeKey_Menu         = 348,
 };
 
 constexpr int operator+(const KeyCode keyCode) noexcept {

--- a/sponge/src/input/mousecode.hpp
+++ b/sponge/src/input/mousecode.hpp
@@ -17,7 +17,7 @@ enum class MouseButton : uint8_t {
 
     ButtonLeft   = Button0,
     ButtonRight  = Button1,
-    ButtonMiddle = Button2
+    ButtonMiddle = Button2,
 };
 
 constexpr int operator+(const MouseButton button) noexcept {

--- a/sponge/src/logging/log.cpp
+++ b/sponge/src/logging/log.cpp
@@ -12,9 +12,6 @@ std::shared_ptr<spdlog::logger> Log::appLogger;
 std::shared_ptr<spdlog::logger> Log::coreLogger;
 std::shared_ptr<spdlog::logger> Log::glLogger;
 
-const char Log::colorFormatPattern[] = "%^%L%m%d %T.%f %7t %s:%# [%n] %v%$";
-const char Log::fileFormatPattern[]  = "%L%m%d %T.%f %7t %s:%# [%n] %v";
-
 void Log::init(const std::string& logfile) {
     spdlog::set_level(
         static_cast<spdlog::level::level_enum>(SPDLOG_ACTIVE_LEVEL));

--- a/sponge/src/logging/log.hpp
+++ b/sponge/src/logging/log.hpp
@@ -38,8 +38,10 @@ public:
     static void addSink(const spdlog::sink_ptr& sink,
                         const std::string&      pattern);
 
-    static const char colorFormatPattern[];
-    static const char fileFormatPattern[];
+    static constexpr const char* colorFormatPattern =
+        "%^%L%m%d %T.%f %7t %s:%# [%n] %v%$";
+    static constexpr const char* fileFormatPattern =
+        "%L%m%d %T.%f %7t %s:%# [%n] %v";
 
 private:
     static std::shared_ptr<spdlog::logger> appLogger;

--- a/sponge/src/platform/glfw/core/application.cpp
+++ b/sponge/src/platform/glfw/core/application.cpp
@@ -70,11 +70,12 @@ bool Application::start() {
 
     graphics = std::make_unique<Context>();
 
-    window = std::make_unique<Window>(
-        sponge::core::WindowProps{ .title      = appName,
-                                   .width      = appSpec.width,
-                                   .height     = appSpec.height,
-                                   .fullscreen = appSpec.fullscreen });
+    window           = std::make_unique<Window>(sponge::core::WindowProps{
+        .title      = appName,
+        .width      = appSpec.width,
+        .height     = appSpec.height,
+        .fullscreen = appSpec.fullscreen,
+    });
     auto* glfwWindow = static_cast<GLFWwindow*>(window->getNativeWindow());
     if (glfwWindow == nullptr) {
         SPONGE_CORE_CRITICAL("Failed to create window");

--- a/sponge/src/platform/glfw/core/inputmanager.cpp
+++ b/sponge/src/platform/glfw/core/inputmanager.cpp
@@ -347,177 +347,263 @@ void InputManager::buildDefaultBindings() {
 
     // ── Menu ──────────────────────────────────────────────────────────────
     menu[+GameAction::MenuUp] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Up,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_KP8,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_UP,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
-                      .axisScale = -1.f,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Up,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_KP8,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_UP,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
+            .axisScale = -1.f,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     menu[+GameAction::MenuDown] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Down,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_KP2,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_DOWN,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
-                      .axisScale = 1.f,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Down,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_KP2,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_DOWN,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
+            .axisScale = 1.f,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     menu[+GameAction::MenuLeft] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Left,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_KP4,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_LEFT,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Left,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_KP4,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_LEFT,
+            .axisScale = 1.f,
+        },
     };
     menu[+GameAction::MenuRight] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Right,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_KP6,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_RIGHT,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Right,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_KP6,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_DPAD_RIGHT,
+            .axisScale = 1.f,
+        },
     };
     menu[+GameAction::MenuConfirm] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Enter,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_KPEnter,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Space,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_A,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Enter,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_KPEnter,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Space,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_A,
+            .axisScale = 1.f,
+        },
     };
     menu[+GameAction::MenuBack] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Escape,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_B,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Escape,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_B,
+            .axisScale = 1.f,
+        },
     };
 
     // ── Gameplay ──────────────────────────────────────────────────────────
     gameplay[+GameAction::MoveForward] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_W,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Up,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
-                      .axisScale = -keyboardSpeed,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_W,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Up,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
+            .axisScale = -keyboardSpeed,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     gameplay[+GameAction::MoveBack] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_S,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Down,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
-                      .axisScale = keyboardSpeed,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_S,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Down,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_Y,
+            .axisScale = keyboardSpeed,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     gameplay[+GameAction::MoveLeft] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_A,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Left,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_X,
-                      .axisScale = -keyboardSpeed,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_A,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Left,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_X,
+            .axisScale = -keyboardSpeed,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     gameplay[+GameAction::MoveRight] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_D,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Right,
-                      .axisScale = keyboardSpeed },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_X,
-                      .axisScale = keyboardSpeed,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_D,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Right,
+            .axisScale = keyboardSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_LEFT_X,
+            .axisScale = keyboardSpeed,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     gameplay[+GameAction::LookHorizontal] = {
-        InputBinding{ .type      = BindingType::MouseAxisX,
-                      .axisScale = mouseSpeed },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_RIGHT_X,
-                      .axisScale = gamepadLook,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::MouseAxisX,
+            .axisScale = mouseSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_RIGHT_X,
+            .axisScale = gamepadLook,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     gameplay[+GameAction::LookVertical] = {
-        InputBinding{ .type      = BindingType::MouseAxisY,
-                      .axisScale = mouseSpeed },
-        InputBinding{ .type      = BindingType::GamepadAxis,
-                      .rawCode   = GLFW_GAMEPAD_AXIS_RIGHT_Y,
-                      .axisScale = gamepadLook,
-                      .deadzone  = gamepadDeadZone },
+        InputBinding{
+            .type      = BindingType::MouseAxisY,
+            .axisScale = mouseSpeed,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadAxis,
+            .rawCode   = GLFW_GAMEPAD_AXIS_RIGHT_Y,
+            .axisScale = gamepadLook,
+            .deadzone  = gamepadDeadZone,
+        },
     };
     gameplay[+GameAction::Pause] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_Escape,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_START,
-                      .axisScale = 1.f },
-        InputBinding{ .type      = BindingType::GamepadButton,
-                      .rawCode   = GLFW_GAMEPAD_BUTTON_BACK,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_Escape,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_START,
+            .axisScale = 1.f,
+        },
+        InputBinding{
+            .type      = BindingType::GamepadButton,
+            .rawCode   = GLFW_GAMEPAD_BUTTON_BACK,
+            .axisScale = 1.f,
+        },
     };
 
     // ── Toggle actions (both contexts) ───────────────────────────────────────
     menu[+GameAction::ToggleFullscreen] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_F,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_F,
+            .axisScale = 1.f,
+        },
     };
     menu[+GameAction::ToggleDebugUI] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_GraveAccent,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_GraveAccent,
+            .axisScale = 1.f,
+        },
     };
     gameplay[+GameAction::ToggleFullscreen] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_F,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_F,
+            .axisScale = 1.f,
+        },
     };
     gameplay[+GameAction::ToggleDebugUI] = {
-        InputBinding{ .type      = BindingType::Key,
-                      .rawCode   = +KeyCode::SpongeKey_GraveAccent,
-                      .axisScale = 1.f },
+        InputBinding{
+            .type      = BindingType::Key,
+            .rawCode   = +KeyCode::SpongeKey_GraveAccent,
+            .axisScale = 1.f,
+        },
     };
 }
 

--- a/sponge/src/platform/glfw/core/window.cpp
+++ b/sponge/src/platform/glfw/core/window.cpp
@@ -17,7 +17,7 @@
 #include <vector>
 
 namespace sponge::platform::glfw::core {
-Window::Window(const sponge::core::WindowProps& props) : window(nullptr) {
+Window::Window(const sponge::core::WindowProps& props) {
     init(props);
 }
 

--- a/sponge/src/platform/glfw/core/window.cpp
+++ b/sponge/src/platform/glfw/core/window.cpp
@@ -209,17 +209,17 @@ std::vector<sponge::core::Resolution> Window::getAvailableResolutions() {
         }) |
         std::views::transform(
             [](const GLFWvidmode& m) -> sponge::core::Resolution {
-                return { static_cast<uint32_t>(m.width),
-                         static_cast<uint32_t>(m.height) };
+                return {
+                    .width  = static_cast<uint32_t>(m.width),
+                    .height = static_cast<uint32_t>(m.height),
+                };
             });
 
     auto resolutions = std::vector(filtered.begin(), filtered.end());
 
-    std::sort(resolutions.begin(), resolutions.end(),
-              [](const auto& a, const auto& b) {
-                  return a.width != b.width ? a.width < b.width :
-                                              a.height < b.height;
-              });
+    std::ranges::sort(resolutions, [](const auto& a, const auto& b) {
+        return a.width != b.width ? a.width < b.width : a.height < b.height;
+    });
 
     return resolutions;
 }

--- a/sponge/src/platform/glfw/core/window.hpp
+++ b/sponge/src/platform/glfw/core/window.hpp
@@ -16,8 +16,8 @@ using EventCallbackFn = std::function<void(event::Event&)>;
 
 struct WindowData {
     std::string_view title;
-    uint32_t         width;
-    uint32_t         height;
+    uint32_t         width  = 0;
+    uint32_t         height = 0;
     EventCallbackFn  eventCallback;
 };
 
@@ -57,7 +57,7 @@ private:
     void shutdown() const;
 
     WindowData  data;
-    GLFWwindow* window;
+    GLFWwindow* window = nullptr;
 };
 
 }  // namespace sponge::platform::glfw::core

--- a/sponge/src/platform/glfw/logging/sink.hpp
+++ b/sponge/src/platform/glfw/logging/sink.hpp
@@ -25,9 +25,11 @@ void Sink<Mutex>::sink_it_(const spdlog::details::log_msg& msg) {
     spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
     const auto formattedText = fmt::to_string(formatted);
 
-    const LogItem it{ .message    = formattedText,
-                      .loggerName = msg.logger_name.data(),
-                      .level      = msg.level };
+    const LogItem it{
+        .message    = formattedText,
+        .loggerName = msg.logger_name.data(),
+        .level      = msg.level,
+    };
 
     core::Application::get().addMessage(it);
 }

--- a/sponge/src/platform/opengl/renderer/context.cpp
+++ b/sponge/src/platform/opengl/renderer/context.cpp
@@ -7,17 +7,30 @@
 #include <GLFW/glfw3.h>
 #include <fmt/format.h>
 
+#include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
 namespace {
-constexpr std::pair<int, int> glVersions[13] = {
-    { 4, 6 }, { 4, 5 }, { 4, 4 }, { 4, 3 }, { 4, 2 }, { 4, 1 }, { 4, 0 },
-    { 3, 3 }, { 3, 2 }, { 3, 1 }, { 3, 0 }, { 2, 1 }, { 2, 0 }
+constexpr std::array<std::pair<int, int>, 13> glVersions = {
+    { { 4, 6 },
+      { 4, 5 },
+      { 4, 4 },
+      { 4, 3 },
+      { 4, 2 },
+      { 4, 1 },
+      { 4, 0 },
+      { 3, 3 },
+      { 3, 2 },
+      { 3, 1 },
+      { 3, 0 },
+      { 2, 1 },
+      { 2, 0 } },
 };
-}
+}  // namespace
 
 namespace sponge::platform::opengl::renderer {
 Context::Context() {
@@ -81,7 +94,9 @@ void Context::init(GLFWwindow* window) const {
             if (glslStr) {
                 glslVer = std::stof(glslStr);
             }
-        } catch (...) {
+        } catch (const std::exception& e) {
+            SPONGE_GL_ERROR("Failed to parse GLSL version '{}': {}", glslStr,
+                            e.what());
         }
         if (glslVer < minGLSL) {
             const char* found = glslStr ? glslStr : "Unknown";

--- a/sponge/src/platform/opengl/renderer/shader.cpp
+++ b/sponge/src/platform/opengl/renderer/shader.cpp
@@ -331,7 +331,7 @@ void Shader::uploadUBO() const {
 
 bool Shader::trySetInUBO(std::string_view name, const void* data, size_t bytes,
                          size_t /*typeSize*/) const {
-    for (auto& block : uboBlocks) {
+    for (const auto& block : uboBlocks) {
         auto it = block.offsets.find(std::string(name));
         if (it == block.offsets.end()) {
             continue;

--- a/sponge/src/platform/opengl/renderer/texture.cpp
+++ b/sponge/src/platform/opengl/renderer/texture.cpp
@@ -5,6 +5,7 @@
 
 #include <stb_image.h>
 
+#include <array>
 #include <filesystem>
 #include <string>
 
@@ -53,8 +54,9 @@ void Texture::createDepthMap(const uint32_t width,
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-    constexpr float borderColor[] = { 1.F, 1.F, 1.F, 1.F };
-    glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor);
+    constexpr std::array<float, 4> borderColor = { 1.F, 1.F, 1.F, 1.F };
+    glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR,
+                     borderColor.data());
 }
 
 void Texture::generate(const uint32_t textureWidth,

--- a/sponge/src/platform/opengl/renderer/texture.hpp
+++ b/sponge/src/platform/opengl/renderer/texture.hpp
@@ -12,7 +12,7 @@ enum LoadFlag : uint8_t {
     None                = 0,
     ExcludeAssetsFolder = BIT(0),
     GammaCorrection     = BIT(1),
-    DepthMap            = BIT(2)
+    DepthMap            = BIT(2),
 };
 
 struct TextureCreateInfo {

--- a/sponge/src/platform/opengl/scene/bitmapfont.cpp
+++ b/sponge/src/platform/opengl/scene/bitmapfont.cpp
@@ -18,7 +18,7 @@ std::array<glm::vec2, maxLength * vertexCount> batchVertices;
 
 // quad index pattern is fixed, so the index buffer is filled once at startup
 std::array<uint32_t, maxLength * indexCount> makeQuadIndices() {
-    std::array<uint32_t, maxLength * indexCount> indices;
+    std::array<uint32_t, maxLength * indexCount> indices{};
     for (uint32_t quad = 0; quad < maxLength; quad++) {
         const uint32_t base            = quad * 4;
         indices[quad * indexCount]     = base;
@@ -41,7 +41,7 @@ BitmapFont::BitmapFont(const FontCreateInfo& createInfo) {
     const auto shaderCreateInfo = renderer::ShaderCreateInfo{
         .name               = shaderName.data(),
         .vertexShaderPath   = "/shaders/glsl/sprite.vert.glsl",
-        .fragmentShaderPath = "/shaders/glsl/text.frag.glsl"
+        .fragmentShaderPath = "/shaders/glsl/text.frag.glsl",
     };
     shader = AssetManager::createShader(shaderCreateInfo);
     shader->bind();
@@ -147,8 +147,8 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
             const float ypos =
                 std::round(position.y - shapedGlyph.yOffset + ascender) -
                 static_cast<float>(glyphInfo->bearingY);
-            const float glyphWidth  = static_cast<float>(glyphInfo->width);
-            const float glyphHeight = static_cast<float>(glyphInfo->height);
+            const auto glyphWidth  = static_cast<float>(glyphInfo->width);
+            const auto glyphHeight = static_cast<float>(glyphInfo->height);
 
             const float uLeft   = glyphInfo->uvLeft;
             const float vTop    = glyphInfo->uvTop;
@@ -163,12 +163,12 @@ void BitmapFont::render(const std::string_view text, const glm::vec2& position,
                   { xpos + glyphWidth, ypos },
                   { uRight, vTop },
                   { xpos + glyphWidth, ypos + glyphHeight },
-                  { uRight, vBottom } }
+                  { uRight, vBottom } },
             };
 
-            std::copy(vertices.begin(), vertices.end(),
-                      batchVertices.begin() +
-                          static_cast<ptrdiff_t>(glyphCount * vertexCount));
+            std::ranges::copy(
+                vertices, batchVertices.begin() +
+                              static_cast<ptrdiff_t>(glyphCount * vertexCount));
             glyphCount++;
         }
 

--- a/sponge/src/platform/opengl/scene/clusteredlights.cpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.cpp
@@ -144,7 +144,7 @@ void ClusteredLights::update(const glm::vec3* positions,
     clusterAABBsSSBO.bindBase(6);
     computeParamsSSBO.bindBase(7);
 
-    assignShader.dispatch((maxClusters + 63) / 64);
+    assignShader.dispatch(static_cast<uint32_t>((maxClusters + 63) / 64));
 
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 }

--- a/sponge/src/platform/opengl/scene/clusteredlights.cpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.cpp
@@ -25,7 +25,8 @@ ClusteredLights::ClusteredLights(const float near, const float far) :
     computeParamsSSBO(sizeof(ComputeParams)),
     assignShader(renderer::ShaderCreateInfo{
         .name              = "cluster_assign",
-        .computeShaderPath = "/shaders/glsl/cluster_assign.comp.glsl" }) {}
+        .computeShaderPath = "/shaders/glsl/cluster_assign.comp.glsl",
+    }) {}
 
 void ClusteredLights::buildClusterAABBs(const glm::mat4& projection) {
     const glm::mat4 invProj = glm::inverse(projection);
@@ -143,7 +144,7 @@ void ClusteredLights::update(const glm::vec3* positions,
     clusterAABBsSSBO.bindBase(6);
     computeParamsSSBO.bindBase(7);
 
-    assignShader.dispatch(static_cast<uint32_t>((maxClusters + 63) / 64));
+    assignShader.dispatch((maxClusters + 63) / 64);
 
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 }

--- a/sponge/src/platform/opengl/scene/clusteredlights.hpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.hpp
@@ -56,9 +56,9 @@ private:
     // std430-compatible: explicit padding so vec3 → 16-byte slot.
     // Must match ClusterAABB in cluster_assign.comp.glsl.
     struct ClusterAABB {
-        glm::vec3 minBounds;
+        glm::vec3 minBounds{ 0.F };
         float     padMin{ 0.F };
-        glm::vec3 maxBounds;
+        glm::vec3 maxBounds{ 0.F };
         float     padMax{ 0.F };
     };
     static_assert(sizeof(ClusterAABB) == 32);

--- a/sponge/src/platform/opengl/scene/cube.cpp
+++ b/sponge/src/platform/opengl/scene/cube.cpp
@@ -27,7 +27,7 @@ constexpr std::array vertices = {
     glm::vec3{ 0.5, -0.5, 0.5 },   glm::vec3{ 0.5, 0.5, 0.5 },
     glm::vec3{ -0.5, -0.5, 0.5 },  glm::vec3{ -0.5, -0.5, -0.5 },
     glm::vec3{ 0.5, -0.5, -0.5 },  glm::vec3{ -0.5, -0.5, 0.5 },
-    glm::vec3{ 0.5, -0.5, -0.5 },  glm::vec3{ 0.5, -0.5, 0.5 }
+    glm::vec3{ 0.5, -0.5, -0.5 },  glm::vec3{ 0.5, -0.5, 0.5 },
 };
 constexpr uint32_t vertexCount = 36;
 }  // namespace
@@ -39,7 +39,7 @@ Cube::Cube() {
     const auto shaderCreateInfo = renderer::ShaderCreateInfo{
         .name               = shaderName.data(),
         .vertexShaderPath   = "/shaders/glsl/cube.vert.glsl",
-        .fragmentShaderPath = "/shaders/glsl/cube.frag.glsl"
+        .fragmentShaderPath = "/shaders/glsl/cube.frag.glsl",
     };
     shader = AssetManager::createShader(shaderCreateInfo);
     shader->bind();

--- a/sponge/src/platform/opengl/scene/model.cpp
+++ b/sponge/src/platform/opengl/scene/model.cpp
@@ -132,13 +132,13 @@ std::shared_ptr<Mesh>
     indices.reserve(mesh.indices.size());
 
     Vertex vertex{};
-    for (auto [vertex_index, normal_index, texcoord_index] : mesh.indices) {
-        auto i          = vertex_index * 3;
+    for (auto [vertexIndex, normalIndex, texcoordIndex] : mesh.indices) {
+        auto i          = vertexIndex * 3;
         vertex.position = glm::vec3{ attrib.vertices[i], attrib.vertices[i + 1],
                                      attrib.vertices[i + 2] };
 
         if (!attrib.texcoords.empty()) {
-            i                = texcoord_index * 2;
+            i                = texcoordIndex * 2;
             vertex.texCoords = glm::vec2{ attrib.texcoords[i],
                                           1.0F - attrib.texcoords[i + 1] };
         } else {
@@ -146,7 +146,7 @@ std::shared_ptr<Mesh>
         }
 
         if (!attrib.normals.empty()) {
-            i             = normal_index * 3;
+            i             = normalIndex * 3;
             vertex.normal = glm::vec3{ attrib.normals[i], attrib.normals[i + 1],
                                        attrib.normals[i + 2] };
         }
@@ -200,13 +200,13 @@ std::shared_ptr<renderer::Texture>
         std::filesystem::path(path) / baseName(material.diffuse_texname));
 
     auto name = baseName(material.diffuse_texname);
-    std::transform(name.begin(), name.end(), name.begin(),
-                   [](const uint8_t c) { return std::tolower(c); });
+    std::ranges::transform(name, name.begin(),
+                           [](const uint8_t c) { return std::tolower(c); });
 
     const renderer::TextureCreateInfo textureCreateInfo{
         .name     = name,
         .path     = filename.string(),
-        .loadFlag = renderer::ExcludeAssetsFolder
+        .loadFlag = renderer::ExcludeAssetsFolder,
     };
     return AssetManager::createTexture(textureCreateInfo);
 }
@@ -405,16 +405,18 @@ UVTransform Model::gltfUVTransform(const cgltf_texture_view& textureView) {
         SPONGE_GL_WARN(
             "KHR_texture_transform rotation is not supported; ignoring");
     }
-    return UVTransform{ .offset = glm::vec2(t.offset[0], t.offset[1]),
-                        .scale  = glm::vec2(t.scale[0], t.scale[1]) };
+    return UVTransform{
+        .offset = glm::vec2(t.offset[0], t.offset[1]),
+        .scale  = glm::vec2(t.scale[0], t.scale[1]),
+    };
 }
 
 // Per-triangle tangent accumulation (Lengyel's method), averaged per vertex
 // and Gram-Schmidt orthogonalized against the vertex normal.
 void Model::computeTangents(std::vector<Vertex>&         vertices,
                             const std::vector<uint32_t>& indices) {
-    std::vector<glm::vec3> tan(vertices.size(), glm::vec3(0.F));
-    std::vector<glm::vec3> bitan(vertices.size(), glm::vec3(0.F));
+    std::vector tan(vertices.size(), glm::vec3(0.F));
+    std::vector bitan(vertices.size(), glm::vec3(0.F));
 
     for (size_t i = 0; i + 2 < indices.size(); i += 3) {
         const auto i0 = indices[i];

--- a/sponge/src/platform/opengl/scene/model.cpp
+++ b/sponge/src/platform/opengl/scene/model.cpp
@@ -415,8 +415,8 @@ UVTransform Model::gltfUVTransform(const cgltf_texture_view& textureView) {
 // and Gram-Schmidt orthogonalized against the vertex normal.
 void Model::computeTangents(std::vector<Vertex>&         vertices,
                             const std::vector<uint32_t>& indices) {
-    std::vector tan(vertices.size(), glm::vec3(0.F));
-    std::vector bitan(vertices.size(), glm::vec3(0.F));
+    std::vector<glm::vec3> tan(vertices.size(), glm::vec3(0.F));
+    std::vector<glm::vec3> bitan(vertices.size(), glm::vec3(0.F));
 
     for (size_t i = 0; i + 2 < indices.size(); i += 3) {
         const auto i0 = indices[i];

--- a/sponge/src/platform/opengl/scene/quad.cpp
+++ b/sponge/src/platform/opengl/scene/quad.cpp
@@ -9,8 +9,7 @@
 
 namespace {
 constexpr std::array<uint32_t, 6> indices = {
-    0, 2, 1,  //
-    0, 3, 2,  //
+    0, 2, 1, 0, 3, 2,
 };
 constexpr uint32_t indexCount  = 6;
 constexpr uint32_t vertexCount = 4;
@@ -57,10 +56,10 @@ void Quad::render(const glm::vec2& top, const glm::vec2& bottom,
                   const glm::vec4& color, const float cornerRadius,
                   const float borderWidth, const glm::vec4& borderColor) const {
     const std::array<glm::vec2, vertexCount> vertices{ {
-        { top.x, bottom.y },     //
-        { top.x, top.y },        //
-        { bottom.x, top.y },     //
-        { bottom.x, bottom.y },  //
+        { top.x, bottom.y },
+        { top.x, top.y },
+        { bottom.x, top.y },
+        { bottom.x, bottom.y },
     } };
 
     const auto corners = glm::vec4(top.x, top.y, bottom.x, bottom.y);

--- a/sponge/src/platform/opengl/scene/quad.cpp
+++ b/sponge/src/platform/opengl/scene/quad.cpp
@@ -10,7 +10,7 @@
 namespace {
 constexpr std::array<uint32_t, 6> indices = {
     0, 2, 1,  //
-    0, 3, 2   //
+    0, 3, 2,  //
 };
 constexpr uint32_t indexCount  = 6;
 constexpr uint32_t vertexCount = 4;
@@ -57,10 +57,10 @@ void Quad::render(const glm::vec2& top, const glm::vec2& bottom,
                   const glm::vec4& color, const float cornerRadius,
                   const float borderWidth, const glm::vec4& borderColor) const {
     const std::array<glm::vec2, vertexCount> vertices{ {
-        { top.x, bottom.y },    //
-        { top.x, top.y },       //
-        { bottom.x, top.y },    //
-        { bottom.x, bottom.y }  //
+        { top.x, bottom.y },     //
+        { top.x, top.y },        //
+        { bottom.x, top.y },     //
+        { bottom.x, bottom.y },  //
     } };
 
     const auto corners = glm::vec4(top.x, top.y, bottom.x, bottom.y);

--- a/sponge/src/platform/opengl/scene/shadowmap.cpp
+++ b/sponge/src/platform/opengl/scene/shadowmap.cpp
@@ -65,7 +65,7 @@ void ShadowMap::initialize() {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-    const std::array<float, 4> borderColor = { 1.F, 1.F, 0.F, 0.F };
+    const std::array borderColor = { 1.F, 1.F, 0.F, 0.F };
     glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR,
                      borderColor.data());
 
@@ -109,9 +109,9 @@ void ShadowMap::initialize() {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     // Fullscreen quad VAO/VBO for blur pass
-    constexpr std::array<float, 24> quadVerts = {
+    constexpr std::array quadVerts = {
         -1.F, 1.F, 0.F, 1.F, -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
-        -1.F, 1.F, 0.F, 1.F, 1.F,  -1.F, 1.F, 0.F, 1.F, 1.F,  1.F, 1.F
+        -1.F, 1.F, 0.F, 1.F, 1.F,  -1.F, 1.F, 0.F, 1.F, 1.F,  1.F, 1.F,
     };
     glGenVertexArrays(1, &blurVao);
     glGenBuffers(1, &blurVbo);

--- a/sponge/src/platform/opengl/scene/shadowmap.cpp
+++ b/sponge/src/platform/opengl/scene/shadowmap.cpp
@@ -65,7 +65,7 @@ void ShadowMap::initialize() {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-    const std::array borderColor = { 1.F, 1.F, 0.F, 0.F };
+    const std::array<float, 4> borderColor = { 1.F, 1.F, 0.F, 0.F };
     glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR,
                      borderColor.data());
 
@@ -109,7 +109,7 @@ void ShadowMap::initialize() {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     // Fullscreen quad VAO/VBO for blur pass
-    constexpr std::array quadVerts = {
+    constexpr std::array<float, 24> quadVerts = {
         -1.F, 1.F, 0.F, 1.F, -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
         -1.F, 1.F, 0.F, 1.F, 1.F,  -1.F, 1.F, 0.F, 1.F, 1.F,  1.F, 1.F,
     };

--- a/sponge/src/platform/opengl/scene/sprite.cpp
+++ b/sponge/src/platform/opengl/scene/sprite.cpp
@@ -12,7 +12,7 @@
 namespace {
 constexpr std::array<uint32_t, 6> indices = {
     0, 1, 2,  //
-    0, 2, 3   //
+    0, 2, 3,  //
 };
 constexpr uint32_t indexCount  = 6;
 constexpr uint32_t vertexCount = 8;
@@ -51,8 +51,10 @@ Sprite::Sprite(const std::string& name, const std::string& texturePath) {
     vbo->unbind();
     vao->unbind();
 
-    const renderer::TextureCreateInfo textureCreateInfo{ .name = name,
-                                                         .path = texturePath };
+    const renderer::TextureCreateInfo textureCreateInfo{
+        .name = name,
+        .path = texturePath,
+    };
     tex = AssetManager::createTexture(textureCreateInfo);
     tex->bind();
 
@@ -69,7 +71,7 @@ void Sprite::render(const glm::vec2& position, const glm::vec2& size,
           { position.x, position.y + size.y },
           { 0.F, 1.F },  //
           { position.x + size.x, position.y + size.y },
-          { 1.F, 1.F } }
+          { 1.F, 1.F } },
     };
 
     vao->bind();

--- a/sponge/src/platform/opengl/scene/sprite.cpp
+++ b/sponge/src/platform/opengl/scene/sprite.cpp
@@ -11,8 +11,7 @@
 
 namespace {
 constexpr std::array<uint32_t, 6> indices = {
-    0, 1, 2,  //
-    0, 2, 3,  //
+    0, 1, 2, 0, 2, 3,
 };
 constexpr uint32_t indexCount  = 6;
 constexpr uint32_t vertexCount = 8;
@@ -65,11 +64,11 @@ void Sprite::render(const glm::vec2& position, const glm::vec2& size,
                     const std::optional<float> alpha) const {
     const std::array<glm::vec2, vertexCount> vertices{
         { { position.x + size.x, position.y },
-          { 1.F, 0.F },  //
+          { 1.F, 0.F },
           { position.x, position.y },
-          { 0.F, 0.F },  //
+          { 0.F, 0.F },
           { position.x, position.y + size.y },
-          { 0.F, 1.F },  //
+          { 0.F, 1.F },
           { position.x + size.x, position.y + size.y },
           { 1.F, 1.F } },
     };

--- a/sponge/src/platform/opengl/scene/sprite.hpp
+++ b/sponge/src/platform/opengl/scene/sprite.hpp
@@ -19,7 +19,7 @@ public:
     explicit Sprite(const std::string& name, const std::string& texturePath);
 
     void render(const glm::vec2& position, const glm::vec2& size,
-                std::optional<float> alpha = std::nullopt) const override;
+                std::optional<float> alpha) const override;
 
     std::shared_ptr<renderer::Shader> getShader() const {
         return shader;

--- a/sponge/src/platform/windows/core/winfile.cpp
+++ b/sponge/src/platform/windows/core/winfile.cpp
@@ -1,23 +1,24 @@
 #include "platform/windows/core/winfile.hpp"
 
 #include <cstddef>
+#include <cstdlib>
 #include <filesystem>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
 namespace sponge::platform::windows::core {
 
 std::string WinFile::getLogDir(const std::string& app) {
-    char*  appdata = nullptr;
-    size_t sz      = 0;
-    if (_dupenv_s(&appdata, &sz, "LOCALAPPDATA") == 0 && appdata != nullptr) {
-        std::string result = (std::filesystem::path(appdata) / app).string();
-        free(appdata);
-        return result;
+    char*  rawAppdata = nullptr;
+    size_t sz         = 0;
+    if (_dupenv_s(&rawAppdata, &sz, "LOCALAPPDATA") != 0 ||
+        rawAppdata == nullptr) {
+        throw std::runtime_error("Failed to get appdata folder");
     }
-    free(appdata);
+    const std::unique_ptr<char, decltype(&free)> appdata(rawAppdata, free);
 
-    throw std::runtime_error("Failed to get appdata folder");
+    return (std::filesystem::path(appdata.get()) / app).string();
 }
 
 }  // namespace sponge::platform::windows::core

--- a/sponge/src/scene/fontatlas.cpp
+++ b/sponge/src/scene/fontatlas.cpp
@@ -68,7 +68,7 @@ void FontAtlas::build(const std::string&           path,
         uint32_t             glyphIndex = 0;
         uint32_t             size       = 0;
         uint32_t             phase      = 0;
-        GlyphInfo            glyphInfo;
+        GlyphInfo            glyphInfo{};
         std::vector<uint8_t> bitmap;
         int                  bitmapWidth  = 0;
         int                  bitmapHeight = 0;

--- a/sponge/src/scene/fontatlas.cpp
+++ b/sponge/src/scene/fontatlas.cpp
@@ -22,7 +22,7 @@ constexpr char32_t firstGlyph = 32;
 constexpr char32_t lastGlyph  = 126;
 
 constexpr std::array<char32_t, 1> supplementalGlyphs = {
-    0xD7,  // × MULTIPLICATION SIGN
+    0xD7  // × MULTIPLICATION SIGN
 };
 }  // namespace
 
@@ -65,14 +65,14 @@ void FontAtlas::build(const std::string&           path,
     hb_ft_font_set_load_flags(hbFont, FT_LOAD_NO_HINTING);
 
     struct PendingGlyph {
-        uint32_t             glyphIndex;
-        uint32_t             size;
-        uint32_t             phase;
+        uint32_t             glyphIndex = 0;
+        uint32_t             size       = 0;
+        uint32_t             phase      = 0;
         GlyphInfo            glyphInfo;
         std::vector<uint8_t> bitmap;
-        int                  bitmapWidth;
-        int                  bitmapHeight;
-        int                  rectIdx;
+        int                  bitmapWidth  = 0;
+        int                  bitmapHeight = 0;
+        int                  rectIdx      = 0;
     };
 
     std::vector<PendingGlyph> pending;
@@ -139,8 +139,8 @@ void FontAtlas::build(const std::string&           path,
 
             stbrp_rect rect{};
             rect.id = pending.back().rectIdx;
-            rect.w  = static_cast<stbrp_coord>(bitmapWidth + 1);
-            rect.h  = static_cast<stbrp_coord>(bitmapHeight + 1);
+            rect.w  = bitmapWidth + 1;
+            rect.h  = bitmapHeight + 1;
             rects.push_back(rect);
         };
 
@@ -221,12 +221,22 @@ std::vector<ShapedGlyph> FontAtlas::shape(const std::string_view text,
     // liga/clig/calt off so shaping never substitutes glyph indices the
     // atlas did not bake (e.g. Inter calt swaps multiply for multiply.case
     // between digits, which would render as nothing)
-    const hb_feature_t features[] = {
-        { HB_TAG('l', 'i', 'g', 'a'), 0, 0, UINT_MAX },
-        { HB_TAG('c', 'l', 'i', 'g'), 0, 0, UINT_MAX },
-        { HB_TAG('c', 'a', 'l', 't'), 0, 0, UINT_MAX },
+    const std::array<hb_feature_t, 3> features = {
+        { { .tag   = HB_TAG('l', 'i', 'g', 'a'),
+            .value = 0,
+            .start = 0,
+            .end   = UINT_MAX },
+          { .tag   = HB_TAG('c', 'l', 'i', 'g'),
+            .value = 0,
+            .start = 0,
+            .end   = UINT_MAX },
+          { .tag   = HB_TAG('c', 'a', 'l', 't'),
+            .value = 0,
+            .start = 0,
+            .end   = UINT_MAX } }
     };
-    hb_shape(hbFont, buffer, features, 3);
+    hb_shape(hbFont, buffer, features.data(),
+             static_cast<unsigned int>(features.size()));
 
     unsigned int     glyphCount = 0;
     hb_glyph_info_t* glyphInfos =

--- a/sponge/src/scene/sprite.hpp
+++ b/sponge/src/scene/sprite.hpp
@@ -10,7 +10,7 @@ public:
     virtual ~Sprite() = default;
 
     virtual void render(const glm::vec2& position, const glm::vec2& size,
-                        std::optional<float> alpha = std::nullopt) const = 0;
+                        std::optional<float> alpha) const = 0;
 };
 
 }  // namespace sponge::scene


### PR DESCRIPTION
## Summary
- Add trailing commas to initializer lists and enums, convert C-style arrays to `std::array`, simplify `#if defined(__APPLE__)` to `#ifdef __APPLE__`
- Fix real defects surfaced by clang-tidy: leak-on-exception in `WinFile::getLogDir` (RAII via `unique_ptr` with a `free` deleter), empty `catch` swallowing GLSL-version parse failures, uninitialized struct fields (`WindowData`, `ClusterAABB`, `PendingGlyph`), a default argument on a virtual method (`Sprite::render`), and an `EventFn` parameter copied instead of taken by `const&`

## Test plan
- [x] `pre-commit run clang-format --all-files` and `cpplint` pass on all changed files
- [x] Full rebuild via `cmake --preset ci-windows-debug` + `cmake --build ... --target game --config Debug` succeeds clean (project builds with `/WX`)