### PR TITLE
Add click sound for keyboard and gamepad menu navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,16 @@ Do not attribute AI in code comments, commit messages and pull request descripti
 * Cluster grid and max-lights constants in `assets/shaders/slang/include/clustered.slang` must match `sponge/src/platform/opengl/scene/clusteredlights.hpp`.
 * Don't edit generated files in `out/` or 3rd-party files in `sponge/deps`.
 
+## IDE Tooling
+
+When running inside CLion with MCP, prefer the `mcp_clion_*` tools:
+
+* `mcp_clion_search_text` for project-wide text search.
+* `mcp_clion_read_file` for reading sources, including inside JARs and decompiled classes.
+* `mcp_clion_list_directory_tree` for directory exploration.
+* `mcp_clion_apply_patch` for applying diffs.
+* `mcp_clion_open_file_in_editor` to surface a file in the editor for the user.
+
 ## Building
 
 Use a configuration preset to compile `maze`. Possible values are:

--- a/game/src/layer/exitlayer.cpp
+++ b/game/src/layer/exitlayer.cpp
@@ -153,7 +153,9 @@ bool ExitLayer::onUpdate(const double elapsedTime) {
         if (wasActiveLastFrame && !Maze::get().getOptionLayer()->isActive()) {
             const auto& input = mgr.getSnapshot();
 
-            ui::stepSelection(input, selectedItem);
+            if (ui::stepSelection(input, selectedItem)) {
+                ui::playHoverClick();
+            }
 
             if (input.isActive(GameAction::MenuBack)) {
                 mgr.consumeActive(GameAction::MenuBack);

--- a/game/src/layer/introlayer.cpp
+++ b/game/src/layer/introlayer.cpp
@@ -165,7 +165,9 @@ bool IntroLayer::onUpdate(const double elapsedTime) {
             using sponge::input::GameAction;
             const auto& input = mgr.getSnapshot();
 
-            ui::stepSelection(input, selectedItem);
+            if (ui::stepSelection(input, selectedItem)) {
+                ui::playHoverClick();
+            }
 
             if (!waitForConfirmRelease &&
                 input.isActive(GameAction::MenuConfirm)) {

--- a/game/src/layer/optionlayer.cpp
+++ b/game/src/layer/optionlayer.cpp
@@ -406,7 +406,9 @@ bool OptionLayer::onUpdate(const double elapsedTime) {
         if (wasActiveLastFrame) {
             const auto& input = mgr.getSnapshot();
 
-            ui::stepSelection(input, selectedItem);
+            if (ui::stepSelection(input, selectedItem)) {
+                ui::playHoverClick();
+            }
 
             if (input.isActive(GameAction::MenuLeft)) {
                 cycleList(selectedItem, -1);
@@ -587,10 +589,9 @@ void OptionLayer::cycleList(const OptionMenuItem item, const int delta) {
         return;
     }
 
-    if (delta < 0) {
-        list->selectPrev();
-    } else {
-        list->selectNext();
+    const bool changed = delta < 0 ? list->selectPrev() : list->selectNext();
+    if (changed) {
+        ui::playHoverClick();
     }
 
     if (item == OptionMenuItem::AspectRatio) {

--- a/game/src/ui/menuselection.hpp
+++ b/game/src/ui/menuselection.hpp
@@ -6,18 +6,22 @@
 namespace game::ui {
 
 // Moves the selection on MenuUp/MenuDown, wrapping at both ends. T is a menu
-// enum with contiguous values and Count last.
+// enum with contiguous values and Count last. Returns true when changed.
 template <typename T>
-void stepSelection(const sponge::input::InputSnapshot& input, T& selected) {
-    constexpr auto count = static_cast<int>(T::Count);
+bool stepSelection(const sponge::input::InputSnapshot& input, T& selected) {
+    constexpr auto count   = static_cast<int>(T::Count);
+    bool           changed = false;
 
     if (input.isActive(sponge::input::GameAction::MenuDown)) {
         selected = static_cast<T>((static_cast<int>(selected) + 1) % count);
+        changed  = true;
     }
     if (input.isActive(sponge::input::GameAction::MenuUp)) {
         selected =
             static_cast<T>((static_cast<int>(selected) - 1 + count) % count);
+        changed = true;
     }
+    return changed;
 }
 
 }  // namespace game::ui


### PR DESCRIPTION
Play the hover-click sound when navigating menus with keyboard (up/down) and gamepad (d-pad/stick), matching the existing mouse hover behavior.

### Changes

- `stepSelection()` in `menuselection.hpp` now returns `bool` indicating whether the selection changed
- `introlayer.cpp`, `exitlayer.cpp`, `optionlayer.cpp` call `playHoverClick()` when `stepSelection` reports a change
- `optionlayer.cpp` `cycleList` plays click only when the select-list value actually changes (not at boundary)