### PR TITLE
refactor(render): tone map once, after bloom, in linear space

### DIFF
--- a/assets/shaders/slang/bloom.slang
+++ b/assets/shaders/slang/bloom.slang
@@ -1,12 +1,12 @@
-// bloom.slang: brightness extraction, Dual Kawase bloom pipeline, composite
+// bloom.slang: brightness extraction + Dual Kawase blur chain.
+// The composite lives in tonemap.slang, which adds bloom in linear light.
 #include "include/kawase.slang"
-#include "include/dither.slang"
 
 [[vk::binding(0)]] Sampler2D<float4> image;
+// The matching down-level, accumulated by the upsample pass.
 [[vk::binding(1)]] Sampler2D<float4> bloomTex;
 uniform float                        threshold;
 uniform float                        offset;
-uniform float                        intensity;
 uniform float                        accumulate;
 
 struct FSInput {
@@ -48,13 +48,4 @@ float4 upFragMain(FSInput input) : SV_Target {
     float3 blurred = kawaseUp(image, input.texCoords, offset).rgb;
     float3 down    = bloomTex.Sample(input.texCoords).rgb;
     return float4(lerp(blurred, lerp(down, blurred, SCATTER), accumulate), 1.0);
-};
-
-// clang-format off
-[shader("fragment")]
-float4 compositeFragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target {
-    // clang-format on
-    float3 color = image.Sample(input.texCoords).rgb;
-    float3 bloom = bloomTex.Sample(input.texCoords).rgb;
-    return float4(dither8(color + bloom * intensity, fragCoord.xy), 1.0);
 };

--- a/assets/shaders/slang/cube.slang
+++ b/assets/shaders/slang/cube.slang
@@ -2,6 +2,11 @@
 uniform float4x4 mvp;
 uniform float3   lightColor;
 
+// The cubes mark light positions, so they read as emitters. Radiance 1.0 is
+// mid-grey once tone mapped (1/(1+1) = 0.5); this keeps them near white and
+// above the bloom threshold, which is now a linear radiance value.
+static const float emissiveStrength = 8.0;
+
 struct VSInput {
     float3 position : POSITION;
 };
@@ -16,7 +21,7 @@ VSOutput vertMain(VSInput input) {
     // clang-format on
     VSOutput output;
     output.pos   = mul(mvp, float4(input.position, 1.0));
-    output.color = lightColor;
+    output.color = lightColor * emissiveStrength;
     return output;
 };
 

--- a/assets/shaders/slang/fxaa.slang
+++ b/assets/shaders/slang/fxaa.slang
@@ -1,4 +1,4 @@
-// fxaa.slang: fullscreen quad vertex + FXAA 3.11 (quality preset 12) + bloom overlay
+// fxaa.slang: fullscreen quad vertex + FXAA 3.11 (quality preset 12)
 // FXAA based on Timothy Lottes / NVIDIA, adapted to Slang.
 #include "include/dither.slang"
 
@@ -23,9 +23,7 @@ VSOutput vertMain(VSInput input) {
 };
 
 [[vk::binding(0)]] Sampler2D<float4> screenTexture;
-[[vk::binding(1)]] Sampler2D<float4> bloomTex;
 uniform float2                       rcpFrame;
-uniform float                        bloomIntensity;
 
 // Quality preset 12: 5-step search (1.5, 2.0, 2.0, 2.0, 8.0)
 static const float FXAA_SUBPIX             = 0.75;
@@ -149,9 +147,6 @@ struct FSInput {
 float4 fragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target {
     // clang-format on
     float4 color = fxaaPass(input.texCoords);
-    if (bloomIntensity > 0.0) {
-        color.rgb += bloomTex.Sample(input.texCoords).rgb * bloomIntensity;
-    }
-    color.rgb = dither8(color.rgb, fragCoord.xy);
+    color.rgb    = dither8(color.rgb, fragCoord.xy);
     return color;
 };

--- a/assets/shaders/slang/pbr.slang
+++ b/assets/shaders/slang/pbr.slang
@@ -2,7 +2,6 @@
 #include "include/uniforms.slang"
 #include "include/shadows.slang"
 #include "include/clustered.slang"
-#include "include/dither.slang"
 
 struct PointLightGPU {
     float3 color;
@@ -133,13 +132,7 @@ float4 fragMain(VSOutput input, float4 fragCoord : SV_Position) : SV_Target {
     float3 ambient = float3(params.ambientStrength) * albedo * ao;
     float3 color   = ambient + Lo + params.emissive + emissiveTexColor;
 
-    // Reinhard HDR tone mapping
-    color = color / (color + float3(1.0));
-
-    // Gamma correction
-    color = pow(color, float3(1.0 / 2.2));
-
-    color = dither8(color, fragCoord.xy);
-
+    // Linear HDR out. Tone mapping, gamma and dither happen once in
+    // tonemap.slang, after bloom has extracted from this unbounded radiance.
     return float4(color, 1.0);
 };

--- a/assets/shaders/slang/taa.slang
+++ b/assets/shaders/slang/taa.slang
@@ -16,7 +16,6 @@ struct FSInput {
 [[vk::binding(4)]] Sampler2D<float4> velocityTex;
 
 uniform float2 rcpFrame;
-uniform float  bloomIntensity;
 // 1.0 discards history entirely (first frame after a resize or a mode change)
 uniform float    historyBlend;
 uniform float4x4 invViewProj;   // inverse of this frame's jittered view-proj

--- a/assets/shaders/slang/taa.slang
+++ b/assets/shaders/slang/taa.slang
@@ -13,7 +13,6 @@ struct FSInput {
 [[vk::binding(0)]] Sampler2D<float4> currentTex;
 [[vk::binding(1)]] Sampler2D<float4> historyTex;
 [[vk::binding(2)]] Sampler2D<float4> depthTex;
-[[vk::binding(3)]] Sampler2D<float4> bloomTex;
 [[vk::binding(4)]] Sampler2D<float4> velocityTex;
 
 uniform float2 rcpFrame;
@@ -23,14 +22,10 @@ uniform float    historyBlend;
 uniform float4x4 invViewProj;   // inverse of this frame's jittered view-proj
 uniform float4x4 prevViewProj;  // last frame's unjittered view-proj
 
-// Scene colour as it will be presented, so the clamp box and the history are
-// in the same space.
+// The input is already the resolved display image (bloom composited, tone
+// mapped), so the clamp box and the history are in the same space.
 float3 sceneColor(float2 uv) {
-    float3 color = currentTex.Sample(uv).rgb;
-    if (bloomIntensity > 0.0) {
-        color += bloomTex.Sample(uv).rgb * bloomIntensity;
-    }
-    return color;
+    return currentTex.Sample(uv).rgb;
 }
 
 // Catmull-Rom history filter (5-tap form of the 9-tap bicubic).

--- a/assets/shaders/slang/tonemap.slang
+++ b/assets/shaders/slang/tonemap.slang
@@ -13,10 +13,10 @@ struct FSInput {
 [[vk::binding(1)]] Sampler2D<float4> bloomTex;
 
 uniform float bloomIntensity;
-// Non-zero only when this pass writes the final 8-bit target. Anti-aliasing
+// True only when this pass writes the final 8-bit target. Anti-aliasing
 // runs after it and dithers on its own write, and dithering into an
 // intermediate float target would just seed noise for TAA to accumulate.
-uniform float ditherOutput;
+uniform bool ditherOutput;
 
 // clang-format off
 [shader("fragment")]
@@ -32,7 +32,7 @@ float4 fragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target {
 
     color = pow(color, float3(1.0 / 2.2));
 
-    if (ditherOutput > 0.0) {
+    if (ditherOutput) {
         color = dither8(color, fragCoord.xy);
     }
     return float4(color, 1.0);

--- a/assets/shaders/slang/tonemap.slang
+++ b/assets/shaders/slang/tonemap.slang
@@ -1,0 +1,39 @@
+// tonemap.slang: resolves the linear HDR scene to a display image.
+// Composites bloom in linear light, then tone maps and gamma encodes. This is
+// the only place the pipeline leaves linear space — the scene pass and the
+// bloom chain both run on unbounded radiance, so the bloom threshold is a real
+// radiance value rather than a point on an already-compressed curve.
+#include "include/dither.slang"
+
+struct FSInput {
+    float2 texCoords : TEXCOORD0;
+};
+
+[[vk::binding(0)]] Sampler2D<float4> sceneTex;
+[[vk::binding(1)]] Sampler2D<float4> bloomTex;
+
+uniform float bloomIntensity;
+// Non-zero only when this pass writes the final 8-bit target. Anti-aliasing
+// runs after it and dithers on its own write, and dithering into an
+// intermediate float target would just seed noise for TAA to accumulate.
+uniform float ditherOutput;
+
+// clang-format off
+[shader("fragment")]
+float4 fragMain(FSInput input, float4 fragCoord : SV_Position) : SV_Target {
+    // clang-format on
+    float3 color = sceneTex.Sample(input.texCoords).rgb;
+    if (bloomIntensity > 0.0) {
+        color += bloomTex.Sample(input.texCoords).rgb * bloomIntensity;
+    }
+
+    // Reinhard
+    color = color / (color + float3(1.0));
+
+    color = pow(color, float3(1.0 / 2.2));
+
+    if (ditherOutput > 0.0) {
+        color = dither8(color, fragCoord.xy);
+    }
+    return float4(color, 1.0);
+};

--- a/cmake/CompileSlang.cmake
+++ b/cmake/CompileSlang.cmake
@@ -54,13 +54,15 @@ compile_slang_shader(blur.slang                downFragMain      blur.frag.glsl)
 compile_slang_shader(blur.slang                upFragMain        blur_up.frag.glsl)
 
 # Bloom pipeline
-compile_slang_shader(bloom.slang               compositeFragMain bloom_composite.frag.glsl)
 compile_slang_shader(bloom.slang               downFragMain      bloom_down.frag.glsl)
 compile_slang_shader(bloom.slang               extractFragMain   bloom_extract.frag.glsl)
 compile_slang_shader(bloom.slang               upFragMain        bloom_up.frag.glsl)
 
 # FXAA
 compile_slang_shader(fxaa.slang                fragMain   fxaa.frag.glsl)
+
+# Tone mapping / resolve
+compile_slang_shader(tonemap.slang             fragMain   tonemap.frag.glsl)
 
 # TAA
 compile_slang_shader(taa.slang                 resolveFragMain taa_resolve.frag.glsl)

--- a/game/src/AGENTS.md
+++ b/game/src/AGENTS.md
@@ -39,9 +39,11 @@ primitives, windowing, or platform backends itself — see
   post-process resize, shadow map FBO rebuild) is set via an atomic flag +
   payload and consumed in `onRender()` on the GL thread; don't apply it inline
   where it's requested.
-* `bloomIntensity` compensates the soft-knee bloom extract (passes only
-  above-threshold energy); don't "simplify" it back toward the old hard
-  threshold without re-deriving the constant.
+* `bloomThreshold` and `bloomIntensity` operate on LINEAR radiance and are
+  applied before tone mapping. The bloom texture holds unbounded values, not
+  the [0,1] ones it held when bloom composited after the curve, so both
+  settings are roughly an order of magnitude smaller than they once were.
+  Re-derive them from a texture readback, never by scaling the old numbers.
 
 ## Anti-patterns
 

--- a/game/src/AGENTS.md
+++ b/game/src/AGENTS.md
@@ -41,9 +41,11 @@ primitives, windowing, or platform backends itself — see
   where it's requested.
 * `bloomThreshold` and `bloomIntensity` operate on LINEAR radiance and are
   applied before tone mapping. The bloom texture holds unbounded values, not
-  the [0,1] ones it held when bloom composited after the curve, so both
-  settings are roughly an order of magnitude smaller than they once were.
-  Re-derive them from a texture readback, never by scaling the old numbers.
+  the [0,1] ones it held when bloom composited after the curve, so
+  `bloomIntensity` is roughly an order of magnitude smaller than it once was.
+  `bloomThreshold` stays at 0.8, but it now cuts on radiance, not on a point
+  of the tone curve, so useful values run past 1.0. Re-derive both from a
+  texture readback, never by scaling the old numbers.
 
 ## Anti-patterns
 

--- a/game/src/layer/imgui/imguilayer.cpp
+++ b/game/src/layer/imgui/imguilayer.cpp
@@ -194,7 +194,9 @@ void ImGuiLayer::showBloomControls() {
             ImGui::Text("Threshold");
             ImGui::TableNextColumn();
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-            if (ImGui::SliderFloat("##bloomthreshold", &threshold, 0.F, 1.F,
+            // Radiance now, not a point on a tone curve, so useful values
+            // run past 1.0.
+            if (ImGui::SliderFloat("##bloomthreshold", &threshold, 0.F, 4.F,
                                    "%.2f", ImGuiSliderFlags_AlwaysClamp)) {
                 mazeLayer->setBloomThreshold(threshold);
             }
@@ -205,8 +207,10 @@ void ImGuiLayer::showBloomControls() {
             ImGui::Text("Intensity");
             ImGui::TableNextColumn();
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-            if (ImGui::SliderFloat("##bloomintensity", &intensity, 0.F, 5.F,
-                                   "%.2f", ImGuiSliderFlags_AlwaysClamp)) {
+            // Weights a linear-space radiance texture, so the whole useful
+            // range sits below 1.0.
+            if (ImGui::SliderFloat("##bloomintensity", &intensity, 0.F, 0.5F,
+                                   "%.3f", ImGuiSliderFlags_AlwaysClamp)) {
                 mazeLayer->setBloomIntensity(intensity);
             }
         });

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -98,6 +98,7 @@ using sponge::platform::opengl::scene::FXAA;
 using sponge::platform::opengl::scene::Mesh;
 using sponge::platform::opengl::scene::Model;
 using sponge::platform::opengl::scene::ModelCreateInfo;
+using sponge::platform::opengl::scene::SceneTarget;
 using sponge::platform::opengl::scene::ShadowMap;
 using sponge::platform::opengl::scene::TAA;
 
@@ -171,6 +172,10 @@ void MazeLayer::finishLoading(std::vector<std::shared_ptr<Model>> builtModels) {
 
     bloom = std::make_unique<Bloom>(Maze::get().getWindow()->getWidth(),
                                     Maze::get().getWindow()->getHeight());
+
+    sceneTarget =
+        std::make_unique<SceneTarget>(Maze::get().getWindow()->getWidth(),
+                                      Maze::get().getWindow()->getHeight());
 
     queueResize(Maze::get().getWindow()->getWidth(),
                 Maze::get().getWindow()->getHeight());
@@ -420,6 +425,9 @@ void MazeLayer::onRender() {
         if (bloom) {
             bloom->resize(w, h);
         }
+        if (sceneTarget) {
+            sceneTarget->resize(w, h);
+        }
         screenWidth  = static_cast<int32_t>(w);
         screenHeight = static_cast<int32_t>(h);
         createDepthPrepassFbo(static_cast<int>(w), static_cast<int>(h));
@@ -452,30 +460,18 @@ void MazeLayer::onRender() {
                                 frame.cameraView, frame.cameraProjection);
     }
 
-    // Phase 4: opaque pass
+    // Phase 4: opaque pass, into the linear HDR scene target.
     const bool fxaaActive = frame.antiAliasing == AntiAliasing::Fxaa && fxaa;
     const bool taaActive  = frame.antiAliasing == AntiAliasing::Taa && taa;
-    const bool hasFbo =
-        (frame.bloomEnabled && bloom != nullptr) || fxaaActive || taaActive;
-    if (frame.bloomEnabled && bloom) {
-        bloom->begin();
-    } else if (fxaaActive) {
-        fxaa->begin();
-    } else if (taaActive) {
-        taa->begin();
-    }
 
-    if (hasFbo) {
-        // Blit prepass depth into the post-processing FBO so the opaque pass
-        // can use GL_LEQUAL (zero overdraw). Both FBOs use
-        // GL_DEPTH_COMPONENT24.
-        blitDepthToCurrentFbo(frame.screenWidth, frame.screenHeight);
-        glClear(GL_COLOR_BUFFER_BIT);
-        glDepthFunc(GL_LEQUAL);
-        glDepthMask(GL_FALSE);
-    } else {
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    }
+    sceneTarget->begin();
+
+    // Blit prepass depth in so the opaque pass can use GL_LEQUAL (zero
+    // overdraw). Both FBOs use GL_DEPTH_COMPONENT24.
+    blitDepthToCurrentFbo(frame.screenWidth, frame.screenHeight);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDepthFunc(GL_LEQUAL);
+    glDepthMask(GL_FALSE);
 
     renderGameObjects(frame);
 
@@ -484,38 +480,45 @@ void MazeLayer::onRender() {
     // on the opaque pass's GL_LEQUAL / depth-write-off state.
     renderLightCubes(frame);
 
-    if (hasFbo) {
-        glDepthMask(GL_TRUE);
-        glDepthFunc(GL_LESS);
+    glDepthMask(GL_TRUE);
+    glDepthFunc(GL_LESS);
+    sceneTarget->end();
+
+    // Phase 5: bloom, extracted from linear radiance rather than from an
+    // already tone-mapped image.
+    uint32_t bloomTexture   = 0;
+    float    bloomIntensity = 0.F;
+    if (frame.bloomEnabled && bloom) {
+        bloom->process(sceneTarget->getTexture(), frame.bloomThreshold);
+        bloomTexture   = bloom->getBloomTexture();
+        bloomIntensity = frame.bloomIntensity;
     }
 
-    if (frame.bloomEnabled && bloom) {
-        bloom->end();
-        bloom->process(frame.bloomThreshold);
-        if (fxaaActive) {
-            fxaa->applyWithBloom(bloom->getSceneTexture(),
-                                 bloom->getBloomTexture(),
-                                 frame.bloomIntensity);
-        } else if (taaActive) {
-            taa->apply(bloom->getSceneTexture(), depthPrepassTexture,
-                       velocityTexture, bloom->getBloomTexture(),
-                       frame.bloomIntensity, frame.invCameraMVP,
-                       frame.prevCameraViewProj);
-        } else {
-            bloom->apply(frame.bloomIntensity);
-        }
-    } else if (fxaaActive) {
+    // Phase 6: resolve to display. Anti-aliasing, when on, consumes the
+    // resolved image and does its own dithered write to the back buffer.
+    if (fxaaActive) {
+        fxaa->begin();
+    } else if (taaActive) {
+        taa->begin();
+    }
+
+    sceneTarget->resolve(bloomTexture, bloomIntensity,
+                         !fxaaActive && !taaActive);
+
+    if (fxaaActive) {
         fxaa->end();
         fxaa->apply();
     } else if (taaActive) {
+        // ponytail: TAA accumulates the tone-mapped image, which is where it
+        // already ran. Accumulating in linear with a reversible weighting curve
+        // resolves highlight edges better; that is a change to TAA, not to the
+        // pass order this commit is fixing.
         taa->end();
         taa->apply(taa->getSceneTexture(), depthPrepassTexture, velocityTexture,
-                   0, 0.F, frame.invCameraMVP, frame.prevCameraViewProj);
+                   frame.invCameraMVP, frame.prevCameraViewProj);
     }
 
-    if (hasFbo) {
-        glDepthFunc(GL_LEQUAL);
-    }
+    glDepthFunc(GL_LEQUAL);
 }
 
 float MazeLayer::getAmbientOcclusion() const {

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -486,12 +486,15 @@ void MazeLayer::onRender() {
 
     // Phase 5: bloom, extracted from linear radiance rather than from an
     // already tone-mapped image.
-    uint32_t bloomTexture   = 0;
-    float    bloomIntensity = 0.F;
+    // Named apart from the bloomIntensity member on purpose: that one is the
+    // ImGui-mutated setting behind settingsMutex, and the render thread must
+    // only ever see it through the snapshot.
+    uint32_t bloomTexId  = 0;
+    float    bloomWeight = 0.F;
     if (frame.bloomEnabled && bloom) {
         bloom->process(sceneTarget->getTexture(), frame.bloomThreshold);
-        bloomTexture   = bloom->getBloomTexture();
-        bloomIntensity = frame.bloomIntensity;
+        bloomTexId  = bloom->getBloomTexture();
+        bloomWeight = frame.bloomIntensity;
     }
 
     // Phase 6: resolve to display. Anti-aliasing, when on, consumes the
@@ -502,8 +505,7 @@ void MazeLayer::onRender() {
         taa->begin();
     }
 
-    sceneTarget->resolve(bloomTexture, bloomIntensity,
-                         !fxaaActive && !taaActive);
+    sceneTarget->resolve(bloomTexId, bloomWeight, !fxaaActive && !taaActive);
 
     if (fxaaActive) {
         fxaa->end();

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -425,9 +425,7 @@ void MazeLayer::onRender() {
         if (bloom) {
             bloom->resize(w, h);
         }
-        if (sceneTarget) {
-            sceneTarget->resize(w, h);
-        }
+        sceneTarget->resize(w, h);
         screenWidth  = static_cast<int32_t>(w);
         screenHeight = static_cast<int32_t>(h);
         createDepthPrepassFbo(static_cast<int>(w), static_cast<int>(h));
@@ -516,8 +514,8 @@ void MazeLayer::onRender() {
         // resolves highlight edges better; that is a change to TAA, not to the
         // pass order this commit is fixing.
         taa->end();
-        taa->apply(taa->getSceneTexture(), depthPrepassTexture, velocityTexture,
-                   frame.invCameraMVP, frame.prevCameraViewProj);
+        taa->apply(depthPrepassTexture, velocityTexture, frame.invCameraMVP,
+                   frame.prevCameraViewProj);
     }
 
     glDepthFunc(GL_LEQUAL);

--- a/game/src/layer/mazelayer.cpp
+++ b/game/src/layer/mazelayer.cpp
@@ -91,6 +91,7 @@ using sponge::input::GameAction;
 using sponge::input::InputSnapshot;
 using sponge::platform::glfw::core::Application;
 using sponge::platform::opengl::renderer::AssetManager;
+using sponge::platform::opengl::renderer::createRenderTarget;
 using sponge::platform::opengl::scene::Bloom;
 using sponge::platform::opengl::scene::ClusteredLights;
 using sponge::platform::opengl::scene::Cube;
@@ -770,27 +771,16 @@ void MazeLayer::createDepthPrepassFbo(const int w, const int h) {
         glDeleteFramebuffers(1, &depthPrepassFbo);
     }
 
-    glGenTextures(1, &depthPrepassTexture);
-    glBindTexture(GL_TEXTURE_2D, depthPrepassTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24,
-                 static_cast<GLsizei>(w), static_cast<GLsizei>(h), 0,
-                 GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    depthPrepassTexture = createRenderTarget(
+        static_cast<uint32_t>(w), static_cast<uint32_t>(h),
+        GL_DEPTH_COMPONENT24, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, GL_NEAREST);
 
     // RG16F holds a UV delta, not an absolute UV: at 1920 wide a one-pixel
     // motion is ~5e-4, which a half float carries accurately as a delta and
     // would quantise to worse than a pixel as an absolute coordinate.
-    glGenTextures(1, &velocityTexture);
-    glBindTexture(GL_TEXTURE_2D, velocityTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RG16F, static_cast<GLsizei>(w),
-                 static_cast<GLsizei>(h), 0, GL_RG, GL_FLOAT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    velocityTexture =
+        createRenderTarget(static_cast<uint32_t>(w), static_cast<uint32_t>(h),
+                           GL_RG16F, GL_RG, GL_FLOAT, GL_NEAREST);
 
     glGenFramebuffers(1, &depthPrepassFbo);
     glBindFramebuffer(GL_FRAMEBUFFER, depthPrepassFbo);

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -11,6 +11,7 @@
 #include "platform/opengl/scene/cube.hpp"
 #include "platform/opengl/scene/fxaa.hpp"
 #include "platform/opengl/scene/model.hpp"
+#include "platform/opengl/scene/scenetarget.hpp"
 #include "platform/opengl/scene/shadowmap.hpp"
 #include "platform/opengl/scene/taa.hpp"
 #include "scene/gamecamera.hpp"
@@ -152,8 +153,9 @@ private:
     std::unique_ptr<sponge::platform::opengl::scene::Cube> cube;
     std::unique_ptr<sponge::platform::opengl::scene::FXAA> fxaa;
     std::unique_ptr<sponge::platform::opengl::scene::TAA>  taa;
-    std::unique_ptr<sponge::platform::opengl::scene::Bloom>     bloom;
-    std::unique_ptr<sponge::platform::opengl::scene::ShadowMap> shadowMap;
+    std::unique_ptr<sponge::platform::opengl::scene::Bloom>       bloom;
+    std::unique_ptr<sponge::platform::opengl::scene::SceneTarget> sceneTarget;
+    std::unique_ptr<sponge::platform::opengl::scene::ShadowMap>   shadowMap;
 
     // Double-buffered snapshots: update writes, render reads, no overlap.
     std::array<thread::MazeRenderFrame, 2> renderFrames;

--- a/game/src/layer/mazelayer.hpp
+++ b/game/src/layer/mazelayer.hpp
@@ -212,9 +212,13 @@ private:
     thread::AntiAliasing antiAliasing     = thread::AntiAliasing::Taa;
     bool                 bloomEnabled     = true;
     float                bloomThreshold   = 0.8F;
-    // Compensates the soft-knee extract, which passes only above-threshold
-    // energy (the old hard threshold passed the full pixel color).
-    float   bloomIntensity     = 2.5F;
+    // Additive weight for the bloom texture, applied in LINEAR space before
+    // tone mapping. The bloom texture holds radiance (measured peak ~2.6 in
+    // this scene), not the [0,1] tone-mapped values it held when bloom
+    // composited after the curve, so this is roughly 1/30th of the old value
+    // for the same look. Re-derive it against a measurement, never by
+    // scaling the old number.
+    float   bloomIntensity     = 0.08F;
     bool    mouseButtonPressed = false;
     int32_t numLights          = 0;
 #ifdef ENABLE_IMGUI

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -161,15 +161,16 @@ float computeMaxCycleValueWidth() {
         });
 }
 
+// video.vsync is not here: it applies and persists the moment its checkbox is
+// toggled, so it never waits for Apply.
 void saveVideoSettings(const uint32_t width, const uint32_t height,
-                       const bool fullscreen, const bool vsync,
+                       const bool                       fullscreen,
                        const game::thread::AntiAliasing antiAliasing,
                        const uint32_t                   shadowRes) {
     using sponge::core::Settings;
     Settings::set("video.width", width);
     Settings::set("video.height", height);
     Settings::set("video.fullscreen", fullscreen);
-    Settings::set("video.vsync", vsync);
     Settings::set("video.aa", static_cast<uint32_t>(antiAliasing));
     Settings::set("video.shadowRes", shadowRes);
     Settings::save();
@@ -613,6 +614,15 @@ void OptionLayer::togglePending(const OptionMenuItem item) {
         return;
     }
     *pending = !*pending;
+
+    // Vsync applies on the spot — unlike resolution and fullscreen it needs no
+    // batching, so it never lights up the Apply button.
+    if (item == OptionMenuItem::VerticalSync) {
+        Maze::get().requestVerticalSync(pendingVsync);
+        sponge::core::Settings::set("video.vsync", pendingVsync);
+        sponge::core::Settings::save();
+    }
+
     updateChangeStatus();
 }
 
@@ -782,14 +792,13 @@ void OptionLayer::applyChanges() {
     if (pendingFullscreen != Maze::get().isFullscreen()) {
         Maze::get().toggleFullscreen();
     }
-    Maze::get().requestVerticalSync(pendingVsync);
     const auto aaMode = aaModes[static_cast<size_t>(pendingAaIndex)];
     Maze::get().setAntiAliasing(aaMode);
     const auto shadowRes =
         shadowResolutions[static_cast<size_t>(pendingShadowResIndex)];
     Maze::get().getMazeLayer()->setShadowMapRes(shadowRes);
-    saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, pendingVsync,
-                      aaMode, shadowRes);
+    saveVideoSettings(saveWidth, saveHeight, pendingFullscreen, aaMode,
+                      shadowRes);
 
     syncPendingCheckboxState();
     hasUnappliedChanges = false;

--- a/game/src/maze.cpp
+++ b/game/src/maze.cpp
@@ -52,7 +52,7 @@ bool Maze::onUserCreate() {
     setBloomThreshold(std::stof(
         sponge::core::Settings::getString("video.bloomThreshold", "0.8")));
     setBloomIntensity(std::stof(
-        sponge::core::Settings::getString("video.bloomIntensity", "2.5")));
+        sponge::core::Settings::getString("video.bloomIntensity", "0.08")));
 
     return true;
 }

--- a/game/src/thread/mazeframe.hpp
+++ b/game/src/thread/mazeframe.hpp
@@ -77,7 +77,7 @@ struct MazeRenderFrame {
 
     bool  bloomEnabled{ false };
     float bloomThreshold{ 0.8F };
-    float bloomIntensity{ 2.5F };
+    float bloomIntensity{ 0.08F };
 };
 
 }  // namespace game::thread

--- a/sponge/src/platform/AGENTS.md
+++ b/sponge/src/platform/AGENTS.md
@@ -44,6 +44,15 @@ than calling GLFW/OpenGL/OS APIs directly.
   FBO rebuilds are deferred to the render thread the same way viewport resize
   is (pending-flag pattern above) — never rebuild the FBO from the thread
   that requested the change.
+* The pipeline is: scene to a linear HDR `SceneTarget` -> bloom extracts and
+  blurs in linear -> `SceneTarget::resolve()` composites bloom, tone maps,
+  gamma encodes. Nothing upstream of resolve() may tone map, or the bloom
+  threshold stops being a radiance value.
+* Dither exactly once, at the final 8-bit write, and keep every intermediate
+  target float (`GL_RGB16F`). An 8-bit intermediate quantises undithered and
+  then quantises again at the real output — the banding `dither8` exists to
+  prevent. resolve() dithers only when it writes the back buffer directly;
+  when FXAA or TAA follows, each dithers on its own final write instead.
 * Anti-aliasing is a three-way mode (`AntiAliasing::None/Fxaa/Taa`), not a
   toggle. `FXAA` is single-pass; `TAA` jitters the camera with Halton(2,3),
   accumulates into a ping-pong `GL_RGB16F` history, and reprojects it through

--- a/sponge/src/platform/opengl/renderer/gl.hpp
+++ b/sponge/src/platform/opengl/renderer/gl.hpp
@@ -3,3 +3,31 @@
 #include "core/base.hpp"
 
 #include <glad/gl.h>
+
+#include <cstdint>
+
+namespace sponge::platform::opengl::renderer {
+
+// FBO attachment: allocate, upload nothing, no mip chain. Wrap is always
+// CLAMP_TO_EDGE — every sampler reading one of these reads neighbouring
+// texels, and wrapping would pull in the opposite edge of the screen.
+// Callers needing another wrap (EVSM's border-colour moment map) rebind and
+// override.
+inline uint32_t createRenderTarget(const uint32_t width, const uint32_t height,
+                                   const GLint  internalFormat,
+                                   const GLenum format, const GLenum type,
+                                   const GLint filter) {
+    uint32_t id = 0;
+    glGenTextures(1, &id);
+    glBindTexture(GL_TEXTURE_2D, id);
+    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, static_cast<GLsizei>(width),
+                 static_cast<GLsizei>(height), 0, format, type, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    return id;
+}
+
+}  // namespace sponge::platform::opengl::renderer

--- a/sponge/src/platform/opengl/renderer/texture.cpp
+++ b/sponge/src/platform/opengl/renderer/texture.cpp
@@ -5,7 +5,6 @@
 
 #include <stb_image.h>
 
-#include <array>
 #include <filesystem>
 #include <string>
 
@@ -27,10 +26,6 @@ Texture::Texture(const TextureCreateInfo& createInfo) {
                     .string();
 
         loadFromFile(texturePath, createInfo.loadFlag);
-    } else if ((createInfo.loadFlag & DepthMap) == DepthMap) {
-        SPONGE_GL_INFO("Creating depth map texture: [{}, {}x{}]",
-                       createInfo.name, createInfo.width, createInfo.height);
-        createDepthMap(createInfo.width, createInfo.height);
     } else if (createInfo.data != nullptr) {
         SPONGE_GL_INFO("Creating texture from memory: [{}, {}x{}]",
                        createInfo.name, createInfo.width, createInfo.height);
@@ -43,20 +38,6 @@ Texture::Texture(const TextureCreateInfo& createInfo) {
 
 Texture::~Texture() {
     glDeleteTextures(1, &id);
-}
-
-void Texture::createDepthMap(const uint32_t depthWidth,
-                             const uint32_t depthHeight) const {
-    glBindTexture(GL_TEXTURE_2D, id);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, depthWidth, depthHeight,
-                 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-    constexpr std::array<float, 4> borderColor = { 1.F, 1.F, 1.F, 1.F };
-    glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR,
-                     borderColor.data());
 }
 
 void Texture::generate(const uint32_t textureWidth,

--- a/sponge/src/platform/opengl/renderer/texture.cpp
+++ b/sponge/src/platform/opengl/renderer/texture.cpp
@@ -49,27 +49,44 @@ void Texture::generate(const uint32_t textureWidth,
 
     const auto gammaCorrection = (flag & GammaCorrection) == GammaCorrection;
 
-    uint32_t internalFormat = GL_RGB;
+    const auto pixelated = (flag & Pixelated) == Pixelated;
+
+    // Sized internal formats: the unsized names let the driver pick a
+    // narrower layout, which shows up as fringing on the subpixel glyph
+    // atlas.
+    uint32_t internalFormat = GL_RGB8;
     uint32_t format         = GL_RGB;
     if (bytesPerPixel == 1) {
-        internalFormat = format = GL_RED;
+        internalFormat = GL_R8;
+        format         = GL_RED;
     } else if (bytesPerPixel == 3) {
-        internalFormat = gammaCorrection ? GL_SRGB : GL_RGB;
+        internalFormat = gammaCorrection ? GL_SRGB8 : GL_RGB8;
         format         = GL_RGB;
     } else if (bytesPerPixel == 4) {
-        internalFormat = gammaCorrection ? GL_SRGB_ALPHA : GL_RGBA;
+        internalFormat = gammaCorrection ? GL_SRGB8_ALPHA8 : GL_RGBA8;
         format         = GL_RGBA;
     }
 
     glBindTexture(GL_TEXTURE_2D, id);
+    // Rows are tightly packed. The default alignment of 4 skews any upload
+    // whose width times bytesPerPixel is not a multiple of it.
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format,
                  GL_UNSIGNED_BYTE, data);
-    glGenerateMipmap(GL_TEXTURE_2D);
 
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-                    GL_LINEAR_MIPMAP_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    if (pixelated) {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    } else {
+        glGenerateMipmap(GL_TEXTURE_2D);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                        GL_LINEAR_MIPMAP_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    }
 
+    glBindTexture(GL_TEXTURE_2D, 0);
     glActiveTexture(GL_TEXTURE0);
 }
 

--- a/sponge/src/platform/opengl/renderer/texture.hpp
+++ b/sponge/src/platform/opengl/renderer/texture.hpp
@@ -12,7 +12,6 @@ enum LoadFlag : uint8_t {
     None                = 0,
     ExcludeAssetsFolder = BIT(0),
     GammaCorrection     = BIT(1),
-    DepthMap            = BIT(2),
 };
 
 struct TextureCreateInfo {
@@ -50,7 +49,6 @@ private:
     uint32_t height = 0;
 
     void loadFromFile(const std::string& path, uint8_t flag);
-    void createDepthMap(uint32_t depthWidth, uint32_t depthHeight) const;
     void generate(uint32_t textureWidth, uint32_t textureHeight,
                   uint32_t bytesPerPixel, const uint8_t* data, uint8_t flag);
 };

--- a/sponge/src/platform/opengl/renderer/texture.hpp
+++ b/sponge/src/platform/opengl/renderer/texture.hpp
@@ -12,6 +12,10 @@ enum LoadFlag : uint8_t {
     None                = 0,
     ExcludeAssetsFolder = BIT(0),
     GammaCorrection     = BIT(1),
+    // Sample exactly: nearest, clamped, no mip chain. For atlases and UI
+    // sheets, where a filtered or wrapped sample crosses into a neighbouring
+    // glyph.
+    Pixelated = BIT(2),
 };
 
 struct TextureCreateInfo {

--- a/sponge/src/platform/opengl/scene/bitmapfont.cpp
+++ b/sponge/src/platform/opengl/scene/bitmapfont.cpp
@@ -2,11 +2,13 @@
 
 #include "platform/opengl/renderer/assetmanager.hpp"
 #include "platform/opengl/renderer/gl.hpp"
+#include "platform/opengl/renderer/texture.hpp"
 
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <memory>
 #include <string_view>
 
 namespace {
@@ -70,24 +72,19 @@ BitmapFont::BitmapFont(const FontCreateInfo& createInfo) {
     const std::string ttfPath = createInfo.assetsFolder + createInfo.path;
     atlas.build(ttfPath, { 18, 24, 32, 48 });
 
-    glGenTextures(1, &textureId);
-    glBindTexture(GL_TEXTURE_2D, textureId);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8,
-                 static_cast<GLsizei>(atlas.atlasWidth()),
-                 static_cast<GLsizei>(atlas.atlasHeight()), 0, GL_RGB,
-                 GL_UNSIGNED_BYTE, atlas.data());
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glBindTexture(GL_TEXTURE_2D, 0);
-}
-
-BitmapFont::~BitmapFont() {
-    if (textureId != 0) {
-        glDeleteTextures(1, &textureId);
-    }
+    // The atlas holds per-channel LCD coverage, not colour, so no gamma
+    // correction: an sRGB internal format would apply a transfer function to
+    // the coverage that feeds the dual-source blend in beginPass().
+    const renderer::TextureCreateInfo textureCreateInfo{
+        .name          = createInfo.name,
+        .path          = "",
+        .width         = atlas.atlasWidth(),
+        .height        = atlas.atlasHeight(),
+        .bytesPerPixel = 3,
+        .data          = atlas.data(),
+        .loadFlag      = renderer::Pixelated,
+    };
+    texture = std::make_unique<renderer::Texture>(textureCreateInfo);
 }
 
 uint32_t BitmapFont::getHeight(const uint32_t size) const {
@@ -108,12 +105,11 @@ uint32_t BitmapFont::getLength(const std::string_view text, const uint32_t size,
 }
 
 void BitmapFont::beginPass(const uint32_t size) {
-    assert(textureId != 0);
+    assert(texture);
     passTargetSize = size;
     vao->bind();
     shader->bind();
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, textureId);
+    texture->activateAndBind(0);
     glBlendFunc(GL_SRC1_COLOR, GL_ONE_MINUS_SRC1_COLOR);
 }
 

--- a/sponge/src/platform/opengl/scene/bitmapfont.hpp
+++ b/sponge/src/platform/opengl/scene/bitmapfont.hpp
@@ -3,6 +3,7 @@
 #include "core/file.hpp"
 #include "platform/opengl/renderer/indexbuffer.hpp"
 #include "platform/opengl/renderer/shader.hpp"
+#include "platform/opengl/renderer/texture.hpp"
 #include "platform/opengl/renderer/vertexarray.hpp"
 #include "platform/opengl/renderer/vertexbuffer.hpp"
 #include "scene/fontatlas.hpp"
@@ -25,7 +26,6 @@ struct FontCreateInfo {
 class BitmapFont {
 public:
     explicit BitmapFont(const FontCreateInfo& createInfo);
-    ~BitmapFont();
 
     // tabularFigures: see FontAtlas::shape()'s doc comment.
     uint32_t getLength(std::string_view text, uint32_t size,
@@ -44,9 +44,9 @@ private:
     static constexpr std::string_view shaderName = "text";
 
     uint32_t passTargetSize = 0;
-    uint32_t textureId      = 0;
 
     sponge::scene::FontAtlas                atlas;
+    std::unique_ptr<renderer::Texture>      texture;
     std::shared_ptr<renderer::Shader>       shader;
     std::unique_ptr<renderer::VertexBuffer> vbo;
     std::unique_ptr<renderer::VertexArray>  vao;

--- a/sponge/src/platform/opengl/scene/bloom.cpp
+++ b/sponge/src/platform/opengl/scene/bloom.cpp
@@ -4,20 +4,9 @@
 #include "platform/opengl/renderer/assetmanager.hpp"
 #include "platform/opengl/renderer/gl.hpp"
 
-#include <array>
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <string_view>
-
-namespace {
-constexpr std::array quadVertices = {
-    -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
-    -1.F, 1.F,  0.F, 1.F, 1.F, 1.F,  1.F, 1.F,
-};
-constexpr uint32_t quadVertexCount = 4;
-constexpr uint32_t quadStride      = 4 * sizeof(float);
-}  // namespace
 
 namespace sponge::platform::opengl::scene {
 using renderer::AssetManager;
@@ -45,23 +34,6 @@ void Bloom::initialize() {
     downShader =
         makeShader(downShaderName, "/shaders/glsl/bloom_down.frag.glsl");
     upShader = makeShader(upShaderName, "/shaders/glsl/bloom_up.frag.glsl");
-
-    vao = renderer::VertexArray::create();
-    vao->bind();
-    vbo = std::make_unique<renderer::VertexBuffer>(quadVertices.data(),
-                                                   sizeof(quadVertices));
-    vbo->bind();
-
-    // blur.vert.glsl uses layout(location=0) aPos, layout(location=1)
-    // aTexCoords
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(0));
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(2 * sizeof(float)));
-
-    vao->unbind();
 
     createFramebuffers();
 }
@@ -121,12 +93,6 @@ void Bloom::destroyFramebuffers() {
     upTextures.fill(0);
 }
 
-void Bloom::renderQuad() const {
-    vao->bind();
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
-    vao->unbind();
-}
-
 void Bloom::process(const uint32_t sceneTexId, const float threshold) const {
     glDisable(GL_DEPTH_TEST);
     glActiveTexture(GL_TEXTURE0);
@@ -138,7 +104,7 @@ void Bloom::process(const uint32_t sceneTexId, const float threshold) const {
     extractShader->bind();
     extractShader->setFloat("threshold", threshold);
     glBindTexture(GL_TEXTURE_2D, sceneTexId);
-    renderQuad();
+    quad.draw();
     extractShader->unbind();
 
     // Downsample: down[i-1] → down[i]
@@ -149,7 +115,7 @@ void Bloom::process(const uint32_t sceneTexId, const float threshold) const {
         glViewport(0, 0, static_cast<GLsizei>(width >> (i + 1)),
                    static_cast<GLsizei>(height >> (i + 1)));
         glBindTexture(GL_TEXTURE_2D, downTextures[i - 1]);
-        renderQuad();
+        quad.draw();
     }
     downShader->unbind();
 
@@ -168,7 +134,7 @@ void Bloom::process(const uint32_t sceneTexId, const float threshold) const {
         const uint32_t src =
             (i == numLevels - 1) ? downTextures[i] : upTextures[i + 1];
         glBindTexture(GL_TEXTURE_2D, src);
-        renderQuad();
+        quad.draw();
     }
     upShader->unbind();
     glActiveTexture(GL_TEXTURE0);

--- a/sponge/src/platform/opengl/scene/bloom.cpp
+++ b/sponge/src/platform/opengl/scene/bloom.cpp
@@ -45,8 +45,6 @@ void Bloom::initialize() {
     downShader =
         makeShader(downShaderName, "/shaders/glsl/bloom_down.frag.glsl");
     upShader = makeShader(upShaderName, "/shaders/glsl/bloom_up.frag.glsl");
-    compositeShader = makeShader(compositeShaderName,
-                                 "/shaders/glsl/bloom_composite.frag.glsl");
 
     vao = renderer::VertexArray::create();
     vao->bind();
@@ -69,34 +67,6 @@ void Bloom::initialize() {
 }
 
 void Bloom::createFramebuffers() {
-    // Scene capture FBO at full resolution (HDR)
-    glGenTextures(1, &sceneColorTexture);
-    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
-                 static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glBindTexture(GL_TEXTURE_2D, 0);
-
-    glGenRenderbuffers(1, &sceneDepthRbo);
-    glBindRenderbuffer(GL_RENDERBUFFER, sceneDepthRbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24,
-                          static_cast<GLsizei>(width),
-                          static_cast<GLsizei>(height));
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
-
-    glGenFramebuffers(1, &sceneFbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           sceneColorTexture, 0);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                              GL_RENDERBUFFER, sceneDepthRbo);
-    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        SPONGE_GL_CRITICAL("Bloom scene framebuffer is not complete!");
-    }
-
     // Mip-chain FBOs: level i at (width >> (i+1)) x (height >> (i+1))
     glGenFramebuffers(numLevels, downFbos.data());
     glGenTextures(numLevels, downTextures.data());
@@ -141,18 +111,6 @@ void Bloom::createFramebuffers() {
 }
 
 void Bloom::destroyFramebuffers() {
-    if (sceneFbo != 0) {
-        glDeleteFramebuffers(1, &sceneFbo);
-        sceneFbo = 0;
-    }
-    if (sceneColorTexture != 0) {
-        glDeleteTextures(1, &sceneColorTexture);
-        sceneColorTexture = 0;
-    }
-    if (sceneDepthRbo != 0) {
-        glDeleteRenderbuffers(1, &sceneDepthRbo);
-        sceneDepthRbo = 0;
-    }
     glDeleteFramebuffers(numLevels, downFbos.data());
     glDeleteTextures(numLevels, downTextures.data());
     glDeleteFramebuffers(numLevels, upFbos.data());
@@ -163,21 +121,13 @@ void Bloom::destroyFramebuffers() {
     upTextures.fill(0);
 }
 
-void Bloom::begin() const {
-    glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
-}
-
-void Bloom::end() const {
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-}
-
 void Bloom::renderQuad() const {
     vao->bind();
     glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
     vao->unbind();
 }
 
-void Bloom::process(const float threshold) const {
+void Bloom::process(const uint32_t sceneTexId, const float threshold) const {
     glDisable(GL_DEPTH_TEST);
     glActiveTexture(GL_TEXTURE0);
 
@@ -187,7 +137,7 @@ void Bloom::process(const float threshold) const {
                static_cast<GLsizei>(height >> 1));
     extractShader->bind();
     extractShader->setFloat("threshold", threshold);
-    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
+    glBindTexture(GL_TEXTURE_2D, sceneTexId);
     renderQuad();
     extractShader->unbind();
 
@@ -225,24 +175,6 @@ void Bloom::process(const float threshold) const {
 
     glViewport(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height));
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glEnable(GL_DEPTH_TEST);
-}
-
-void Bloom::apply(const float intensity) const {
-    glDisable(GL_DEPTH_TEST);
-
-    compositeShader->bind();
-    compositeShader->setFloat("intensity", intensity);
-
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
-    glActiveTexture(GL_TEXTURE1);
-    glBindTexture(GL_TEXTURE_2D, upTextures[0]);
-
-    renderQuad();
-    compositeShader->unbind();
-
-    glActiveTexture(GL_TEXTURE0);
     glEnable(GL_DEPTH_TEST);
 }
 

--- a/sponge/src/platform/opengl/scene/bloom.cpp
+++ b/sponge/src/platform/opengl/scene/bloom.cpp
@@ -41,26 +41,17 @@ void Bloom::initialize() {
 void Bloom::createFramebuffers() {
     // Mip-chain FBOs: level i at (width >> (i+1)) x (height >> (i+1))
     glGenFramebuffers(numLevels, downFbos.data());
-    glGenTextures(numLevels, downTextures.data());
     glGenFramebuffers(numLevels, upFbos.data());
-    glGenTextures(numLevels, upTextures.data());
-
-    auto makeMipTex = [](uint32_t tex, GLsizei w, GLsizei h) {
-        glBindTexture(GL_TEXTURE_2D, tex);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, w, h, 0, GL_RGB, GL_FLOAT,
-                     nullptr);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glBindTexture(GL_TEXTURE_2D, 0);
+    auto makeMipTex = [](uint32_t w, uint32_t h) {
+        return renderer::createRenderTarget(w, h, GL_RGB16F, GL_RGB, GL_FLOAT,
+                                            GL_LINEAR);
     };
 
     for (int i = 0; i < numLevels; i++) {
-        const auto w = static_cast<GLsizei>(width >> (i + 1));
-        const auto h = static_cast<GLsizei>(height >> (i + 1));
+        const auto w = width >> (i + 1);
+        const auto h = height >> (i + 1);
 
-        makeMipTex(downTextures[i], w, h);
+        downTextures[i] = makeMipTex(w, h);
         glBindFramebuffer(GL_FRAMEBUFFER, downFbos[i]);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                                GL_TEXTURE_2D, downTextures[i], 0);
@@ -69,7 +60,7 @@ void Bloom::createFramebuffers() {
             SPONGE_GL_CRITICAL("Bloom down framebuffer {} is not complete!", i);
         }
 
-        makeMipTex(upTextures[i], w, h);
+        upTextures[i] = makeMipTex(w, h);
         glBindFramebuffer(GL_FRAMEBUFFER, upFbos[i]);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                                GL_TEXTURE_2D, upTextures[i], 0);

--- a/sponge/src/platform/opengl/scene/bloom.hpp
+++ b/sponge/src/platform/opengl/scene/bloom.hpp
@@ -20,14 +20,10 @@ public:
     Bloom(const Bloom&)            = delete;
     Bloom& operator=(const Bloom&) = delete;
 
-    void begin() const;
-    void end() const;
-    void process(float threshold) const;
-    void apply(float intensity) const;
-
-    uint32_t getSceneTexture() const {
-        return sceneColorTexture;
-    }
+    // Extracts and blurs from `sceneTexId`, which must be linear HDR — the
+    // threshold is a radiance value, so feeding it a tone-mapped image makes
+    // the setting meaningless.
+    void process(uint32_t sceneTexId, float threshold) const;
 
     uint32_t getBloomTexture() const {
         return upTextures[0];
@@ -36,22 +32,16 @@ public:
     void resize(uint32_t newWidth, uint32_t newHeight);
 
 private:
-    static constexpr std::string_view extractShaderName   = "bloom_extract";
-    static constexpr std::string_view downShaderName      = "bloom_down";
-    static constexpr std::string_view upShaderName        = "bloom_up";
-    static constexpr std::string_view compositeShaderName = "bloom_composite";
-    static constexpr int              numLevels           = 5;
+    static constexpr std::string_view extractShaderName = "bloom_extract";
+    static constexpr std::string_view downShaderName    = "bloom_down";
+    static constexpr std::string_view upShaderName      = "bloom_up";
+    static constexpr int              numLevels         = 5;
 
     std::shared_ptr<renderer::Shader>       extractShader;
     std::shared_ptr<renderer::Shader>       downShader;
     std::shared_ptr<renderer::Shader>       upShader;
-    std::shared_ptr<renderer::Shader>       compositeShader;
     std::unique_ptr<renderer::VertexArray>  vao;
     std::unique_ptr<renderer::VertexBuffer> vbo;
-
-    uint32_t sceneFbo          = 0;
-    uint32_t sceneColorTexture = 0;
-    uint32_t sceneDepthRbo     = 0;
 
     std::array<uint32_t, numLevels> downFbos{};
     std::array<uint32_t, numLevels> downTextures{};

--- a/sponge/src/platform/opengl/scene/bloom.hpp
+++ b/sponge/src/platform/opengl/scene/bloom.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "platform/opengl/renderer/shader.hpp"
-#include "platform/opengl/renderer/vertexarray.hpp"
-#include "platform/opengl/renderer/vertexbuffer.hpp"
+#include "platform/opengl/scene/screenquad.hpp"
 
 #include <array>
 #include <cstdint>
@@ -37,11 +36,10 @@ private:
     static constexpr std::string_view upShaderName      = "bloom_up";
     static constexpr int              numLevels         = 5;
 
-    std::shared_ptr<renderer::Shader>       extractShader;
-    std::shared_ptr<renderer::Shader>       downShader;
-    std::shared_ptr<renderer::Shader>       upShader;
-    std::unique_ptr<renderer::VertexArray>  vao;
-    std::unique_ptr<renderer::VertexBuffer> vbo;
+    std::shared_ptr<renderer::Shader> extractShader;
+    std::shared_ptr<renderer::Shader> downShader;
+    std::shared_ptr<renderer::Shader> upShader;
+    ScreenQuad                        quad;
 
     std::array<uint32_t, numLevels> downFbos{};
     std::array<uint32_t, numLevels> downTextures{};
@@ -54,7 +52,6 @@ private:
     void initialize();
     void createFramebuffers();
     void destroyFramebuffers();
-    void renderQuad() const;
 };
 
 }  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/fxaa.cpp
+++ b/sponge/src/platform/opengl/scene/fxaa.cpp
@@ -31,23 +31,16 @@ void FXAA::initialize() {
 }
 
 void FXAA::createFramebuffer() {
-    glGenTextures(1, &colorTexture);
-    glBindTexture(GL_TEXTURE_2D, colorTexture);
     // RGB16F, not RGB8. This holds the tone-mapped image on its way into the
     // filter, and an 8-bit target here would quantise it a second time — once
     // undithered on the way in, once dithered on the way out — which is the
     // banding dither8 exists to prevent. Dither belongs at the final write
     // only, which is apply()'s.
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
-                 static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT, nullptr);
-
+    //
     // Linear filtering is required — FXAA samples between texels when blending
     // across detected edges, so nearest-neighbor would negate the entire pass.
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    colorTexture = renderer::createRenderTarget(width, height, GL_RGB16F,
+                                                GL_RGB, GL_FLOAT, GL_LINEAR);
 
     glGenFramebuffers(1, &fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);

--- a/sponge/src/platform/opengl/scene/fxaa.cpp
+++ b/sponge/src/platform/opengl/scene/fxaa.cpp
@@ -5,22 +5,7 @@
 #include "platform/opengl/renderer/gl.hpp"
 
 #include <glm/glm.hpp>
-#include <array>
 #include <cstdint>
-#include <memory>
-
-namespace {
-// Interleaved NDC position (vec2) + UV (vec2) for a full-screen triangle strip.
-// Triangle strip chosen over two separate triangles to halve the vertex count
-// and avoid a diagonal seam that can produce a one-pixel artifact on some GPUs.
-constexpr std::array quadVertices = {
-    -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
-    -1.F, 1.F,  0.F, 1.F, 1.F, 1.F,  1.F, 1.F,
-};
-
-constexpr uint32_t quadVertexCount = 4;
-constexpr uint32_t quadStride      = 4 * sizeof(float);
-}  // namespace
 
 namespace sponge::platform::opengl::scene {
 using renderer::AssetManager;
@@ -41,26 +26,6 @@ void FXAA::initialize() {
         .fragmentShaderPath = "/shaders/glsl/fxaa.frag.glsl",
     };
     shader = AssetManager::createShader(shaderCreateInfo);
-    shader->bind();
-
-    vao = renderer::VertexArray::create();
-    vao->bind();
-
-    vbo = std::make_unique<renderer::VertexBuffer>(quadVertices.data(),
-                                                   sizeof(quadVertices));
-    vbo->bind();
-
-    constexpr uint32_t positionLoc = 0;
-    constexpr uint32_t texCoordLoc = 1;
-    glEnableVertexAttribArray(positionLoc);
-    glVertexAttribPointer(positionLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(0));
-    glEnableVertexAttribArray(texCoordLoc);
-    glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(2 * sizeof(float)));
-
-    shader->unbind();
-    vao->unbind();
 
     createFramebuffer();
 }
@@ -127,9 +92,7 @@ void FXAA::apply() const {
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, colorTexture);
 
-    vao->bind();
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
-    vao->unbind();
+    quad.draw();
 
     shader->unbind();
 

--- a/sponge/src/platform/opengl/scene/fxaa.cpp
+++ b/sponge/src/platform/opengl/scene/fxaa.cpp
@@ -68,9 +68,13 @@ void FXAA::initialize() {
 void FXAA::createFramebuffer() {
     glGenTextures(1, &colorTexture);
     glBindTexture(GL_TEXTURE_2D, colorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, static_cast<GLsizei>(width),
-                 static_cast<GLsizei>(height), 0, GL_RGB, GL_UNSIGNED_BYTE,
-                 nullptr);
+    // RGB16F, not RGB8. This holds the tone-mapped image on its way into the
+    // filter, and an 8-bit target here would quantise it a second time — once
+    // undithered on the way in, once dithered on the way out — which is the
+    // banding dither8 exists to prevent. Dither belongs at the final write
+    // only, which is apply()'s.
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
+                 static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT, nullptr);
 
     // Linear filtering is required — FXAA samples between texels when blending
     // across detected edges, so nearest-neighbor would negate the entire pass.

--- a/sponge/src/platform/opengl/scene/fxaa.hpp
+++ b/sponge/src/platform/opengl/scene/fxaa.hpp
@@ -22,8 +22,6 @@ public:
     void begin() const;
     void end() const;
     void apply() const;
-    void applyWithBloom(uint32_t sceneTexId, uint32_t bloomTexId,
-                        float intensity) const;
 
     void resize(uint32_t newWidth, uint32_t newHeight);
 
@@ -36,9 +34,9 @@ private:
 
     // Raw GL handles — managed here because the Texture class has no
     // color-buffer creation path, and the framebuffer must be recreated on
-    // every window resize.
+    // every window resize. No depth attachment: only the resolve pass's
+    // full-screen quad draws here, never scene geometry.
     uint32_t colorTexture = 0;
-    uint32_t depthRbo     = 0;
     uint32_t fbo          = 0;
 
     uint32_t width  = 0;

--- a/sponge/src/platform/opengl/scene/fxaa.hpp
+++ b/sponge/src/platform/opengl/scene/fxaa.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "platform/opengl/renderer/shader.hpp"
-#include "platform/opengl/renderer/vertexarray.hpp"
-#include "platform/opengl/renderer/vertexbuffer.hpp"
+#include "platform/opengl/scene/screenquad.hpp"
 
 #include <cstdint>
 #include <memory>
@@ -28,9 +27,8 @@ public:
 private:
     static constexpr std::string_view shaderName = "fxaa";
 
-    std::shared_ptr<renderer::Shader>       shader;
-    std::unique_ptr<renderer::VertexArray>  vao;
-    std::unique_ptr<renderer::VertexBuffer> vbo;
+    std::shared_ptr<renderer::Shader> shader;
+    ScreenQuad                        quad;
 
     // Raw GL handles — managed here because the Texture class has no
     // color-buffer creation path, and the framebuffer must be recreated on

--- a/sponge/src/platform/opengl/scene/scenetarget.cpp
+++ b/sponge/src/platform/opengl/scene/scenetarget.cpp
@@ -1,23 +1,18 @@
-#include "platform/opengl/scene/fxaa.hpp"
+#include "platform/opengl/scene/scenetarget.hpp"
 
 #include "logging/log.hpp"
 #include "platform/opengl/renderer/assetmanager.hpp"
 #include "platform/opengl/renderer/gl.hpp"
 
-#include <glm/glm.hpp>
 #include <array>
 #include <cstdint>
 #include <memory>
 
 namespace {
-// Interleaved NDC position (vec2) + UV (vec2) for a full-screen triangle strip.
-// Triangle strip chosen over two separate triangles to halve the vertex count
-// and avoid a diagonal seam that can produce a one-pixel artifact on some GPUs.
 constexpr std::array quadVertices = {
     -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
     -1.F, 1.F,  0.F, 1.F, 1.F, 1.F,  1.F, 1.F,
 };
-
 constexpr uint32_t quadVertexCount = 4;
 constexpr uint32_t quadStride      = 4 * sizeof(float);
 }  // namespace
@@ -25,74 +20,75 @@ constexpr uint32_t quadStride      = 4 * sizeof(float);
 namespace sponge::platform::opengl::scene {
 using renderer::AssetManager;
 
-FXAA::FXAA(const uint32_t width, const uint32_t height) :
+SceneTarget::SceneTarget(const uint32_t width, const uint32_t height) :
     width(width), height(height) {
     initialize();
 }
 
-FXAA::~FXAA() {
+SceneTarget::~SceneTarget() {
     destroyFramebuffer();
 }
 
-void FXAA::initialize() {
-    const auto shaderCreateInfo = renderer::ShaderCreateInfo{
+void SceneTarget::initialize() {
+    shader = AssetManager::createShader(renderer::ShaderCreateInfo{
         .name               = shaderName.data(),
         .vertexShaderPath   = "/shaders/glsl/screenquad.vert.glsl",
-        .fragmentShaderPath = "/shaders/glsl/fxaa.frag.glsl",
-    };
-    shader = AssetManager::createShader(shaderCreateInfo);
-    shader->bind();
+        .fragmentShaderPath = "/shaders/glsl/tonemap.frag.glsl",
+    });
 
     vao = renderer::VertexArray::create();
     vao->bind();
-
     vbo = std::make_unique<renderer::VertexBuffer>(quadVertices.data(),
                                                    sizeof(quadVertices));
     vbo->bind();
 
-    constexpr uint32_t positionLoc = 0;
-    constexpr uint32_t texCoordLoc = 1;
-    glEnableVertexAttribArray(positionLoc);
-    glVertexAttribPointer(positionLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, quadStride,
                           reinterpret_cast<const void*>(0));
-    glEnableVertexAttribArray(texCoordLoc);
-    glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, quadStride,
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, quadStride,
                           reinterpret_cast<const void*>(2 * sizeof(float)));
 
-    shader->unbind();
     vao->unbind();
 
     createFramebuffer();
 }
 
-void FXAA::createFramebuffer() {
+void SceneTarget::createFramebuffer() {
+    // RGB16F, not RGB8: the whole point of this target is that radiance above
+    // 1.0 survives as far as the bloom extract and the tone map.
     glGenTextures(1, &colorTexture);
     glBindTexture(GL_TEXTURE_2D, colorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, static_cast<GLsizei>(width),
-                 static_cast<GLsizei>(height), 0, GL_RGB, GL_UNSIGNED_BYTE,
-                 nullptr);
-
-    // Linear filtering is required — FXAA samples between texels when blending
-    // across detected edges, so nearest-neighbor would negate the entire pass.
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
+                 static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT, nullptr);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBindTexture(GL_TEXTURE_2D, 0);
 
+    // GL_DEPTH_COMPONENT24 to match the prepass FBO — blitDepthToCurrentFbo()
+    // requires identical depth formats.
+    glGenRenderbuffers(1, &depthRbo);
+    glBindRenderbuffer(GL_RENDERBUFFER, depthRbo);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24,
+                          static_cast<GLsizei>(width),
+                          static_cast<GLsizei>(height));
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
     glGenFramebuffers(1, &fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                            colorTexture, 0);
-
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                              GL_RENDERBUFFER, depthRbo);
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        SPONGE_GL_CRITICAL("FXAA framebuffer is not complete!");
+        SPONGE_GL_CRITICAL("Scene framebuffer is not complete!");
     }
-
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
-void FXAA::destroyFramebuffer() {
+void SceneTarget::destroyFramebuffer() {
     if (fbo != 0) {
         glDeleteFramebuffers(1, &fbo);
         fbo = 0;
@@ -101,38 +97,46 @@ void FXAA::destroyFramebuffer() {
         glDeleteTextures(1, &colorTexture);
         colorTexture = 0;
     }
+    if (depthRbo != 0) {
+        glDeleteRenderbuffers(1, &depthRbo);
+        depthRbo = 0;
+    }
 }
 
-void FXAA::begin() const {
+void SceneTarget::begin() const {
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 }
 
-void FXAA::end() const {
+void SceneTarget::end() const {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
-void FXAA::apply() const {
-    // Depth testing would discard full-screen quad fragments behind anything
-    // left in the depth buffer from the scene pass — disable for this blit.
+void SceneTarget::resolve(const uint32_t bloomTexId, const float bloomIntensity,
+                          const bool ditherOutput) const {
+    // Depth testing would discard the full-screen quad behind whatever the
+    // scene pass left in the depth buffer.
     glDisable(GL_DEPTH_TEST);
 
     shader->bind();
-    shader->setFloat2("rcpFrame", glm::vec2(1.0f / static_cast<float>(width),
-                                            1.0f / static_cast<float>(height)));
+    shader->setFloat("bloomIntensity", bloomIntensity);
+    shader->setFloat("ditherOutput", ditherOutput ? 1.F : 0.F);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, colorTexture);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, bloomTexId);
 
     vao->bind();
     glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
     vao->unbind();
 
+    glActiveTexture(GL_TEXTURE0);
     shader->unbind();
 
     glEnable(GL_DEPTH_TEST);
 }
 
-void FXAA::resize(const uint32_t newWidth, const uint32_t newHeight) {
+void SceneTarget::resize(const uint32_t newWidth, const uint32_t newHeight) {
     if (width == newWidth && height == newHeight) {
         return;
     }

--- a/sponge/src/platform/opengl/scene/scenetarget.cpp
+++ b/sponge/src/platform/opengl/scene/scenetarget.cpp
@@ -4,18 +4,7 @@
 #include "platform/opengl/renderer/assetmanager.hpp"
 #include "platform/opengl/renderer/gl.hpp"
 
-#include <array>
 #include <cstdint>
-#include <memory>
-
-namespace {
-constexpr std::array quadVertices = {
-    -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
-    -1.F, 1.F,  0.F, 1.F, 1.F, 1.F,  1.F, 1.F,
-};
-constexpr uint32_t quadVertexCount = 4;
-constexpr uint32_t quadStride      = 4 * sizeof(float);
-}  // namespace
 
 namespace sponge::platform::opengl::scene {
 using renderer::AssetManager;
@@ -35,21 +24,6 @@ void SceneTarget::initialize() {
         .vertexShaderPath   = "/shaders/glsl/screenquad.vert.glsl",
         .fragmentShaderPath = "/shaders/glsl/tonemap.frag.glsl",
     });
-
-    vao = renderer::VertexArray::create();
-    vao->bind();
-    vbo = std::make_unique<renderer::VertexBuffer>(quadVertices.data(),
-                                                   sizeof(quadVertices));
-    vbo->bind();
-
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(0));
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(2 * sizeof(float)));
-
-    vao->unbind();
 
     createFramebuffer();
 }
@@ -119,16 +93,14 @@ void SceneTarget::resolve(const uint32_t bloomTexId, const float bloomIntensity,
 
     shader->bind();
     shader->setFloat("bloomIntensity", bloomIntensity);
-    shader->setFloat("ditherOutput", ditherOutput ? 1.F : 0.F);
+    shader->setBoolean("ditherOutput", ditherOutput);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, colorTexture);
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, bloomTexId);
 
-    vao->bind();
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
-    vao->unbind();
+    quad.draw();
 
     glActiveTexture(GL_TEXTURE0);
     shader->unbind();

--- a/sponge/src/platform/opengl/scene/scenetarget.cpp
+++ b/sponge/src/platform/opengl/scene/scenetarget.cpp
@@ -31,15 +31,8 @@ void SceneTarget::initialize() {
 void SceneTarget::createFramebuffer() {
     // RGB16F, not RGB8: the whole point of this target is that radiance above
     // 1.0 survives as far as the bloom extract and the tone map.
-    glGenTextures(1, &colorTexture);
-    glBindTexture(GL_TEXTURE_2D, colorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
-                 static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    colorTexture = renderer::createRenderTarget(width, height, GL_RGB16F,
+                                                GL_RGB, GL_FLOAT, GL_LINEAR);
 
     // GL_DEPTH_COMPONENT24 to match the prepass FBO — blitDepthToCurrentFbo()
     // requires identical depth formats.

--- a/sponge/src/platform/opengl/scene/scenetarget.hpp
+++ b/sponge/src/platform/opengl/scene/scenetarget.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "platform/opengl/renderer/shader.hpp"
+#include "platform/opengl/renderer/vertexarray.hpp"
+#include "platform/opengl/renderer/vertexbuffer.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace sponge::platform::opengl::scene {
+
+// The linear HDR buffer the scene renders into, and the pass that turns it
+// into a display image.
+//
+// The two belong together: everything upstream of resolve() works in unbounded
+// radiance, and resolve() is the single point where the pipeline leaves linear
+// space. Bloom extracts from getTexture() before that happens, so its threshold
+// is a radiance value rather than a point on an already-compressed curve.
+class SceneTarget {
+public:
+    SceneTarget() = delete;
+    SceneTarget(uint32_t width, uint32_t height);
+    ~SceneTarget();
+
+    SceneTarget(const SceneTarget&)            = delete;
+    SceneTarget& operator=(const SceneTarget&) = delete;
+
+    void begin() const;
+    void end() const;
+
+    // Linear HDR scene colour. Valid after end().
+    uint32_t getTexture() const {
+        return colorTexture;
+    }
+
+    // Composites bloom in linear light, then tone maps and gamma encodes into
+    // whichever framebuffer is currently bound. `bloomTexId` may be 0 when
+    // `bloomIntensity` is 0. Set `ditherOutput` only when this pass writes the
+    // final 8-bit target — anti-aliasing, when enabled, runs afterwards and
+    // dithers on its own write.
+    void resolve(uint32_t bloomTexId, float bloomIntensity,
+                 bool ditherOutput) const;
+
+    void resize(uint32_t newWidth, uint32_t newHeight);
+
+private:
+    static constexpr std::string_view shaderName = "tonemap";
+
+    std::shared_ptr<renderer::Shader>       shader;
+    std::unique_ptr<renderer::VertexArray>  vao;
+    std::unique_ptr<renderer::VertexBuffer> vbo;
+
+    // Raw GL handles, as in the other post-processing classes: the Texture
+    // class has no colour-buffer creation path and these are rebuilt on resize.
+    uint32_t colorTexture = 0;
+    uint32_t depthRbo     = 0;
+    uint32_t fbo          = 0;
+
+    uint32_t width  = 0;
+    uint32_t height = 0;
+
+    void initialize();
+    void createFramebuffer();
+    void destroyFramebuffer();
+};
+
+}  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/scenetarget.hpp
+++ b/sponge/src/platform/opengl/scene/scenetarget.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "platform/opengl/renderer/shader.hpp"
-#include "platform/opengl/renderer/vertexarray.hpp"
-#include "platform/opengl/renderer/vertexbuffer.hpp"
+#include "platform/opengl/scene/screenquad.hpp"
 
 #include <cstdint>
 #include <memory>
@@ -47,9 +46,8 @@ public:
 private:
     static constexpr std::string_view shaderName = "tonemap";
 
-    std::shared_ptr<renderer::Shader>       shader;
-    std::unique_ptr<renderer::VertexArray>  vao;
-    std::unique_ptr<renderer::VertexBuffer> vbo;
+    std::shared_ptr<renderer::Shader> shader;
+    ScreenQuad                        quad;
 
     // Raw GL handles, as in the other post-processing classes: the Texture
     // class has no colour-buffer creation path and these are rebuilt on resize.

--- a/sponge/src/platform/opengl/scene/screenquad.cpp
+++ b/sponge/src/platform/opengl/scene/screenquad.cpp
@@ -1,0 +1,50 @@
+#include "platform/opengl/scene/screenquad.hpp"
+
+#include "platform/opengl/renderer/gl.hpp"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+
+namespace {
+// Interleaved NDC position (vec2) + UV (vec2). Triangle strip rather than two
+// triangles: half the vertex count and no diagonal seam, which can produce a
+// one-pixel artifact on some GPUs.
+constexpr std::array vertices = {
+    -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
+    -1.F, 1.F,  0.F, 1.F, 1.F, 1.F,  1.F, 1.F,
+};
+
+constexpr uint32_t vertexCount = 4;
+constexpr uint32_t stride      = 4 * sizeof(float);
+}  // namespace
+
+namespace sponge::platform::opengl::scene {
+
+ScreenQuad::ScreenQuad() {
+    vao = renderer::VertexArray::create();
+    vao->bind();
+
+    vbo = std::make_unique<renderer::VertexBuffer>(vertices.data(),
+                                                   sizeof(vertices));
+    vbo->bind();
+
+    constexpr uint32_t positionLoc = 0;
+    constexpr uint32_t texCoordLoc = 1;
+    glEnableVertexAttribArray(positionLoc);
+    glVertexAttribPointer(positionLoc, 2, GL_FLOAT, GL_FALSE, stride,
+                          reinterpret_cast<const void*>(0));
+    glEnableVertexAttribArray(texCoordLoc);
+    glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, stride,
+                          reinterpret_cast<const void*>(2 * sizeof(float)));
+
+    vao->unbind();
+}
+
+void ScreenQuad::draw() const {
+    vao->bind();
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, vertexCount);
+    vao->unbind();
+}
+
+}  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/screenquad.hpp
+++ b/sponge/src/platform/opengl/scene/screenquad.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "platform/opengl/renderer/vertexarray.hpp"
+#include "platform/opengl/renderer/vertexbuffer.hpp"
+
+#include <memory>
+
+namespace sponge::platform::opengl::scene {
+
+// Full-screen triangle strip shared by every post-processing pass. All of them
+// use screenquad.vert.glsl, so the vertex layout is fixed: location 0 is the
+// NDC position, location 1 the UV.
+class ScreenQuad {
+public:
+    ScreenQuad();
+
+    void draw() const;
+
+private:
+    std::unique_ptr<renderer::VertexArray>  vao;
+    std::unique_ptr<renderer::VertexBuffer> vbo;
+};
+
+}  // namespace sponge::platform::opengl::scene

--- a/sponge/src/platform/opengl/scene/shadowmap.cpp
+++ b/sponge/src/platform/opengl/scene/shadowmap.cpp
@@ -56,29 +56,21 @@ ShadowMap::~ShadowMap() {
 
 void ShadowMap::initialize() {
     // Moment texture (RG32F): R = depth, G = depth²
-    glGenTextures(1, &momentTexture);
+    momentTexture = renderer::createRenderTarget(
+        shadowWidth, shadowHeight, GL_RG32F, GL_RG, GL_FLOAT, GL_LINEAR);
+    // Overrides the helper's CLAMP_TO_EDGE: outside the light frustum the
+    // moments must read as fully lit, which is what the border colour encodes.
     glBindTexture(GL_TEXTURE_2D, momentTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, static_cast<GLsizei>(shadowWidth),
-                 static_cast<GLsizei>(shadowHeight), 0, GL_RG, GL_FLOAT,
-                 nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
     const std::array<float, 4> borderColor = { 1.F, 1.F, 0.F, 0.F };
     glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR,
                      borderColor.data());
+    glBindTexture(GL_TEXTURE_2D, 0);
 
     // Blur ping-pong texture (same format)
-    glGenTextures(1, &blurTexture);
-    glBindTexture(GL_TEXTURE_2D, blurTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, static_cast<GLsizei>(shadowWidth),
-                 static_cast<GLsizei>(shadowHeight), 0, GL_RG, GL_FLOAT,
-                 nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    blurTexture = renderer::createRenderTarget(
+        shadowWidth, shadowHeight, GL_RG32F, GL_RG, GL_FLOAT, GL_LINEAR);
 
     // Depth renderbuffer for depth testing during the moment-writing pass
     glGenRenderbuffers(1, &depthRbo);

--- a/sponge/src/platform/opengl/scene/sprite.cpp
+++ b/sponge/src/platform/opengl/scene/sprite.cpp
@@ -55,7 +55,6 @@ Sprite::Sprite(const std::string& name, const std::string& texturePath) {
         .path = texturePath,
     };
     tex = AssetManager::createTexture(textureCreateInfo);
-    tex->bind();
 
     shader->unbind();
 }

--- a/sponge/src/platform/opengl/scene/taa.cpp
+++ b/sponge/src/platform/opengl/scene/taa.cpp
@@ -100,8 +100,9 @@ void TAA::initialize() {
 }
 
 void TAA::createFramebuffers() {
-    // Scene capture, used only when bloom is off — otherwise the scene is
-    // already in the bloom FBO and apply() takes that texture instead.
+    // Receives the tone-mapped image from SceneTarget::resolve(). RGB16F
+    // rather than 8-bit so the history accumulates without requantising the
+    // input every frame.
     glGenTextures(1, &sceneColorTexture);
     glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
@@ -112,21 +113,10 @@ void TAA::createFramebuffers() {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    // GL_DEPTH_COMPONENT24 to match the prepass FBO — blitDepthToCurrentFbo()
-    // requires identical depth formats.
-    glGenRenderbuffers(1, &sceneDepthRbo);
-    glBindRenderbuffer(GL_RENDERBUFFER, sceneDepthRbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24,
-                          static_cast<GLsizei>(width),
-                          static_cast<GLsizei>(height));
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
-
     glGenFramebuffers(1, &sceneFbo);
     glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                            sceneColorTexture, 0);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                              GL_RENDERBUFFER, sceneDepthRbo);
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
         SPONGE_GL_CRITICAL("TAA scene framebuffer is not complete!");
     }
@@ -168,10 +158,6 @@ void TAA::destroyFramebuffers() {
         glDeleteTextures(1, &sceneColorTexture);
         sceneColorTexture = 0;
     }
-    if (sceneDepthRbo != 0) {
-        glDeleteRenderbuffers(1, &sceneDepthRbo);
-        sceneDepthRbo = 0;
-    }
     for (uint32_t i = 0; i < historyTextures.size(); i++) {
         if (historyFbos[i] != 0) {
             glDeleteFramebuffers(1, &historyFbos[i]);
@@ -200,8 +186,7 @@ void TAA::renderQuad() const {
 }
 
 void TAA::apply(const uint32_t sceneTexId, const uint32_t depthTexId,
-                const uint32_t velocityTexId, const uint32_t bloomTexId,
-                const float bloomIntensity, const glm::mat4& invViewProj,
+                const uint32_t velocityTexId, const glm::mat4& invViewProj,
                 const glm::mat4& prevViewProj) {
     // Depth testing would discard the full-screen quad behind whatever the
     // scene pass left in the depth buffer.
@@ -217,7 +202,6 @@ void TAA::apply(const uint32_t sceneTexId, const uint32_t depthTexId,
     resolveShader->setFloat2("rcpFrame",
                              glm::vec2(1.F / static_cast<float>(width),
                                        1.F / static_cast<float>(height)));
-    resolveShader->setFloat("bloomIntensity", bloomIntensity);
     resolveShader->setFloat("historyBlend", historyValid ? currentWeight : 1.F);
     resolveShader->setMat4("invViewProj", invViewProj);
     resolveShader->setMat4("prevViewProj", prevViewProj);
@@ -228,8 +212,6 @@ void TAA::apply(const uint32_t sceneTexId, const uint32_t depthTexId,
     glBindTexture(GL_TEXTURE_2D, historyTextures[readIndex]);
     glActiveTexture(GL_TEXTURE2);
     glBindTexture(GL_TEXTURE_2D, depthTexId);
-    glActiveTexture(GL_TEXTURE3);
-    glBindTexture(GL_TEXTURE_2D, bloomTexId);
     glActiveTexture(GL_TEXTURE4);
     glBindTexture(GL_TEXTURE_2D, velocityTexId);
 

--- a/sponge/src/platform/opengl/scene/taa.cpp
+++ b/sponge/src/platform/opengl/scene/taa.cpp
@@ -6,20 +6,11 @@
 
 #include <glm/glm.hpp>
 
-#include <array>
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <string_view>
 
 namespace {
-constexpr std::array quadVertices = {
-    -1.F, -1.F, 0.F, 0.F, 1.F, -1.F, 1.F, 0.F,
-    -1.F, 1.F,  0.F, 1.F, 1.F, 1.F,  1.F, 1.F,
-};
-constexpr uint32_t quadVertexCount = 4;
-constexpr uint32_t quadStride      = 4 * sizeof(float);
-
 // Radical inverse in the given base — the Halton building block.
 constexpr float halton(uint32_t index, const uint32_t base) {
     float result   = 0.F;
@@ -80,21 +71,6 @@ void TAA::initialize() {
         makeShader(resolveShaderName, "/shaders/glsl/taa_resolve.frag.glsl");
     presentShader =
         makeShader(presentShaderName, "/shaders/glsl/taa_present.frag.glsl");
-
-    vao = renderer::VertexArray::create();
-    vao->bind();
-    vbo = std::make_unique<renderer::VertexBuffer>(quadVertices.data(),
-                                                   sizeof(quadVertices));
-    vbo->bind();
-
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(0));
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, quadStride,
-                          reinterpret_cast<const void*>(2 * sizeof(float)));
-
-    vao->unbind();
 
     createFramebuffers();
 }
@@ -179,15 +155,8 @@ void TAA::end() const {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
-void TAA::renderQuad() const {
-    vao->bind();
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, quadVertexCount);
-    vao->unbind();
-}
-
-void TAA::apply(const uint32_t sceneTexId, const uint32_t depthTexId,
-                const uint32_t velocityTexId, const glm::mat4& invViewProj,
-                const glm::mat4& prevViewProj) {
+void TAA::apply(const uint32_t depthTexId, const uint32_t velocityTexId,
+                const glm::mat4& invViewProj, const glm::mat4& prevViewProj) {
     // Depth testing would discard the full-screen quad behind whatever the
     // scene pass left in the depth buffer.
     glDisable(GL_DEPTH_TEST);
@@ -207,7 +176,7 @@ void TAA::apply(const uint32_t sceneTexId, const uint32_t depthTexId,
     resolveShader->setMat4("prevViewProj", prevViewProj);
 
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, sceneTexId);
+    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, historyTextures[readIndex]);
     glActiveTexture(GL_TEXTURE2);
@@ -215,7 +184,7 @@ void TAA::apply(const uint32_t sceneTexId, const uint32_t depthTexId,
     glActiveTexture(GL_TEXTURE4);
     glBindTexture(GL_TEXTURE_2D, velocityTexId);
 
-    renderQuad();
+    quad.draw();
     resolveShader->unbind();
 
     // Pass 2: present the resolved history. A blit would skip the dither the
@@ -226,7 +195,7 @@ void TAA::apply(const uint32_t sceneTexId, const uint32_t depthTexId,
     // Unit 1: the present pass shares historyTex with the resolve pass.
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, historyTextures[historyIndex]);
-    renderQuad();
+    quad.draw();
     presentShader->unbind();
     glActiveTexture(GL_TEXTURE0);
 

--- a/sponge/src/platform/opengl/scene/taa.cpp
+++ b/sponge/src/platform/opengl/scene/taa.cpp
@@ -79,15 +79,8 @@ void TAA::createFramebuffers() {
     // Receives the tone-mapped image from SceneTarget::resolve(). RGB16F
     // rather than 8-bit so the history accumulates without requantising the
     // input every frame.
-    glGenTextures(1, &sceneColorTexture);
-    glBindTexture(GL_TEXTURE_2D, sceneColorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
-                 static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    sceneColorTexture = renderer::createRenderTarget(
+        width, height, GL_RGB16F, GL_RGB, GL_FLOAT, GL_LINEAR);
 
     glGenFramebuffers(1, &sceneFbo);
     glBindFramebuffer(GL_FRAMEBUFFER, sceneFbo);
@@ -100,16 +93,8 @@ void TAA::createFramebuffers() {
     // Float history: with a 0.1 blend factor an 8-bit target quantises every
     // increment below 1/255 to zero and the image never converges.
     for (uint32_t i = 0; i < historyTextures.size(); i++) {
-        glGenTextures(1, &historyTextures[i]);
-        glBindTexture(GL_TEXTURE_2D, historyTextures[i]);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<GLsizei>(width),
-                     static_cast<GLsizei>(height), 0, GL_RGB, GL_FLOAT,
-                     nullptr);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glBindTexture(GL_TEXTURE_2D, 0);
+        historyTextures[i] = renderer::createRenderTarget(
+            width, height, GL_RGB16F, GL_RGB, GL_FLOAT, GL_LINEAR);
 
         glGenFramebuffers(1, &historyFbos[i]);
         glBindFramebuffer(GL_FRAMEBUFFER, historyFbos[i]);

--- a/sponge/src/platform/opengl/scene/taa.hpp
+++ b/sponge/src/platform/opengl/scene/taa.hpp
@@ -37,9 +37,7 @@ public:
     // Resolves the scene into the history buffer and presents it.
     // `velocityTexId` supplies per-pixel motion wherever `depthTexId` is not
     // at the far plane; elsewhere the two matrices reproject the camera alone.
-    // `bloomTexId` may be 0 when `bloomIntensity` is 0.
     void apply(uint32_t sceneTexId, uint32_t depthTexId, uint32_t velocityTexId,
-               uint32_t bloomTexId, float bloomIntensity,
                const glm::mat4& invViewProj, const glm::mat4& prevViewProj);
 
     uint32_t getSceneTexture() const {
@@ -70,7 +68,6 @@ private:
     // creation path and these are rebuilt on every resize.
     uint32_t sceneFbo          = 0;
     uint32_t sceneColorTexture = 0;
-    uint32_t sceneDepthRbo     = 0;
 
     // Ping-pong: historyIndex is the slot written this frame.
     std::array<uint32_t, 2> historyFbos{};

--- a/sponge/src/platform/opengl/scene/taa.hpp
+++ b/sponge/src/platform/opengl/scene/taa.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "platform/opengl/renderer/shader.hpp"
-#include "platform/opengl/renderer/vertexarray.hpp"
-#include "platform/opengl/renderer/vertexbuffer.hpp"
+#include "platform/opengl/scene/screenquad.hpp"
 
 #include <glm/glm.hpp>
 
@@ -37,12 +36,8 @@ public:
     // Resolves the scene into the history buffer and presents it.
     // `velocityTexId` supplies per-pixel motion wherever `depthTexId` is not
     // at the far plane; elsewhere the two matrices reproject the camera alone.
-    void apply(uint32_t sceneTexId, uint32_t depthTexId, uint32_t velocityTexId,
+    void apply(uint32_t depthTexId, uint32_t velocityTexId,
                const glm::mat4& invViewProj, const glm::mat4& prevViewProj);
-
-    uint32_t getSceneTexture() const {
-        return sceneColorTexture;
-    }
 
     void resize(uint32_t newWidth, uint32_t newHeight);
 
@@ -59,10 +54,9 @@ private:
     // convergence — enough to resolve the jitter pattern without visible lag.
     static constexpr float currentWeight = 0.1F;
 
-    std::shared_ptr<renderer::Shader>       resolveShader;
-    std::shared_ptr<renderer::Shader>       presentShader;
-    std::unique_ptr<renderer::VertexArray>  vao;
-    std::unique_ptr<renderer::VertexBuffer> vbo;
+    std::shared_ptr<renderer::Shader> resolveShader;
+    std::shared_ptr<renderer::Shader> presentShader;
+    ScreenQuad                        quad;
 
     // Raw GL handles, as in FXAA: the Texture class has no colour-buffer
     // creation path and these are rebuilt on every resize.
@@ -81,7 +75,6 @@ private:
     void initialize();
     void createFramebuffers();
     void destroyFramebuffers();
-    void renderQuad() const;
 };
 
 }  // namespace sponge::platform::opengl::scene


### PR DESCRIPTION
Corrects the post-processing order to: render linear HDR → extract and blur in
linear → composite → tone map → gamma → dither, once, at the final 8-bit write.

## The problem

`pbr.slang` tone mapped, gamma encoded and dithered before writing to the bloom
FBO, so bloom extracted from an already-compressed, gamma-encoded image.
Reinhard maps `[0, ∞)` to `[0, 1)`, so all HDR headroom was gone before the
threshold was applied — `bloomThreshold` was a point on a tone curve rather than
a radiance value, and bloom could not tell a bright highlight from a blazing one.

## The change

The scene renders to a linear `RGB16F` `SceneTarget`. Bloom extracts and blurs
from that. `SceneTarget::resolve()` composites bloom in linear light, then tone
maps, gamma encodes and dithers.

`SceneTarget` owns both the HDR buffer and the resolve pass, because the buffer
and the single point where the pipeline leaves linear space are inseparable.

This collapses the branching in `onRender()`: the scene always renders to one
FBO and the resolve always runs, so `hasFbo`, the three-way `begin()` ladder and
the conditional depth blit all go away. FXAA and TAA no longer take bloom
parameters and no longer carry depth attachments — they consume the resolved
image and write the final frame. `Bloom` no longer owns a scene FBO, and
`bloom_composite` is gone.

One `ScreenQuad` replaces the full-screen triangle strip that Bloom, FXAA, TAA
and `SceneTarget` each carried a verbatim copy of — vertex array, stride
constants, attribute setup and a `renderQuad()` helper, four times over. Along
with it go the leftovers from moving the composite: the unread `bloomIntensity`
uniform in `taa.slang`, `TAA::apply`'s `sceneTexId` parameter and the
`getSceneTexture()` its only caller used, and a null guard on `sceneTarget`
sitting above three unguarded dereferences. `ditherOutput` becomes a `bool`
uniform through the existing `Shader::setBoolean`; the generated GLSL puts it in
the same 4-byte std140 slot in `GlobalParams` that the float used.

Net −397 lines against +458, including five new files.

## Dither happens once

Every intermediate target is float. An 8-bit intermediate would quantise
undithered on the way in and again on the way out, which is the banding
`dither8` exists to prevent. FXAA's input FBO was `RGB8` and is now `RGB16F`
(`0b0fbad`); this was pre-existing but only became load-bearing once that target
started carrying the tone-mapped image.

## Bloom constants were re-derived, not carried over

`bloomIntensity` 2.5 → **0.08**. It now weights linear radiance and is applied
before the curve: the bloom texture peaks near 2.6, so 2.5 added ~6.5 to the
scene and Reinhard drove everything near a highlight to white. The ImGui ranges
were calibrated to the old scale too — intensity `0..5` → `0..0.5`, threshold
`0..1` → `0..4`, since the threshold is a radiance value and useful settings run
past 1.0.

0.08 comes from a measurement, not a look decision. Worth a second opinion.

## Testing

Verified by texture readback rather than by eye, since a screenshot cannot
distinguish "bloom extracts from linear HDR" from "it doesn't":

* Scene target reaches radiance **36.28** — unrepresentable in the old pipeline.
* Bloom texture peaks at **2.62** with 0.58% of texels lit, so bloom still fires,
  on genuine highlights rather than across the frame. Checked specifically
  because the numbers were also consistent with bloom being silently disabled.
* All three anti-aliasing paths run with an empty log: TAA, FXAA, and Off. Off
  was previously untested and is a distinct path — resolve writes straight to the
  back buffer with dither.
* Sampler bindings in the generated GLSL match the texture units the C++ binds.
* Blend state checked rather than assumed: `GL_BLEND` is enabled globally and
  `tonemap.slang` writes alpha 1.0, so src replaces dst. A shader writing no
  alpha here would be silently blended away — that is what broke the velocity
  buffer in #463.

Built and run on Windows (`ci-windows-release`).

## Behaviour changes to expect

* Bloom is subtler and confined to real highlights. With the old constants it
  blew out; with the new ones it reads as a glow.
* Light cubes bypassed tone mapping entirely and rendered pure white. They now go
  through it like everything else, at `emissiveStrength = 8.0` in `cube.slang` —
  a number chosen to keep them near white, not derived. Only visible when
  `numLights > 0`, which is not the default.
* `glDepthFunc(GL_LEQUAL)` at the end of `onRender()` is now unconditional. It
  used to sit inside `if (hasFbo)`, so the no-bloom-no-AA path left `GL_LESS`.
  That path no longer exists; this matches the dominant old behaviour.
* FXAA's init no longer binds its shader around the attribute setup. The layout
  locations are fixed in the shader source, so the bind did nothing.

## Vertical sync applies on toggle (`c9f9b2c`)

Unrelated to the pipeline, found while looking at the options screen.

Toggling the vsync checkbox only flipped a pending flag. Nothing reached
`glfwSwapInterval` until the Return button — relabelled "Apply" — was activated,
and leaving with `MenuBack` discarded the change silently. Unlike resolution and
fullscreen, vsync needs no batching, so it now applies and persists in
`togglePending()`. `applyChanges()` no longer re-requests it and
`saveVideoSettings()` no longer writes `video.vsync`; both were redundant once
the toggle owned it.

Measured with process CPU time over wall time, as a frame-rate proxy:

* startup path, main thread: 5.2 CPU-s per 15s with vsync on, 14.6 with it off
* deferred path, render thread: 4.1 / 14.7 — isolated by temporarily routing the
  startup call through `requestVerticalSync`, then reverted
* driving the real menu after the fix: 3.5 CPU-s per 6s on, 6.0 off, flipping on
  the keystroke with no Apply pressed, `settings.json` following it
* toggled vsync, then changed anti-aliasing and pressed Apply: vsync stayed at
  the toggled value rather than being rewritten

The swap-interval plumbing was never broken — only unreachable without the Apply
press.
