### PR TITLE
chore: update vcpkg dependencies

### DIFF
--- a/sponge/src/platform/opengl/scene/model.cpp
+++ b/sponge/src/platform/opengl/scene/model.cpp
@@ -362,10 +362,8 @@ ModelData Model::parseGltf(const std::string&           path,
         cgltf_node_transform_world(&node, worldMatrix.data());
         const auto transform = glm::make_mat4(worldMatrix.data());
 
-        [[maybe_unused]] const auto* nodeName =
-            node.name != nullptr ? node.name : "unnamed";
         for (size_t p = 0; p < node.mesh->primitives_count; p++) {
-            SPONGE_GL_INFO("Loading mesh: [{}, primitive {}]", nodeName, p);
+            SPONGE_GL_INFO("Loading mesh: [primitive {}]", p);
             auto parsedMesh =
                 parseGltfPrimitive(node.mesh->primitives[p], transform, path);
             if (!parsedMesh) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "maze",
   "version-string": "latest",
-  "builtin-baseline": "94a541197763a4f449a1b91478df48c0584a6256",
+  "builtin-baseline": "809d4e072ea48e74bc0c5e6c1227a5cc636a63ad",
   "dependencies": [
     {
       "name": "fmt",
@@ -43,7 +43,7 @@
     },
     {
       "name": "mimalloc",
-      "version>=": "3.4.5",
+      "version>=": "3.5.0",
       "features": [
         "secure"
       ]


### PR DESCRIPTION
## Summary
- Bump vcpkg builtin-baseline to `809d4e0`
- Raise mimalloc floor to 3.5.0
- Drop the node name from the glTF mesh load log line

## Test plan
- Build with the new baseline and load a glTF model