### PR TITLE
fix: apply sponge's/game's own compile options to their own sources

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -106,47 +106,47 @@ if (MSVC)
             /guard:cf>)
 
     # properly report what c++ version is being used
-    target_compile_options(game INTERFACE /Zc:__cplusplus)
+    target_compile_options(game PUBLIC /Zc:__cplusplus)
 
     # fast math and SIMD support
     # https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170#fast
     message(STATUS "Applying fast math and SIMD support")
-    target_compile_options(game INTERFACE $<$<CONFIG:RELEASE>:/fp:fast>)
+    target_compile_options(game PUBLIC $<$<CONFIG:RELEASE>:/fp:fast>)
 
     # do not omit frame pointers for crash dumps
-    target_compile_options(game INTERFACE /Oy-)
+    target_compile_options(game PUBLIC /Oy-)
 
     # enable exception handling
-    target_compile_options(game INTERFACE /EHsc)
+    target_compile_options(game PUBLIC /EHsc)
 
     # enable warnings as errors
-    target_compile_options(game INTERFACE /W4 /WX)
+    target_compile_options(game PUBLIC /W4 /WX)
 
     # disable RTTI
     message(STATUS "Disable RTTI")
-    target_compile_options(game INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/GR->)
+    target_compile_options(game PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/GR->)
 else ()
     # see the implications here: https://stackoverflow.com/q/45685487
     message(STATUS "Applying fast math and SIMD support")
-    target_compile_options(game INTERFACE $<$<CONFIG:RELEASE>:-ffast-math>)
+    target_compile_options(game PUBLIC $<$<CONFIG:RELEASE>:-ffast-math>)
 
     # do not omit frame pointers for crash dumps
-    target_compile_options(game INTERFACE -fno-omit-frame-pointer)
+    target_compile_options(game PUBLIC -fno-omit-frame-pointer)
 
     # enable exception handling
-    target_compile_options(game INTERFACE -fexceptions)
+    target_compile_options(game PUBLIC -fexceptions)
 
     # enable warnings as errors
-    target_compile_options(game INTERFACE -Wall -Werror)
+    target_compile_options(game PUBLIC -Wall -Werror)
 
     # disable RTTI
     message(STATUS "Disable RTTI")
-    target_compile_options(game INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+    target_compile_options(game PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 
     # enable separate sections per function and data item
     target_compile_options(game
-            INTERFACE $<$<CONFIG:RELEASE>:-ffunction-sections>)
-    target_compile_options(game INTERFACE $<$<CONFIG:RELEASE>:-fdata-sections>)
+            PUBLIC $<$<CONFIG:RELEASE>:-ffunction-sections>)
+    target_compile_options(game PUBLIC $<$<CONFIG:RELEASE>:-fdata-sections>)
 
     # discard unused sections
     message(STATUS "Discard unused sections")

--- a/sponge/CMakeLists.txt
+++ b/sponge/CMakeLists.txt
@@ -78,6 +78,8 @@ file(
         LIST_DIRECTORIES false
         deps/tinyobjloader/tiny_obj_loader.cpp)
 list(APPEND SOURCE_FILES ${TINYOBJLOADER_SOURCES})
+set_source_files_properties(${TINYOBJLOADER_SOURCES} PROPERTIES COMPILE_OPTIONS
+        "$<IF:$<CXX_COMPILER_ID:MSVC>,/W0,-w>")
 
 if (ENABLE_IMGUI)
     message(STATUS "Including imgui platform files")
@@ -144,43 +146,43 @@ if (MSVC)
             /guard:cf>)
 
     # properly report what c++ version is being used
-    target_compile_options(sponge INTERFACE /Zc:__cplusplus)
+    target_compile_options(sponge PUBLIC /Zc:__cplusplus)
 
     # fast math and SIMD support
     # https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170#fast
-    target_compile_options(sponge INTERFACE $<$<CONFIG:RELEASE>:/fp:fast>)
+    target_compile_options(sponge PUBLIC $<$<CONFIG:RELEASE>:/fp:fast>)
 
     # do not omit frame pointers for crash dumps
-    target_compile_options(sponge INTERFACE /Oy-)
+    target_compile_options(sponge PUBLIC /Oy-)
 
     # enable exception handling
-    target_compile_options(sponge INTERFACE /EHsc)
+    target_compile_options(sponge PUBLIC /EHsc)
 
     # enable warnings as errors
-    target_compile_options(sponge INTERFACE /W4 /WX)
+    target_compile_options(sponge PUBLIC /W4 /WX)
 
     # disable RTTI
-    target_compile_options(sponge INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/GR->)
+    target_compile_options(sponge PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/GR->)
 else ()
     # see the implications here: https://stackoverflow.com/q/45685487
-    target_compile_options(sponge INTERFACE $<$<CONFIG:RELEASE>:-ffast-math>)
+    target_compile_options(sponge PUBLIC $<$<CONFIG:RELEASE>:-ffast-math>)
 
     # do not omit frame pointers for crash dumps
