### PR TITLE
fix: options menu Apply button and post-tonemap emissive clipping

### DIFF
--- a/assets/shaders/slang/pbr.slang
+++ b/assets/shaders/slang/pbr.slang
@@ -131,7 +131,7 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target {
     }
 
     float3 ambient = float3(params.ambientStrength) * albedo * ao;
-    float3 color   = ambient + Lo;
+    float3 color   = ambient + Lo + params.emissive + emissiveTexColor;
 
     // Reinhard HDR tone mapping
     color = color / (color + float3(1.0));
@@ -141,5 +141,5 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target {
 
     color = dither8(color, fragCoord.xy);
 
-    return float4(color + params.emissive + emissiveTexColor, 1.0);
+    return float4(color, 1.0);
 };

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -332,19 +332,6 @@ void OptionLayer::onAttach() {
         shadowQualityList->setItems({ "Low", "Normal", "High", "Ultra" });
     }
 
-    {
-        const auto currentShadowRes =
-            Maze::get().getMazeLayer()->getDirectionalLightShadowMapRes();
-        const auto it = std::ranges::find(shadowResolutions, currentShadowRes);
-        pendingShadowResIndex =
-            it != shadowResolutions.end() ?
-                static_cast<int>(it - shadowResolutions.begin()) :
-                1;
-        shadowQualityList->setSelectedIndex(
-            static_cast<size_t>(pendingShadowResIndex));
-        currentShadowResIndex = static_cast<size_t>(pendingShadowResIndex);
-    }
-
     const auto window        = Maze::get().getWindow();
     const auto currentWidth  = window->getWidth();
     const auto currentHeight = window->getHeight();
@@ -394,8 +381,7 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
         {
             const auto& input = mgr.getSnapshot();
             if (!wasActiveLastFrame) {
-                syncPendingCheckboxState();
-                updateChangeStatus();
+                resetSelectionToCurrentState();
                 waitForConfirmRelease = input.isHeld(GameAction::MenuConfirm);
             } else if (waitForConfirmRelease &&
                        !input.isHeld(GameAction::MenuConfirm)) {
@@ -807,6 +793,7 @@ void OptionLayer::syncPendingCheckboxState() {
         shadowQualityList->setSelectedIndex(
             static_cast<size_t>(pendingShadowResIndex));
     }
+    appliedShadowResIndex = pendingShadowResIndex;
 }
 
 void OptionLayer::updateChangeStatus() {
@@ -849,13 +836,11 @@ void OptionLayer::updateChangeStatus() {
     const auto currentShadowRes =
         Maze::get().getMazeLayer()->getDirectionalLightShadowMapRes();
     const auto sqIt = std::ranges::find(shadowResolutions, currentShadowRes);
-    currentShadowResIndex = sqIt != shadowResolutions.end() ?
-                                std::optional{ static_cast<size_t>(
-                                    sqIt - shadowResolutions.begin()) } :
-                                std::nullopt;
-    const bool shadowChanged =
-        shadowResolutions[static_cast<size_t>(pendingShadowResIndex)] !=
-        currentShadowRes;
+    currentShadowResIndex    = sqIt != shadowResolutions.end() ?
+                                   std::optional{ static_cast<size_t>(
+                                       sqIt - shadowResolutions.begin()) } :
+                                   std::nullopt;
+    const bool shadowChanged = pendingShadowResIndex != appliedShadowResIndex;
 
     hasUnappliedChanges = checkboxChanged || resolutionChanged || shadowChanged;
     returnButton->setMessage(hasUnappliedChanges ? applyMessage :

--- a/game/src/layer/optionlayer.hpp
+++ b/game/src/layer/optionlayer.hpp
@@ -49,6 +49,7 @@ private:
     bool pendingVsync          = false;
     bool pendingFxaa           = false;
     int  pendingShadowResIndex = 1;
+    int  appliedShadowResIndex = 1;  // baseline pendingShadowResIndex synced to
 
     std::unique_ptr<ui::SelectList> aspectRatioList;
     std::unique_ptr<ui::SelectList> resolutionList;

--- a/sponge/src/platform/opengl/scene/clusteredlights.hpp
+++ b/sponge/src/platform/opengl/scene/clusteredlights.hpp
@@ -16,7 +16,10 @@ class ClusteredLights {
 public:
     // Cluster grid — must match TILES_X/Y/Z in clustered.slang.
     // ponytail: fixed 16x9x24 grid (Doom 2016 shape); slices are less cubic
-    // at narrow FOV, which only coarsens culling, never causes artifacts.
+    // at narrow FOV (already reachable via scroll zoom, gamecamera.cpp),
+    // which only coarsens culling, never causes artifacts. upgrade: derive
+    // tilesX/Y/Z from FOV/aspect if profiling shows over-lit clusters at
+    // min FOV (30 deg).
     static constexpr int tilesX      = 16;
     static constexpr int tilesY      = 9;
     static constexpr int tilesZ      = 24;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,7 +37,10 @@
     },
     {
       "name": "mimalloc",
-      "version>=": "3.4.3"
+      "version>=": "3.4.3",
+      "features": [
+        "secure"
+      ]
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
## Summary
- Options menu showed "Apply" on first open with no changes: the resolution/aspect-ratio selection never resynced to the current window size on menu activation, and shadow-quality change detection compared a resolved preset value against a live re-read that could legitimately not match any of the four presets. Both now compare against a synced baseline (`appliedShadowResIndex`).
- Emissive was added after Reinhard tonemapping and gamma correction in `pbr.slang`, bypassing the tonemap curve and clipping inconsistently depending on whether bloom's float FBO or FXAA's 8-bit FBO was active. Moved it before tonemapping so it's treated like every other light term.
- Updated a `ponytail:` comment in `ClusteredLights`: FOV is already adjustable via scroll zoom, so the narrow-FOV cluster coarsening tradeoff is live today, not a future trigger.

Note: this branch also carries `chore: make mimalloc secure by default` (2400cf7), a pre-existing local commit from before this work that hasn't been pushed elsewhere yet.

## Test plan
- [ ] Build and open Options menu on first display — confirm it shows "Return", not "Apply"
- [ ] Cycle Shadow Quality and confirm "Apply" appears/clears correctly
- [ ] Visually check emissive materials (lava, screens, etc.) for brightness/clipping changes with bloom on and off