### PR TITLE
build: use real cl.exe for windows-msvc-debug/release presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ cmake.exe -B build --preset windows-msvc-release
 cmake.exe --build build --target game --config Release
 ```
 
+`windows-msvc-debug`/`windows-msvc-release` use real `cl.exe` (`ci-windows-*`
+use `clang-cl`, which warns differently) — run both commands from a Developer
+Command Prompt, or `VsDevCmd.bat` first, so `cl.exe`/`rc.exe`/`INCLUDE`/`LIB`
+are on `PATH`.
+
 ## Running
 
 On Windows, you can find the maze executable will be found in the build directory.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -142,16 +142,25 @@
             "inherits": ["base-windows", "ninja", "release", "sccache", "vcpkg"]
         },
         {
+            "name": "msvc-cl",
+            "description": "Use real cl.exe instead of clang-cl; run from a Developer Command Prompt (VsDevCmd.bat) so cl.exe/rc.exe/INCLUDE/LIB are on PATH",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "cl",
+                "CMAKE_CXX_COMPILER": "cl"
+            }
+        },
+        {
             "name": "windows-msvc-debug",
             "displayName": "VSCode - Windows x64 - Debug",
             "description": "Sets debug build type and x64 arch",
-            "inherits": ["base-windows", "debug", "imgui", "ninja", "vcpkg"]
+            "inherits": ["base-windows", "debug", "imgui", "ninja", "msvc-cl", "vcpkg"]
         },
         {
             "name": "windows-msvc-release",
             "displayName": "VSCode - Windows x64 - Release",
             "description": "Sets release build type",
-            "inherits": ["base-windows", "ninja", "release", "vcpkg"]
+            "inherits": ["base-windows", "ninja", "release", "msvc-cl", "vcpkg"]
         },
         {
             "name": "base-osx",


### PR DESCRIPTION
## Summary
- `windows-msvc-debug`/`windows-msvc-release` had no explicit compiler set, so they picked up whatever the shell's `PATH` resolved first. On my dev machine that was `clang-cl` (same as `ci-windows-*`), which doesn't catch everything real `cl.exe` does — the `C4458` member-shadow warnings from #452/#453 only surfaced once CI's Windows job (which resolves to real `cl.exe` in its own environment) actually ran, three separate round-trips later.
- Added a `msvc-cl` fragment pinning `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER` to `cl`, applied to `windows-msvc-debug` and `windows-msvc-release`, so local builds via these presets can't silently drift to whatever compiler happens to be first on `PATH`. `ci-windows-*` untouched.
- Documented in `AGENTS.md` that these two presets need a Developer Command Prompt (or `VsDevCmd.bat` first) so `cl.exe`/`rc.exe`/`INCLUDE`/`LIB` resolve.

## Test plan
- [x] Fresh-configured and built both `windows-msvc-debug` (with ImGui) and `windows-msvc-release` from a `VsDevCmd`-initialized shell — both compile and link `maze.exe` clean end to end