-    target_compile_options(sponge INTERFACE -fno-omit-frame-pointer)
+    target_compile_options(sponge PUBLIC -fno-omit-frame-pointer)
 
     # enable exception handling
-    target_compile_options(sponge INTERFACE -fexceptions)
+    target_compile_options(sponge PUBLIC -fexceptions)
 
     # enable warnings as errors
-    target_compile_options(sponge INTERFACE -Wall -Werror)
+    target_compile_options(sponge PUBLIC -Wall -Werror)
 
     # disable RTTI
-    target_compile_options(sponge INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+    target_compile_options(sponge PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 
     # enable separate sections per function and data item
     target_compile_options(sponge
-            INTERFACE $<$<CONFIG:RELEASE>:-ffunction-sections>)
-    target_compile_options(sponge INTERFACE $<$<CONFIG:RELEASE>:-fdata-sections>)
+            PUBLIC $<$<CONFIG:RELEASE>:-ffunction-sections>)
+    target_compile_options(sponge PUBLIC $<$<CONFIG:RELEASE>:-fdata-sections>)
 
     # discard unused sections
     target_link_options(

--- a/sponge/src/platform/glfw/core/inputmanager.cpp
+++ b/sponge/src/platform/glfw/core/inputmanager.cpp
@@ -18,8 +18,8 @@ InputManager* InputManager::instance = nullptr;
 static_assert(+input::InputContext::Menu + 1 == 2,
               "Update bindingMaps array size to match InputContext values");
 
-void InputManager::onAttach(GLFWwindow* window) {
-    this->window = window;
+void InputManager::onAttach(GLFWwindow* glfwWindow) {
+    window = glfwWindow;
 
     // Scan for already-connected gamepad
     for (int jid = GLFW_JOYSTICK_1; jid <= GLFW_JOYSTICK_LAST; jid++) {

--- a/sponge/src/platform/opengl/renderer/context.cpp
+++ b/sponge/src/platform/opengl/renderer/context.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <utility>
 
+#ifndef __APPLE__
 namespace {
 constexpr std::array<std::pair<int, int>, 13> glVersions = {
     { { 4, 6 },
@@ -31,6 +32,7 @@ constexpr std::array<std::pair<int, int>, 13> glVersions = {
       { 2, 0 } },
 };
 }  // namespace
+#endif
 
 namespace sponge::platform::opengl::renderer {
 Context::Context() {

--- a/sponge/src/platform/opengl/renderer/shader.cpp
+++ b/sponge/src/platform/opengl/renderer/shader.cpp
@@ -174,9 +174,10 @@ uint32_t Shader::compileShader(const GLenum       type,
     return id;
 }
 
-uint32_t Shader::compileStage(const GLenum type, std::string_view stageName,
-                              const std::string& assetsFolder,
-                              const std::string& path) const {
+uint32_t Shader::compileStage(const GLenum                      type,
+                              [[maybe_unused]] std::string_view stageName,
+                              const std::string&                assetsFolder,
+                              const std::string&                path) const {
     SPONGE_GL_INFO("Loading {} shader file: [{}, {}]", stageName, shaderName,
                    path);
     const std::string source = loadGlslSource(assetsFolder + path);

--- a/sponge/src/platform/opengl/renderer/texture.cpp
+++ b/sponge/src/platform/opengl/renderer/texture.cpp
@@ -98,18 +98,18 @@ void Texture::loadFromFile(const std::string& path, const uint8_t flag) {
     const std::filesystem::path name{ path };
 
     int bytesPerPixel = 0;
-    int height        = 0;
-    int width         = 0;
+    int loadedHeight  = 0;
+    int loadedWidth   = 0;
 
-    auto* data =
-        stbi_load(name.string().data(), &width, &height, &bytesPerPixel, 0);
+    auto* data = stbi_load(name.string().data(), &loadedWidth, &loadedHeight,
+                           &bytesPerPixel, 0);
     if (data == nullptr) {
         SPONGE_GL_ERROR("Unable to load texture, path = {}: {}", name.string(),
                         stbi_failure_reason());
         return;
     }
 
-    generate(width, height, bytesPerPixel, data, flag);
+    generate(loadedWidth, loadedHeight, bytesPerPixel, data, flag);
 
     stbi_image_free(data);
 }

--- a/sponge/src/platform/opengl/renderer/texture.cpp
+++ b/sponge/src/platform/opengl/renderer/texture.cpp
@@ -45,11 +45,11 @@ Texture::~Texture() {
     glDeleteTextures(1, &id);
 }
 
-void Texture::createDepthMap(const uint32_t width,
-                             const uint32_t height) const {
+void Texture::createDepthMap(const uint32_t depthWidth,
+                             const uint32_t depthHeight) const {
     glBindTexture(GL_TEXTURE_2D, id);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0,
-                 GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, depthWidth, depthHeight,
+                 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);

--- a/sponge/src/platform/opengl/renderer/texture.hpp
+++ b/sponge/src/platform/opengl/renderer/texture.hpp
@@ -50,7 +50,7 @@ private:
     uint32_t height = 0;
 
     void loadFromFile(const std::string& path, uint8_t flag);
-    void createDepthMap(uint32_t width, uint32_t height) const;
+    void createDepthMap(uint32_t depthWidth, uint32_t depthHeight) const;
     void generate(uint32_t textureWidth, uint32_t textureHeight,
                   uint32_t bytesPerPixel, const uint8_t* data, uint8_t flag);
 };

--- a/sponge/src/platform/opengl/scene/mesh.cpp
+++ b/sponge/src/platform/opengl/scene/mesh.cpp
@@ -32,7 +32,7 @@ using sponge::scene::Vertex;
 
 uint32_t Mesh::meshProgramId = 0;
 
-std::shared_ptr<Shader> Mesh::shader;
+std::shared_ptr<Shader> Mesh::defaultShader;
 
 Mesh::Mesh(std::vector<Vertex>&& vertices, const std::size_t numVertices,
            std::vector<uint32_t>&& indices, const std::size_t numIndices,
@@ -61,9 +61,9 @@ Mesh::Mesh(std::vector<Vertex>&& vertices, const std::size_t numVertices,
         .vertexShaderPath   = "/shaders/glsl/pbr.vert.glsl",
         .fragmentShaderPath = "/shaders/glsl/pbr.frag.glsl",
     };
-    shader        = AssetManager::createShader(shaderCreateInfo);
-    meshProgramId = shader->getId();
-    shader->bind();
+    defaultShader = AssetManager::createShader(shaderCreateInfo);
+    meshProgramId = defaultShader->getId();
+    defaultShader->bind();
 
     vao = renderer::VertexArray::create();
     vao->bind();
@@ -96,7 +96,7 @@ Mesh::Mesh(std::vector<Vertex>&& vertices, const std::size_t numVertices,
         this->indices.data(), numIndices * sizeof(uint32_t));
     ebo->bind();
 
-    shader->unbind();
+    defaultShader->unbind();
     vao->unbind();
 }
 

--- a/sponge/src/platform/opengl/scene/mesh.hpp
+++ b/sponge/src/platform/opengl/scene/mesh.hpp
@@ -46,13 +46,13 @@ public:
     void render(const std::shared_ptr<renderer::Shader>& shader) const;
 
     static std::shared_ptr<renderer::Shader> getShader() {
-        return shader;
+        return defaultShader;
     }
 
 private:
     static constexpr std::string_view        shaderName = "mesh";
     static uint32_t                          meshProgramId;
-    static std::shared_ptr<renderer::Shader> shader;
+    static std::shared_ptr<renderer::Shader> defaultShader;
 
     std::unique_ptr<renderer::VertexBuffer> vbo;
     std::unique_ptr<renderer::IndexBuffer>  ebo;

--- a/sponge/src/platform/opengl/scene/model.cpp
+++ b/sponge/src/platform/opengl/scene/model.cpp
@@ -29,7 +29,7 @@
 #include <utility>
 
 namespace {
-constexpr double secondsToMilliseconds = 1000.F;
+[[maybe_unused]] constexpr double secondsToMilliseconds = 1000.F;
 }
 
 namespace sponge::platform::opengl::scene {
@@ -158,7 +158,7 @@ std::shared_ptr<Mesh>
 
     // calculate normals since they are missing
     if (attrib.normals.empty()) {
-        for (auto j = 0; j < vertices.size(); j += 3) {
+        for (size_t j = 0; j < vertices.size(); j += 3) {
             const auto p0 = vertices[j + 0].position;
             const auto p1 = vertices[j + 1].position;
             const auto p2 = vertices[j + 2].position;


### PR DESCRIPTION
Fixes #452

## Summary
- \`sponge/CMakeLists.txt\` and \`game/CMakeLists.txt\` declared their MSVC/Clang compile options (RTTI-disable, \`/W4 /WX\`, fast-math, etc.) with \`INTERFACE\` scope, which only propagates to targets that link against them — it never applied to their own translation units. \`sponge\`'s own ~80 source files were compiling without RTTI actually disabled and without warnings-as-errors ever checked against them; \`game\` only got these transitively via linking \`sponge\`'s (equally self-inert) properties. Switched both to \`PUBLIC\`.
- Enabling \`/W4 /WX\` for real on \`sponge\`'s sources surfaced two genuine issues:
  - A signed/unsigned loop comparison in \`model.cpp\` (\`auto j = 0\` compared against \`vertices.size()\`)
  - Three unused-function warnings in the vendored \`tinyobjloader\` header — can't edit third-party code per \`AGENTS.md\`, so suppressed the same way \`cgltf\` already is
- Two more warnings surfaced only under Release, where \`SPDLOG_ACTIVE_LEVEL=ERROR\` compiles out the debug-only log calls that were the sole use of a parameter (\`shader.cpp\`) and a constant (\`model.cpp\`) — marked \`[[maybe_unused]]\` since they're genuinely conditionally used depending on log level.

## Test plan
- [x] \`pre-commit run --all-files\` passes
- [x] Debug build (\`ci-windows-debug\`) compiles clean end to end
- [x] Release build (\`ci-windows-release\`) compiles clean end to end