### PR TITLE
chore: enable freetype subpixel-rendering, harfbuzz freetype, spdlog fmt features

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,7 +37,10 @@
     },
     {
       "name": "mimalloc",
-      "version>=": "3.4.3"
+      "version>=": "3.4.3",
+      "features": [
+        "secure"
+      ]
     },
     {
       "name": "nlohmann-json",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,10 @@
     },
     {
       "name": "freetype",
-      "version>=": "2.14.3"
+      "version>=": "2.14.3",
+      "features": [
+        "subpixel-rendering"
+      ]
     },
     {
       "name": "glfw3",
@@ -21,7 +24,10 @@
     },
     {
       "name": "harfbuzz",
-      "version>=": "14.3.0"
+      "version>=": "14.3.0",
+      "features": [
+        "freetype"
+      ]
     },
     {
       "name": "imgui",
@@ -52,7 +58,10 @@
     },
     {
       "name": "spdlog",
-      "version>=": "1.17.0"
+      "version>=": "1.17.0",
+      "features": [
+        "fmt"
+      ]
     },
     {
       "name": "tracy",


### PR DESCRIPTION
## Summary
- Enable freetype's `subpixel-rendering` feature (matches the LCD/ClearType-style glyph rendering already in `fontatlas.cpp` via `FT_RENDER_MODE_LCD`)
- Enable harfbuzz's `freetype` integration feature
- Enable spdlog's `fmt` feature (matches `-DSPDLOG_FMT_EXTERNAL` already set in the build)

Note: this branch also carries `chore: make mimalloc secure by default` (2400cf7), a pre-existing local commit from before this work that hasn't been pushed elsewhere yet.

## Test plan
- [ ] Clean vcpkg install/build succeeds with the new features